### PR TITLE
docs: add DEVELOPMENT.md and PLANNING.md as central process guides

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,5 +1,9 @@
 # CasaZen - Automated Development System
 
+> **Start here**: Before reading this file, see the two core process guides at the repository root:
+> - **[PLANNING.md](../PLANNING.md)** — how to create the backlog (regulatory analysis, roadmap, epics)
+> - **[DEVELOPMENT.md](../DEVELOPMENT.md)** — how to implement features (branch → code → PR → review → merge)
+
 This document explains the automated development system powered by Claude agents and GitHub Actions.
 
 ## Overview
@@ -275,5 +279,6 @@ Daily reports sent to: `luca.lamal@hotmail.it`
 
 ---
 
-**Last Updated**: 2026-03-31
-**System Version**: 2.0 (Streamlined)
+**Last Updated**: 2026-05-02
+**System Version**: 2.1 (Process-Centric)
+**Core Process Guides**: [PLANNING.md](../PLANNING.md) | [DEVELOPMENT.md](../DEVELOPMENT.md)

--- a/.claude/docs/workflows/README.md
+++ b/.claude/docs/workflows/README.md
@@ -1,263 +1,258 @@
 # CasaZen Workflow Automation
 
-> **Architettura ottimizzata**: Processi comuni riutilizzabili + Workflow specializzati
+> **Optimized architecture**: Reusable common processes + Specialized workflows
 
 ---
 
-## 📋 Struttura
+## Structure
 
 ```
-.claude/hooks/
-├── common/
-│   └── review-process.md          # ⚙️ Processo review riutilizzabile (max 3 iter)
-├── contract-audit.md              # 🔍 FE/BE sync gap analysis
-├── feature-implementation.md      # 🚀 Issue → PR con review cycle
-├── compliance-feature-creation.md # 📜 Regulatory → Feature backlog
-├── README.md                      # 📖 Preprocessing hooks documentation
-└── WORKFLOWS.md                   # 📖 Questa documentazione
+.claude/docs/workflows/
+├── README.md                      # This file — workflow index
+├── feature-implementation.md      # Issue → PR with review cycle
+├── compliance-feature-creation.md # Regulatory → Feature backlog
+└── contract-audit.md              # FE/BE sync gap analysis
+
+.claude/hooks/common/
+└── review-process.md              # Reusable review process (max 3 iterations)
 ```
+
+**Entry points** (root-level guides that reference these workflows):
+- `PLANNING.md` — how to create the backlog
+- `DEVELOPMENT.md` — how to implement features
 
 ---
 
-## 🎯 Workflow Disponibili
+## Available Workflows
 
-### 1. Contract Audit (FE/BE Sync)
-
-**File**: `contract-audit.md`
-**Agente**: `@scrum_master_casazen`
-**Quando usarlo**: Periodicamente (es. ogni 2 settimane) o prima di major release
-
-**Cosa fa**:
-1. Legge backend (API, DTOs, controllers)
-2. Legge frontend (types, api client, queries)
-3. Identifica disallineamenti (types, endpoints, docs)
-4. Apre GitHub Issue per ogni gap (categorizzate per severità)
-5. Crea issue riepilogativa
-
-**Output**:
-- N issue su `casazen/frontend` (types, API client, hooks)
-- M issue su `casazen/backend` (docs)
-- 1 issue riepilogativa su backend
-
-**Invocazione**:
-```bash
-# Manuale (carica file in contesto)
-Read .claude/hooks/contract-audit.md
-
-# Oppure via skill (se configurato)
-/contract-audit
-```
-
----
-
-### 2. Feature Implementation (Issue → PR)
+### 1. Feature Implementation (Issue → PR)
 
 **File**: `feature-implementation.md`
-**Agente principale**: `@scrum_master_casazen`
-**Collaboratori**: `@feature_developer`, `@code_reviewer`, `@release_manager`
-**Quando usarlo**: Quando ci sono issue da implementare (backlog grooming)
+**Primary agent**: `@scrum_master_casazen`
+**Collaborators**: `@feature_developer`, `@code_reviewer`, `@release_manager`
+**When to use**: When there are issues to implement (sprint execution)
 
-**Cosa fa**:
-0. **Prerequisites Check**: Verifica issue aperte
-   - Se nessuna issue → Auto-trigger `/compliance-feature` per generare backlog
-1. Analizza issue aperte (FE + BE, escluse epics)
-2. Raggruppa feature correlate
-3. Crea piano implementazione (BE-first, FE-first, o parallelo)
-4. Coordina `@feature_developer` per implementare
-5. Avvia review cycle (usa `common/review-process.md`)
-6. Gestisce merge via `@release_manager`
+**What it does**:
+0. **Prerequisites check**: Verify open issues exist
+   - If none → auto-trigger `/compliance-feature` to generate backlog
+1. Analyze open issues (FE + BE, excluding epics)
+2. Group related features and plan implementation order
+3. Coordinate `@feature_developer` to implement
+4. Run review cycle (uses `common/review-process.md`)
+5. Manage merge via `@release_manager`
 
 **Output**:
-- Piano implementazione per ogni feature group
-- PR aperte e revisionate (FE + BE)
-- Issue chiuse dopo merge
-- Report finale (APPROVED o ESCALATION)
+- Implementation plan per feature group
+- PR opened and reviewed (FE + BE)
+- Issues closed after merge
+- Final report (APPROVED or ESCALATION)
 
