### PR TITLE
fix: transform Auth0 custom role claims to standard claims

### DIFF
--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// File: Casazen.Web/Extensions/ServiceCollectionExtensions.cs
 
+using System.Security.Claims;
+using System.Text.Json;
 using Casazen.Core.Repositories;
 using Casazen.Core.Services;
 using Casazen.Infrastructure.Data;
@@ -39,7 +41,34 @@ public static class ServiceCollectionExtensions
 
                 // Map Auth0 custom claims to ASP.NET Core claims
                 options.TokenValidationParameters.NameClaimType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier";
-                options.TokenValidationParameters.RoleClaimType = "https://casazen.app/roles";
+                options.TokenValidationParameters.RoleClaimType = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role";
+
+                // Transform Auth0 custom role claim to standard role claims
+                options.Events = new JwtBearerEvents
+                {
+                    OnTokenValidated = context =>
+                    {
+                        if (context.Principal?.Identity is ClaimsIdentity identity)
+                        {
+                            var rolesClaim = context.Principal.FindFirst("https://casazen.app/roles");
+                            if (rolesClaim != null)
+                            {
+                                // Auth0 sends roles as JSON array
+                                var roles = JsonSerializer.Deserialize<string[]>(rolesClaim.Value);
+                                if (roles != null)
+                                {
+                                    foreach (var role in roles)
+                                    {
+                                        identity.AddClaim(new Claim(
+                                            "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
+                                            role));
+                                    }
+                                }
+                            }
+                        }
+                        return Task.CompletedTask;
+                    }
+                };
 
                 // Disable HTTPS requirement in development
                 if (environment.IsDevelopment())


### PR DESCRIPTION
## Summary
Fixes JWT role-based authorization by transforming Auth0's custom role claim format into standard ASP.NET role claims, enabling `User.IsInRole()` to work correctly.

## Problem
Auth0 sends roles in a custom claim (`https://casazen.app/roles`) as a JSON array, but ASP.NET's `User.IsInRole()` expects standard role claims (`http://schemas.microsoft.com/ws/2008/06/identity/claims/role`). This caused all role-based authorization checks to fail even with valid roles in the JWT token.

## Solution
Added `OnTokenValidated` event handler in JWT Bearer authentication that:
1. Reads the Auth0 custom role claim
2. Deserializes the JSON array of roles
3. Creates standard role claims for each role
4. Adds them to the user's ClaimsIdentity

## Changes
**ServiceCollectionExtensions.cs**:
- Added using statements for `System.Security.Claims` and `System.Text.Json`
- Changed `RoleClaimType` to standard Microsoft claim type
- Added `OnTokenValidated` event handler with role claim transformation logic

## Related Issues
This PR addresses **Fix #59** from issue #62:
- ✅ **Fix #59**: JWT role claims transformation (this PR)
- ✅ **Fix #54**: Role policies enforcement (resolved in PR #82)
- ✅ **Fix #60**: Auth0Service dead code removal (resolved in PR #79)

## Technical Details
**Auth0 Token Format**:
```json
{
  "https://casazen.app/roles": ["PropertyOwner", "Admin"]
}
```

**Transformed Claims**:
```
http://schemas.microsoft.com/ws/2008/06/identity/claims/role: PropertyOwner
http://schemas.microsoft.com/ws/2008/06/identity/claims/role: Admin
```

## Test Plan
- [x] Build succeeds
- [x] All 172 tests pass
- [x] JWT authentication still works
- [x] Role claims properly transformed

## Impact
- Enables role-based authorization policies to function correctly
- Required for PR #82 (authorization policies) to work properly
- No breaking changes to existing authentication flow

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)