### PR TITLE
fix: enforce role-based authorization policies on endpoints

### DIFF
--- a/Casazen.Web/Controllers/BookingController.cs
+++ b/Casazen.Web/Controllers/BookingController.cs
@@ -9,7 +9,7 @@ namespace Casazen.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize]
+[Authorize(Policy = "PropertyOwner")]
 public class BookingsController(
     IBookingService bookingService,
     ITaxCalculationService taxCalculationService,

--- a/Casazen.Web/Controllers/GuestsController.cs
+++ b/Casazen.Web/Controllers/GuestsController.cs
@@ -8,7 +8,7 @@ namespace Casazen.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize]
+[Authorize(Policy = "PropertyOwner")]
 public class GuestsController(IGuestService guestService, ILogger<GuestsController> logger) : ControllerBase
 {
     [HttpGet]

--- a/Casazen.Web/Controllers/OtaController.cs
+++ b/Casazen.Web/Controllers/OtaController.cs
@@ -8,7 +8,7 @@ namespace Casazen.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize]
+[Authorize(Policy = "PropertyOwner")]
 public class OtaController : ControllerBase
 {
     private readonly IOtaManager _otaManager;

--- a/Casazen.Web/Controllers/PaymentsController.cs
+++ b/Casazen.Web/Controllers/PaymentsController.cs
@@ -7,7 +7,7 @@ namespace Casazen.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize]
+[Authorize(Policy = "PropertyOwner")]
 public class PaymentsController(IPaymentService paymentService, ILogger<PaymentsController> logger) : ControllerBase
 {
     [HttpGet]

--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -7,7 +7,7 @@ namespace Casazen.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize]
+[Authorize(Policy = "PropertyOwner")]
 public class PropertiesController(
     IPropertyService propertyService,
     IImageStorageService imageStorageService,


### PR DESCRIPTION
## Summary
Enforces role-based authorization policies on API endpoints. Policies were defined in `ServiceCollectionExtensions` but not applied to controllers, allowing any authenticated user to access all endpoints.

## Changes
Applied `[Authorize(Policy = "PropertyOwner")]` to 5 controllers:
- **PropertiesController** - Property management endpoints
- **BookingsController** - Booking management endpoints
- **PaymentsController** - Payment processing endpoints
- **GuestsController** - Guest management endpoints
- **OtaController** - OTA integration endpoints

## Policy Definition
Policy requires user to have either `PropertyOwner` OR `Admin` role:
```csharp
.AddPolicy("PropertyOwner", policy => policy.RequireRole("PropertyOwner", "Admin"));
```

## Security Impact
**Before**: Any authenticated user could manage properties, bookings, payments
**After**: Only users with PropertyOwner or Admin role can access these endpoints

## Test Plan
- [x] Build succeeds
- [x] All 172 tests pass
- [x] Policies correctly defined in ServiceCollectionExtensions.cs
- [x] No regression in test coverage

## Notes
- Tests already set up proper role claims, no test changes needed
- TouristTaxRatesController already uses `AdminOnly` policy (unchanged)
- AuthController remains unauthenticated (registration/login)
- WebhooksController remains unauthenticated (external webhooks)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)