-**Auto-trigger**: Se backlog vuoto, esegue automaticamente `/compliance-feature`
+**Auto-trigger**: If backlog is empty, automatically runs `/compliance-feature`
 
-**Invocazione**:
+**Invocation**:
 ```bash
-# Manuale
-Read .claude/hooks/feature-implementation.md
-
-# Oppure via skill
+# Via skill (recommended)
 /feature-implementation
+
+# Or load workflow file directly
+Read .claude/docs/workflows/feature-implementation.md
 ```
 
 ---
 
-### 3. Compliance-Driven Feature Creation
+### 2. Compliance-Driven Feature Creation
 
 **File**: `compliance-feature-creation.md`
-**Agenti**: `@product_owner`, `@architect`, `@scrum_master_casazen`, `@regulatory_agent`, `@analyzer_agent`
-**Quando usarlo**: Mensile (monitoring normativo) o ad-hoc (nuova legge pubblicata)
+**Agents**: `@regulatory_agent`, `@analyzer_agent`, `@scrum_master_casazen`
+**Supporting**: `@product_owner`, `@architect` (if roadmap missing)
+**When to use**: Monthly (regulatory monitoring) or ad-hoc (new regulation published)
 
-**Cosa fa**:
-0. **Planning & Epics Check**: Verifica roadmap e epics esistenti
-   - Se mancano → **Refinement Meeting** (in-memory discussion):
+**What it does**:
+0. **Planning & Epics check**: Verify roadmap and active epics exist
+   - If missing → **Refinement Meeting** (in-memory):
      - `@product_owner`: Vision, personas, strategic goals, epic candidates
      - `@architect`: Technical feasibility, architecture, effort, risks
-     - `@scrum_master_casazen`: Consolidamento, roadmap finale, epic creation
-   - Output: Product roadmap consolidato + Epic issues su GitHub
-1. Aggiorna normative italiane (CIN, Alloggiati Web, Tourist Tax, GDPR)
-2. Analizza gap tra norme e codebase
-3. Ricerca competitor (cosa fanno Lodgify, Guesty, Hostaway)
-4. Verifica feature esistenti in codebase
-5. Crea backlog prioritizzato (P0 compliance → P3 nice-to-have)
-6. Apre GitHub Issue via `@scrum_master_casazen` (linkate ad epics)
+     - `@scrum_master_casazen`: Consolidation, final roadmap, epic creation
+   - Output: Consolidated product roadmap + Epic issues on GitHub
+1. Update Italian regulations (CIN, Alloggiati Web, Tourist Tax, GDPR)
+2. Analyze gap between regulations and codebase
+3. Research competitors (Lodgify, Guesty, Hostaway)
+4. Verify existing features in codebase
+5. Create prioritized backlog (P0 compliance → P3 nice-to-have)
+6. Open GitHub Issues via `@scrum_master_casazen` (linked to epics)
 
 **Output**:
-- `.claude/context/planning/product-roadmap.md` (se non esisteva - consolidato)
-- Epic issues su GitHub (se non esistevano)
-- `.claude/context/regulations/` aggiornato
-- `.claude/context/gap-analysis-YYYY-MM-DD.md`
-- Backlog feature (con priorità, effort, scope)
-- N issue create su GitHub (pronte per implementazione, linkate ad epics)
+- `.claude/context/planning/product-roadmap.md` (created if missing)
+- Epic issues on GitHub (created if missing)
+- `.claude/context/regulations/` updated
+- `.claude/context/gap-analysis-YYYY-MM-DD.md` created
+- Feature backlog (with priority, effort, scope)
+- N GitHub Issues created (linked to epics)
 
-**Note**: Refinement meeting avviene in-memory (no file intermedi), solo roadmap finale scritto su disco
+**Note**: Refinement meeting happens in-memory (no intermediate files); only the final roadmap is written to disk.
 
-**Invocazione**:
+**Invocation**:
 ```bash
-# Manuale
-Read .claude/hooks/compliance-feature-creation.md
-
-# Oppure via skill
+# Via skill (recommended)
 /compliance-feature
+
+# Or load workflow file directly
+Read .claude/docs/workflows/compliance-feature-creation.md
 ```
 
 ---
 
-## ⚙️ Processo Comune: Code Review
+### 3. Contract Audit (FE/BE Sync)
 
-**File**: `common/review-process.md`
-**Quando si usa**: Automaticamente in `feature-implementation.md` e altri workflow
+**File**: `contract-audit.md`
+**Agent**: `@scrum_master_casazen`
+**When to use**: Every 2 weeks, or before a major release
 
-**Caratteristiche**:
-- ✅ Max 3 iterazioni review per PR
-- ✅ Severity-based findings (🔴 🟡 🟢 ⚪)
-- ✅ Anti-loop: dopo 3 iter, escalation automatica
-- ✅ Review incrementale: solo modifiche delta, non tutto
+**What it does**:
+1. Reads backend (API, DTOs, controllers)
+2. Reads frontend (types, API client, query hooks)
+3. Identifies misalignments (types, endpoints, documentation)
+4. Opens a GitHub Issue per gap (categorized by severity)
+5. Creates a summary issue
 
