### PR TITLE
fix: restore [Authorize] on all controllers and re-enable JWT audience validation

### DIFF
--- a/Casazen.Tests/Unit/Controllers/AuthorizationAttributeTests.cs
+++ b/Casazen.Tests/Unit/Controllers/AuthorizationAttributeTests.cs
@@ -1,0 +1,72 @@
+using Casazen.Web.Controllers;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Controllers;
+
+/// <summary>
+/// Verifies that security-critical [Authorize] attributes are present on all protected controllers.
+/// Guards against accidental removal or commenting-out of authorization during debugging.
+/// See GitHub issues #95, #99-#104.
+/// </summary>
+public class AuthorizationAttributeTests
+{
+    [Theory]
+    [InlineData(typeof(PropertiesController))]
+    [InlineData(typeof(BookingsController))]
+    [InlineData(typeof(GuestsController))]
+    [InlineData(typeof(PaymentsController))]
+    [InlineData(typeof(OtaController))]
+    [InlineData(typeof(OtaIntegrationsController))]
+    public void Controller_MustHaveAuthorizeAttribute(Type controllerType)
+    {
+        // Arrange & Act
+        var authorizeAttr = controllerType
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .FirstOrDefault();
+
+        // Assert
+        Assert.True(
+            authorizeAttr is not null,
+            $"{controllerType.Name} is missing [Authorize] attribute. " +
+            "All protected controllers must require authentication. " +
+            "See GitHub issues #95, #99-#104 for context."
+        );
+    }
+
+    [Theory]
+    [InlineData(typeof(PropertiesController))]
+    [InlineData(typeof(BookingsController))]
+    [InlineData(typeof(GuestsController))]
+    [InlineData(typeof(PaymentsController))]
+    [InlineData(typeof(OtaController))]
+    [InlineData(typeof(OtaIntegrationsController))]
+    public void Controller_AuthorizePolicyMustBePropertyOwner(Type controllerType)
+    {
+        // Arrange & Act
+        var authorizeAttr = controllerType
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .Cast<AuthorizeAttribute>()
+            .FirstOrDefault();
+
+        // Assert
+        Assert.NotNull(authorizeAttr);
+        Assert.True(
+            authorizeAttr.Policy == "PropertyOwner",
+            $"{controllerType.Name} must use [Authorize(Policy = \"PropertyOwner\")]. " +
+            $"Current policy: '{authorizeAttr.Policy ?? "(none)"}'. " +
+            "Do not use bare [Authorize] without a policy."
+        );
+    }
+
+    [Fact]
+    public void HealthController_ShouldNotHaveAuthorizeAttribute()
+    {
+        // HealthController is intentionally public — verify it stays that way
+        var authorizeAttr = typeof(HealthController)
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .FirstOrDefault();
+
+        Assert.Null(authorizeAttr);
+    }
+}

--- a/Casazen.Web/Controllers/BookingController.cs
+++ b/Casazen.Web/Controllers/BookingController.cs
@@ -11,8 +11,7 @@ namespace Casazen.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-// TEMPORARY: Disabled for debugging - Re-enable in production!
-// [Authorize(Policy = "PropertyOwner")]
+[Authorize(Policy = "PropertyOwner")]
 public class BookingsController(
     IBookingService bookingService,
     ITaxCalculationService taxCalculationService,

--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -7,8 +7,7 @@ namespace Casazen.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-// TEMPORARY: Disabled for debugging - Re-enable in production!
-// [Authorize(Policy = "PropertyOwner")]
+[Authorize(Policy = "PropertyOwner")]
 public class PropertiesController(
     IPropertyService propertyService,
     IImageStorageService imageStorageService,

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Casazen.Infrastructure.Services;
 using Casazen.Web.Middleware;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authentication;
 using Polly;
 
 namespace Casazen.Web.Extensions;
@@ -37,47 +38,47 @@ public static class ServiceCollectionExtensions
             {
                 var domain = configuration["Auth0:Domain"];
                 var audience = configuration["Auth0:Audience"];
-                
+
                 options.Authority = $"https://{domain}";
                 options.Audience = audience;
 
-                // IMPORTANT: Token validation parameters
                 options.TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters
                 {
                     ValidateIssuer = true,
                     ValidIssuer = $"https://{domain}/",
-                    // TEMPORARY: Disable audience validation for debugging
-                    ValidateAudience = false,
-                    // Accept both API audience and Auth0 userinfo audience
-                    // ValidAudiences = new[] { audience, $"https://{domain}/userinfo" },
+                    ValidateAudience = true,
+                    ValidAudience = audience,
                     ValidateLifetime = true,
                     ValidateIssuerSigningKey = true,
                     NameClaimType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
                     RoleClaimType = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
                 };
 
-                // Transform Auth0 custom role claim to standard role claims
                 options.Events = new JwtBearerEvents
                 {
                     OnAuthenticationFailed = context =>
                     {
-                        Console.WriteLine($"[Auth Debug] Authentication failed: {context.Exception.Message}");
+                        var logger = context.HttpContext.RequestServices
+                            .GetRequiredService<ILogger<JwtBearerHandler>>();
+                        logger.LogWarning("Authentication failed: {Error}", context.Exception.Message);
                         return Task.CompletedTask;
                     },
                     OnChallenge = context =>
                     {
-                        Console.WriteLine($"[Auth Debug] Auth challenge: {context.Error}, {context.ErrorDescription}");
+                        var logger = context.HttpContext.RequestServices
+                            .GetRequiredService<ILogger<JwtBearerHandler>>();
+                        logger.LogWarning("Auth challenge — error: {Error}, description: {Description}",
+                            context.Error, context.ErrorDescription);
                         return Task.CompletedTask;
                     },
                     OnTokenValidated = context =>
                     {
-                        Console.WriteLine("[Auth Debug] Token validated successfully");
+                        // Map Auth0 custom roles claim to standard .NET role claims
                         if (context.Principal?.Identity is ClaimsIdentity identity)
                         {
                             var rolesClaim = context.Principal.FindFirst("https://casazen.app/roles");
                             if (rolesClaim != null)
                             {
-                                // Auth0 sends roles as JSON array
                                 var roles = JsonSerializer.Deserialize<string[]>(rolesClaim.Value);
                                 if (roles != null)
                                 {
@@ -94,7 +95,7 @@ public static class ServiceCollectionExtensions
                     }
                 };
 
-                // Disable HTTPS requirement in development
+                // Disable HTTPS requirement in development only
                 if (environment.IsDevelopment())
                 {
                     options.RequireHttpsMetadata = false;


### PR DESCRIPTION
## Summary

Restores authentication and authorization that was disabled during debugging, reintroducing a critical security vulnerability in the process.

**What was broken:**
- `[Authorize(Policy = "PropertyOwner")]` commented out on `PropertiesController` and `BookingsController` — all endpoints exposed without authentication
- `ValidateAudience = false` in JWT validation — tokens from any Auth0 application accepted
- `Console.WriteLine` used for auth failure logging — no structured observability

**What this fixes:**
- `[Authorize(Policy = "PropertyOwner")]` restored on all affected controllers
- `ValidateAudience = true` + `ValidAudience` set from configuration
- Auth failure events now log via `ILogger<JwtBearerHandler>` (structured, observable)
- 13 new unit tests in `AuthorizationAttributeTests` act as a regression guard — the build will fail if any protected controller loses its `[Authorize]` attribute

## Test Plan

- [x] Build succeeds (`dotnet build`)
- [x] 161 unit tests pass, 0 failures (`dotnet test --filter FullyQualifiedName~Unit`)
- [x] 13 new `AuthorizationAttributeTests` all pass
- [x] All 6 protected controllers verified to carry `[Authorize(Policy = "PropertyOwner")]`
- [x] No secrets committed

## Security Notes

This fix addresses the immediate auth bypass. Issue #96 (`System.Security.Cryptography.Xml` vulnerability) is tracked separately and pre-dates this branch.

Closes #95
Closes #99
Closes #100
Closes #101
Closes #102
Closes #103
Closes #104