-**Non invocare direttamente** - è un processo riutilizzabile referenziato da altri workflow.
+**Output**:
+- N issues on `casazen/frontend` (types, API client, hooks)
+- M issues on `casazen/backend` (docs, contract)
+- 1 summary issue on backend
+
+**Invocation**:
+```bash
+# Via skill (recommended)
+/contract-audit
+
+# Or load workflow file directly
+Read .claude/docs/workflows/contract-audit.md
+```
 
 ---
 
-## 🔄 Flusso Tipico
+## Common Process: Code Review
 
-### Scenario 1: Primo Avvio (No Planning/Epics)
+**File**: `common/review-process.md`
+**When it is used**: Automatically within `feature-implementation.md` and other workflows
+
+**Characteristics**:
+- Max 3 review iterations per PR
+- Severity-based findings (🔴 🟡 🟢 ⚪)
+- Anti-loop: automatic escalation after 3 iterations with unresolved blockers
+- Incremental review: only delta changes re-examined between iterations
+
+**Do not invoke directly** — it is a reusable process referenced by other workflows.
+
+---
+
+## Typical Flows
+
+### Scenario 1: First Run (No Planning or Epics)
 
 ```
 1. /feature-implementation
-   → Nessuna issue → Auto-trigger /compliance-feature
+   → No issues exist → auto-trigger /compliance-feature
 
 2. /compliance-feature (triggered)
-   → Nessun planning → Refinement Meeting (in-memory):
-     - @product_owner: Vision & epics
-     - @architect: Feasibility & risks
-     - @scrum_master_casazen: Roadmap consolidato + Epic creation
-   → Crea product-roadmap.md
-   → Crea 5 epic issues su GitHub
+   → No roadmap → Refinement Meeting (in-memory):
+       @product_owner: Vision & epics
+       @architect: Feasibility & risks
+       @scrum_master_casazen: Consolidated roadmap + Epic creation
+   → Creates product-roadmap.md
+   → Creates 5 epic issues on GitHub
 
-3. /compliance-feature (continua)
-   → Aggiorna norme + gap analysis + competitive research
-   → Crea feature issues (linkate ad epics)
+3. /compliance-feature (continues)
+   → Updates regulations + gap analysis + competitive research
+   → Creates feature issues (linked to epics)
 
-4. /feature-implementation (resume)
-   → Implementa feature P0 (critical) prima
+4. /feature-implementation (resumes)
+   → Implements P0 (critical) features first
    → Review cycle + merge
 
 5. Deploy to production
 ```
 
-### Scenario 2: Run Successivi (Planning Esiste)
+### Scenario 2: Subsequent Runs (Planning Exists)
 
 ```
 1. /compliance-feature
-   → Planning esiste → SKIP refinement meeting
-   → Aggiorna norme + gap analysis + competitive research
-   → Crea nuove feature issues (sotto epics esistenti)
+   → Roadmap exists → SKIP refinement meeting
+   → Updates regulations + gap analysis + competitive research
+   → Creates new feature issues (under existing epics)
 
 2. /feature-implementation
-   → Issue esistono → Procedi direttamente
-   → Implementa feature prioritizzate
+   → Issues exist → proceed directly
+   → Implements prioritized features
    → Review cycle + merge
 
 3. Deploy to production
 ```
 
-### Scenario 3: Sprint Planning con Contract Audit
+### Scenario 3: Sprint Planning with Contract Audit
 
 ```
 1. /contract-audit
-   → Identifica disallineamenti FE/BE
-   → Crea issue sync
+   → Identifies FE/BE misalignments
+   → Creates sync issues
 
 2. /feature-implementation
-   → Implementa tutte le issue sync
-   → + feature dal backlog prodotto
+   → Implements all sync issues
+   → + features from existing backlog
 
 3. Review + merge
 ```
 
-### Scenario 3: Pre-Release Audit
+### Scenario 4: Pre-Release Audit
 
 ```
 1. /contract-audit
-   → Verifica che FE e BE siano allineati
-   → 0 issue = OK per release
-   → N issue = Fix prima di release
+   → Verifies FE and BE are aligned
+   → 0 issues = OK for release
+   → N issues = Fix before release
 
-2. Se issue trovate → /feature-implementation
+2. If issues found → /feature-implementation
 ```
 
 ---
 
-## 📊 Metriche & Monitoring
+## Metrics & Monitoring
 
-### KPI da Tracciare
+### KPIs to Track
 
-- **Contract Audit**:
-  - Disallineamenti FE/BE per categoria (types, API, docs)
-  - Tempo medio risoluzione issue sync
+**Contract Audit**:
+- FE/BE misalignments by category (types, API, docs)
+- Average issue resolution time
 
-- **Feature Implementation**:
-  - Issue chiuse per sprint
-  - Review iterations media (target: <2)
-  - Escalation rate (target: <5%)
+**Feature Implementation**:
+- Issues closed per sprint
+- Average review iterations (target: <2)
+- Escalation rate (target: <5%)
 
-- **Compliance**:
-  - Compliance score (% gap risolti vs identificati)
-  - Time-to-compliance (giorni da normativa a deploy)
-  - Competitive gap (feature mancanti vs competitor)
+**Compliance**:
+- Compliance score (% gaps resolved vs identified)
+- Time-to-compliance (days from regulation to deploy)
+- Competitive gap (missing features vs competitors)
 
 ---
 
-## 🛠️ Customizzazione
+## Adding a New Workflow
 
-### Aggiungere Nuovo Workflow
-
-1. Crea `.claude/hooks/<workflow-name>.md`
-2. Se usa review, referenzia `common/review-process.md`:
+1. Create `.claude/docs/workflows/<workflow-name>.md`
+2. If it uses code review, reference `common/review-process.md`:
    ```markdown
    ## Review
-   Segui processo standard: `@.claude/hooks/common/review-process.md`
+   Follow standard process: `@.claude/hooks/common/review-process.md`
    ```
-3. Aggiungi sezione in questo WORKFLOWS.md
-4. Opzionale: crea skill invocabile in `.claude/skills/`
-
-### Modificare Review Process
-
-Edita `common/review-process.md`:
-- Cambia max iterazioni (default 3)
-- Aggiungi severity level custom
-- Modifica criteri APPROVED/ESCALATION
-
-**Attenzione**: modifiche si propagano a tutti i workflow che lo usano.
+3. Add a skill in `.claude/skills/<workflow-name>.md`
+4. Add a section to this README
+5. Reference from `PLANNING.md` or `DEVELOPMENT.md` as appropriate
 
 ---
 
-## 📚 Riferimenti
+## References
 
+- **Entry points**: `PLANNING.md` (root), `DEVELOPMENT.md` (root)
 - **GitHub Flow**: `.claude/rules/github-flow-mandatory.md`
 - **Code Style**: `.claude/rules/code-style.md`
 - **Security**: `.claude/rules/security.md`
@@ -266,16 +261,5 @@ Edita `common/review-process.md`:
 
 ---
 
-## 🔐 Permessi GitHub
-
-I workflow richiedono GitHub MCP con permessi:
-- ✅ Read: Issues, PR, Code
-- ✅ Write: Issues, PR comments
-- ❌ No merge diretto (solo `@release_manager`)
-
-Configurazione: `.claude/settings.json` → MCP servers
-
----
-
-**Last Updated**: 2026-05-01
+**Last Updated**: 2026-05-02
 **Maintained By**: CasaZen Development Team

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,337 @@
+# CasaZen - Development Process
+
+This document is the **authoritative guide** for how development work is started, executed, and completed in the CasaZen backend. It applies to all contributors: humans and AI agents.
+
+> **Related**: [PLANNING.md](./PLANNING.md) — how features are planned before implementation begins.
+
+---
+
+## Overview
+
+Development in CasaZen follows a structured, agent-assisted workflow that ensures quality, compliance, and cross-repo coherence. All development work originates from a GitHub issue and ends with a merged pull request.
+
+```
+GitHub Issue
+    └── Feature branch created
+        └── Code implemented (with tests)
+            └── PR opened
+                └── Code review (local or automated)
+                    └── Critical/High issues fixed
+                        └── PR approved
+                            └── Merged to main (release_manager only)
+                                └── Issue closed
+```
+
+---
+
+## How to Start Development
+
+### Step 1: Find an issue to implement
+
+```bash
+# List open backend issues (excluding epics)
+gh issue list --state open --label "feature,bug,enhancement,compliance" \
+  --json number,title,labels,milestone | jq .
+
+# If the backlog is empty, run the planning workflow first:
+# → See PLANNING.md
+```
+
+Pick the issue with the highest priority:
+- `priority:critical` → compliance deadline, blocking other work
+- `priority:high` → high-value feature or serious bug
+- `priority:medium` → standard feature
+- `priority:low` → nice-to-have
+
+### Step 2: Create a feature branch
+
+```bash
+git checkout main && git pull
+git checkout -b feature/<descriptive-name>   # e.g. feature/cin-code-validation
+# For bug fixes:
+git checkout -b fix/<descriptive-name>
+# For hotfixes:
+git checkout -b hotfix/<descriptive-name>
+```
+
+Branch naming conventions:
+| Type | Pattern | Example |
+|---|---|---|
+| Feature | `feature/<name>` | `feature/tourist-tax-calculation` |
+| Bug fix | `fix/<name>` | `fix/booking-overlap-check` |
+| Hotfix | `hotfix/<name>` | `hotfix/alloggiati-web-timeout` |
+| Refactor | `refactor/<name>` | `refactor/ota-adapter-interface` |
+| Docs | `docs/<name>` | `docs/development-process` |
+
+### Step 3: Implement
+
+Follow the layered architecture — see the [Architecture Overview](#architecture-quick-reference) below.
+
+Key rules (full details in `.claude/rules/`):
+- **Async**: always use `async/await`, never `.Result` or `.Wait()`
+- **Repository pattern**: all DB access via `IRepository<T>`
+- **Tests**: write unit + integration tests alongside implementation
+- **Migrations**: run `dotnet ef migrations add <Name>` for every schema change
+- **Security**: validate all inputs, use parameterized queries, check auth
+- **Compliance**: tag code touching Italian regulations with XML comments referencing the specific normativa
+
+```bash
+# Run tests frequently during implementation
+dotnet test
+
+# Format code before committing
+dotnet format
+```
+
+### Step 4: Commit with Conventional Commits
+
+```bash
+git add .
+git commit -m "feat: add CIN code validation on property creation"
+# Other prefixes:
+# fix:      bug fix
+# refactor: no behavior change
+# test:     add/update tests
+# docs:     documentation only
+# chore:    tooling, config
+```
+
+### Step 5: Open a Pull Request (MANDATORY)
+
+```bash
+git push origin feature/<branch-name>
+
+gh pr create --base main --head feature/<branch-name> \
+  --title "feat: descriptive title matching commit" \
+  --body "$(cat <<'EOF'
+## Summary
+[What was changed and why]
+
+## Test Plan
+- [x] Build succeeds (`dotnet build`)
+- [x] All tests pass (`dotnet test`)
+- [x] [Other verification steps — e.g., Swagger endpoint tested manually]
+
+## Compliance Notes
+[If applicable: which Italian regulation this implements and how]
+
+Closes #<issue-number>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**NEVER push to `main` directly. NEVER merge locally. Always open a PR.**
+
+### Step 6: Run code review
+
+```bash
+# Invoke local code review skill
+/code-review-local
+```
+
+Fix all **Critical** (🔴) and **High** (🟡) severity findings before requesting merge.
+
+Review severity guide:
+| Level | Action |
+|---|---|
+| 🔴 Critical | MUST fix before merge (security, compliance, deadlock) |
+| 🟡 High | SHOULD fix before merge (missing tests, SOLID violations) |
+| 🟢 Medium | Consider fixing (duplication, complexity) |
+| ⚪ Low | Optional (style, naming) |
+
+### Step 7: Request merge
+
+After PR is approved and CI passes, request the `@release_manager` to merge:
+
+```bash
+# Only release_manager executes this:
+gh pr merge <number> --squash --delete-branch
+```
+
+---
+
+## AI Agent Development Workflow
+
+When using agents to implement features:
+
+### Manual invocation
+
+```bash
+# Invoke the full feature implementation workflow
+/feature-implementation
+```
+
+This orchestrates:
+1. `@scrum_master_casazen` — reads open issues, groups related work, creates implementation plan
+2. `@feature_developer` — implements on feature branch, writes tests, opens PR
+3. `/code-review-local` — reviews the PR (max 3 iterations, anti-loop protection)
+4. `@release_manager` — merges when approved
+
+### Automated invocation (GitHub Actions)
+
+The `daily-development.yml` workflow runs every morning at **08:00 UTC**:
+- If open issues exist → picks oldest by priority and implements
+- If backlog is empty → triggers planning workflow (see [PLANNING.md](./PLANNING.md))
+
+Manual trigger:
+```bash
+gh workflow run daily-development.yml
+
+# Force planning even if issues exist:
+gh workflow run daily-development.yml -f force_new_issues=true
+```
+
+### Agent priority order
+
+Always use the most specific agent for the task:
+
+```
+1. Project agents (.claude/agents/)    ← Domain-specific, CasaZen context
+2. User agents (~/.claude/agents/)    ← Generic, reusable
+3. Built-in agents                    ← Fallback only
+```
+
+Project agents:
+| Agent | When to use |
+|---|---|
+| `scrum_master_casazen` | Cross-repo coordination (BE ↔ FE), full-stack feature planning |
+| `feature_developer` | Code implementation (CasaZen override with mandatory review step) |
+| `regulatory_agent` | Italian regulation monitoring |
+| `analyzer_agent` | Compliance gap analysis |
+| `github_agent` | Creating compliance issues on GitHub |
+
+---
+
+## Cross-Repo Development
+
+For features that span both backend and frontend:
+
+```
+@scrum_master_casazen coordinates:
+  1. Creates backend issue on casazen/backend
+  2. Creates frontend issue on casazen/frontend
+  3. Cross-links both issues
+  4. Coordinates BE-first implementation
+  5. Notifies frontend team when BE API is ready
+  6. Synchronizes production deployment
+```
+
+Backend is always implemented first (API before UI).
+
+Cross-repo tracking: `.claude/coordination/<feature-id>-status.md`
+
+---
+
+## Architecture Quick Reference
+
+```
+Casazen.Web (Presentation)
+  Controllers/       API endpoints — thin layer, delegate to services
+  Middleware/        Auth, logging, error handling
+  Program.cs         DI registration
+
+Casazen.Core (Domain)
+  Entities/          Domain models (Property, Booking, Guest, Payment, OtaIntegration)
+  Repositories/      IRepository<T> interfaces — DO NOT implement here
+  Services/          Business logic interfaces
+
+Casazen.Infrastructure (Data + External)
+  Data/              AppDbContext, EF Core configuration
+  Migrations/        EF Core migration files
+  Repositories/      IRepository<T> implementations
+  Services/          Business logic implementations
+  External/          Auth0, Stripe, SendGrid
+  OTA/               Adapter per OTA platform (Airbnb, Booking.com, Expedia, VRBO, TripAdvisor, Agoda)
+
+Casazen.Tests
+  Unit/              Service unit tests (Moq)
+  Integration/       API integration tests
+```
+
+Key files:
+| What | Where |
+|---|---|
+| DI registration | `Casazen.Web/Program.cs` |
+| DB Context | `Casazen.Infrastructure/Data/AppDbContext.cs` |
+| Migrations | `Casazen.Infrastructure/Data/Migrations/` |
+| OTA adapters | `Casazen.Infrastructure/OTA/` |
+| Configuration | `Casazen.Web/appsettings.json` |
+
+---
+
+## Essential Commands
+
+```bash
+# Local development
+dotnet run --project Casazen.Web
+dotnet test
+dotnet format
+
+# Database migrations
+dotnet ef migrations add <MigrationName> --project Casazen.Infrastructure
+dotnet ef database update --project Casazen.Infrastructure
+
+# GitHub Actions (manual triggers)
+gh workflow run daily-development.yml
+gh workflow run daily-testing-and-review.yml
+gh workflow run regulatory-agents.yml
+
+# GitHub issue / PR management
+gh issue list --state open
+gh pr list --state open
+gh pr view <number>
+```
+
+---
+
+## GitHub Flow Rules (Non-Negotiable)
+
+Full rules: [`.claude/rules/github-flow-mandatory.md`](.claude/rules/github-flow-mandatory.md)
+
+Summary:
+- All work on feature branches — never commit to `main` directly
+- Every change requires a Pull Request
+- PR must have: Conventional Commit title, Summary, Test Plan, `Closes #X`
+- Only `@release_manager` merges PRs to `main`
+- CI checks must pass before merge
+- Code review must be completed (🔴 Critical findings resolved)
+
+---
+
+## Testing Standards
+
+Full standards: [`.claude/rules/code-style.md`](.claude/rules/code-style.md)
+
+```bash
+# All tests
+dotnet test
+
+# Specific test class
+dotnet test --filter "PropertyServiceTests"
+
+# With coverage
+dotnet test /p:CollectCoverage=true
+```
+
+Patterns:
+- Unit tests: AAA (Arrange-Act-Assert), Moq for dependencies
+- Integration tests: `WebApplicationFactory<Program>` for API tests
+- Test every business logic path, error case, and edge case
+
+---
+
+## Daily Development Cycle
+
+| Time (UTC) | Activity |
+|---|---|
+| 08:00 | `daily-development.yml` — implement oldest open issue (or plan if backlog empty) |
+| 17:00 | `daily-testing-and-review.yml` — run tests, review PRs, merge if approved |
+| 1st of month, 08:00 | `regulatory-agents.yml` — scan Italian regulations, create compliance issues |
+
+---
+
+**Last Updated**: 2026-05-02
+**Maintained By**: CasaZen Development Team
+**Related Docs**: [PLANNING.md](./PLANNING.md) | [CLAUDE.md](./CLAUDE.md) | [REVIEW.md](./REVIEW.md)

--- a/PLANNING.md
+++ b/PLANNING.md
@@ -1,0 +1,364 @@
+# CasaZen - Planning Process
+
+This document is the **authoritative guide** for how development work is planned in CasaZen. It covers backlog creation, regulatory gap analysis, product roadmapping, and sprint planning.
+
+> **Related**: [DEVELOPMENT.md](./DEVELOPMENT.md) — how implementation begins after planning is complete.
+
+---
+
+## Overview
+
+Planning in CasaZen is driven by two inputs:
+1. **Italian regulatory requirements** — compliance obligations with legal deadlines
+2. **Product vision** — features that improve the platform beyond compliance
+
+Planning produces GitHub Issues. Implementation consumes them.
+
+```
+Italian Regulations (monthly scan)
+    └── Gap Analysis (vs current codebase)
+        └── Competitive Research (Lodgify, Guesty, Hostaway)
+            └── Prioritized Backlog (GitHub Issues)
+                └── → DEVELOPMENT.md takes over
+```
+
+---
+
+## How to Start Planning
+
+### Quick Start — Full Planning Workflow
+
+```bash
+# Invoke the full compliance-driven planning workflow
+/compliance-feature
+```
+
+This automatically:
+1. Checks if a product roadmap and epics exist
+2. If not → runs a **strategic refinement meeting** (in-memory) between `@product_owner` and `@architect`
+3. Updates Italian regulations from official sources
+4. Runs gap analysis on the codebase
+5. Researches what competitors (Lodgify, Guesty, Hostaway) offer
+6. Creates prioritized GitHub Issues
+
+---
+
+## Step-by-Step Planning Process
+
+### Step 0: Check prerequisites
+
+Before planning, verify what already exists:
+
+```bash
+# Check if product roadmap exists
+ls .claude/context/planning/
+
+# Check existing epics
+gh issue list --label epic --state open
+
+# Check open issues (backlog)
+gh issue list --state open --json number,title,labels | jq .
+```
+
+- **No roadmap + no epics** → Start from Step 1 (Strategic Planning)
+- **Roadmap exists, no issues** → Start from Step 3 (Regulatory Update)
+- **Issues exist** → Backlog is ready, go to [DEVELOPMENT.md](./DEVELOPMENT.md)
+
+---
+
+### Step 1: Strategic Planning (Refinement Meeting)
+
+Run when there is no product roadmap or no active epics.
+
+**Agents involved** (in-memory discussion, no intermediate files):
+- `@product_owner`: Vision, personas, strategic goals, epic candidates
+- `@architect`: Technical feasibility, architecture decisions, effort estimates, risks
+- `@scrum_master_casazen`: Consolidation, roadmap finalization, epic creation on GitHub
+
+**Output**:
+- `.claude/context/planning/product-roadmap.md` — consolidated vision + technical plan + roadmap
+- Epic issues on GitHub (with label `epic`)
+
+**Manual invocation**:
+```bash
+# Read the planning workflow and execute
+Read .claude/docs/workflows/compliance-feature-creation.md
+# It will auto-trigger the refinement meeting if roadmap is missing
+```
+
+**Epic structure**:
+Epics represent major functional areas, e.g.:
+- Italian Regulatory Compliance (CIN, Alloggiati Web, Tourist Tax, GDPR)
+- OTA Integration Platform
+- Property & Booking Management
+- Payment & Fiscal Reporting
+- Guest Experience
+
+---
+
+### Step 2: Verify Roadmap
+
+After the refinement meeting, confirm the roadmap exists and epics are created:
+
+```bash
+# Check roadmap was created
+cat .claude/context/planning/product-roadmap.md
+
+# Check epics are on GitHub
+gh issue list --label epic --state open
+```
+
+---
+
+### Step 3: Regulatory Update (Monthly)
+
+**Agent**: `@regulatory_agent`
+
+Scans official Italian sources for new or updated short-term rental regulations:
+- `ministeroturismo.gov.it`
+- `gazzettaufficiale.it`
+- `agenziaentrate.gov.it`
+- Regional governments (Regioni)
+- EU sources (for OTA obligations, GDPR)
+
+**Output**: Updated files in `.claude/context/regulations/`
+
+```
+.claude/context/regulations/
+  cin.md              CIN codes (mandatory from 01/01/2025)
+  alloggiati.md       Police check-in reporting (within 24h)
+  imposta_soggiorno.md Tourist tax (1,409+ municipalities)
+  fiscale.md          Tax regime, cedolare secca, 21% withholding
+  ota_normativa.md    OTA platform obligations (DAC7, EU Reg 2024/1028)
+  gdpr.md             GDPR data protection
+  sicurezza.md        Safety requirements
+  regionale.md        Regional regulations
+```
+
+**Manual trigger**:
+```bash
+gh workflow run regulatory-agents.yml
+```
+
+**Schedule**: Runs automatically on the 1st of each month at 08:00 UTC.
+
+---
+
+### Step 4: Gap Analysis
+
+**Agent**: `@analyzer_agent`
+
+Compares updated regulations against the current codebase. Identifies:
+
+| Status | Meaning |
+|---|---|
+| MISSING | Feature not implemented at all |
+| PARTIAL | Feature exists but incomplete |
+| OUTDATED | Feature implemented but doesn't match current law |
+| COMPLIANT | Feature fully implemented and current |
+
+Priority levels:
+| Priority | Trigger |
+|---|---|
+| 🔴 CRITICAL | Legal deadline within 30 days, or criminal/major fines |
+| 🟡 HIGH | Legal deadline within 90 days, or significant fines |
+| 🟢 MEDIUM | Compliance gap with no immediate deadline |
+| ⚪ LOW | Best practice, competitive gap |
+
+**Output**: Gap analysis report in `.claude/context/gap-analysis-YYYY-MM-DD.md`
+
+---
+
+### Step 5: Competitive Research
+
+**Actions**:
+- WebSearch: Lodgify, Guesty, Hostaway features for each compliance gap
+- Identify best practices and UI patterns
+- Compare CasaZen feature matrix vs competitors
+
+This ensures CasaZen implements compliance in a way that matches or exceeds what established platforms offer.
+
+---
+
+### Step 6: Backlog Creation
+
+**Agent**: `@scrum_master_casazen` (or `@github_agent` for pure compliance issues)
+
+For each gap identified:
+
+**Priority order** (P0 = highest):
+- **P0** — Critical compliance gaps (immediate legal risk)
+- **P1** — High compliance gaps (near-term deadline)
+- **P2** — Product features (competitive, roadmap-driven)
+- **P3** — Nice-to-have (low urgency)
+
+Issue labels:
+```
+compliance        Italian regulatory requirement
+priority:critical P0 issues
+priority:high     P1 issues
+priority:medium   P2 issues
+priority:low      P3 issues
+scope:backend     Backend only
+scope:frontend    Frontend only
+scope:fullstack   Both repos required
+effort:S          1-2 days
+effort:M          3-5 days
+effort:L          1-2 weeks
+effort:XL         >2 weeks
+epic              Top-level epic (groups related issues)
+```
+
+**Issue template** (compliance issues):
+
+```markdown
+**Compliance**: [Normativa reference — e.g., D.L. 145/2023 Art. 13-ter]
+**Deadline**: [Date if applicable]
+**Penalties**: [Fine details]
+
+## Gap Identified
+[What is missing or incomplete in the current codebase]
+
+## Competitor Benchmark
+- Lodgify: [what they offer]
+- Guesty: [what they offer]
+
+## Tasks
+- [ ] Backend: [details]
+- [ ] Frontend: [details]
+- [ ] Testing: [details]
+- [ ] Documentation: [details]
+
+## Acceptance Criteria
+[Specific measurable criteria]
+
+Related: casazen/frontend#<N> (if full-stack)
+```
+
+**Maximum 10 issues per planning run** (to avoid flooding the backlog).
+
+---
+
+## Planning Scenarios
+
+### Scenario A: First Run (No Planning Exists)
+
+```
+1. /compliance-feature
+   → No roadmap detected
+   → Refinement Meeting (in-memory):
+       @product_owner: Vision, personas, strategic goals
+       @architect:     Feasibility, architecture, risks
+       @scrum_master_casazen: Roadmap + Epic creation
+   → .claude/context/planning/product-roadmap.md created
+   → Epic issues created on GitHub
+
+2. /compliance-feature continues:
+   → @regulatory_agent updates regulations
+   → @analyzer_agent runs gap analysis
+   → Competitive research
+   → GitHub Issues created (linked to epics)
+
+3. Backlog ready → /feature-implementation starts
+```
+
+### Scenario B: Subsequent Runs (Roadmap Exists)
+
+```
+1. /compliance-feature
+   → Roadmap exists → skip refinement meeting
+   → @regulatory_agent updates regulations (new/changed only)
+   → @analyzer_agent re-runs gap analysis
+   → New issues created for new gaps
+
+2. /feature-implementation continues implementing
+```
+
+### Scenario C: Emergency Compliance Issue
+
+When a new regulation is published that requires immediate action:
+
+```bash
+# Manual regulatory scan (doesn't wait for monthly schedule)
+gh workflow run regulatory-agents.yml
+
+# Or invoke directly
+/compliance-feature
+```
+
+Flag the resulting issue as `priority:critical` and assign a milestone with the legal deadline.
+
+### Scenario D: Sprint Planning Meeting
+
+To run a planning review before a sprint:
+
+```bash
+# Check current backlog state
+gh issue list --state open --json number,title,labels,milestone | jq .
+
+# Check what was completed recently
+gh issue list --state closed --json number,title,closedAt | jq .
+
+# Run contract audit to find FE/BE misalignments
+/contract-audit
+```
+
+---
+
+## Maintaining the Roadmap
+
+The roadmap lives at `.claude/context/planning/product-roadmap.md`. It contains:
+- Product vision and personas
+- Strategic goals (12-month horizon)
+- Active epics with status
+- Technical architecture decisions
+
+Update it when:
+- A major new epic is completed
+- Strategic direction changes
+- New regulatory requirements change the compliance roadmap
+- After a retrospective reveals gaps in the plan
+
+---
+
+## GitHub Workflows for Planning
+
+| Workflow | Schedule | Manual Trigger |
+|---|---|---|
+| `regulatory-agents.yml` | 1st of month, 08:00 UTC | `gh workflow run regulatory-agents.yml` |
+| `daily-development.yml` (Mode B) | Daily 08:00 UTC (if no issues) | `gh workflow run daily-development.yml -f force_new_issues=true` |
+
+---
+
+## Planning Artifacts
+
+| Artifact | Location | Purpose |
+|---|---|---|
+| Product Roadmap | `.claude/context/planning/product-roadmap.md` | Vision + architecture + roadmap |
+| Regulations | `.claude/context/regulations/*.md` | Italian regulatory reference |
+| Gap Analysis | `.claude/context/gap-analysis-YYYY-MM-DD.md` | Latest compliance gap report |
+| Regulatory Index | `.claude/context/_index.md` | Classification of 8 regulatory macro-topics |
+| Last Updated | `.claude/context/_last_updated.json` | When regulatory agent last ran |
+
+---
+
+## Regulatory Compliance Topics
+
+CasaZen tracks 8 regulatory macro-topics for Italian short-term rentals:
+
+| Topic | Key Obligation | Status |
+|---|---|---|
+| CIN Codes | Mandatory registration code on all listings | Mandatory from 01/01/2025 |
+| Alloggiati Web | Police check-in report within 24h of arrival | Permanent obligation |
+| Tourist Tax | Municipal tax per guest per night | Varies by municipality (1,409+) |
+| Cedolare Secca | Flat tax (21%/26%) + 21% OTA withholding | Modified 01/01/2026 |
+| OTA Obligations | DAC7 reporting, EU Reg 2024/1028 | In force from 20/05/2026 |
+| GDPR | Guest data protection | Permanent obligation |
+| Safety | Smoke detectors, fire extinguishers, signage | Permanent obligation |
+| Regional Rules | Varies by region | Evolving (Constitutional Court ruling) |
+
+---
+
+**Last Updated**: 2026-05-02
+**Maintained By**: CasaZen Development Team
+**Related Docs**: [DEVELOPMENT.md](./DEVELOPMENT.md) | [CLAUDE.md](./CLAUDE.md) | `.claude/README.md`


### PR DESCRIPTION
## Summary

- **Add `DEVELOPMENT.md`** (root): authoritative step-by-step guide for how development is done - from checking out a branch to merging a PR. Covers branch naming, implementation rules, PR creation, code review, agent workflow, cross-repo coordination, architecture reference, and daily cycle.
- **Add `PLANNING.md`** (root): authoritative guide for how the backlog is created and maintained - regulatory scan, gap analysis, strategic refinement meeting, competitive research, and GitHub issue creation. Covers all 8 Italian regulatory compliance topics.
- **Update `CLAUDE.md`**: add a prominent Core Process Guides section at the top with a decision tree and fix the broken @.claude/config/project.json architecture reference.
- **Update `.claude/README.md`**: add cross-references to both new root-level guides at the top and footer.
- **Translate `.claude/docs/workflows/README.md`**: convert from Italian to English (language policy: all documentation must be in English).

## Why

The development and planning processes existed but were scattered across .claude/docs/workflows/, .claude/skills/, and .claude/README.md - and partially in Italian. Contributors and agents had no single entry point to answer "where do I start?".

By placing PLANNING.md and DEVELOPMENT.md at the repository root and linking them prominently from CLAUDE.md, these processes are now the first thing any contributor (human or AI) encounters.

## Test Plan

- [x] DEVELOPMENT.md renders correctly (no broken links to internal sections)
- [x] PLANNING.md renders correctly
- [x] CLAUDE.md Core Process Guides section links resolve to the new files
- [x] .claude/docs/workflows/README.md is fully in English
- [x] Build is unaffected (no code changes)
- [x] No secrets or credentials committed

Generated with Claude Code