### PR TITLE
fix: update System.Security.Cryptography.Xml to 10.0.7 to fix security vulnerabilities

### DIFF
--- a/Casazen.Infrastructure/Casazen.Infrastructure.csproj
+++ b/Casazen.Infrastructure/Casazen.Infrastructure.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="SendGrid" Version="9.29.3" />
     <PackageReference Include="Stripe.net" Version="50.1.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Updates System.Security.Cryptography.Xml from 10.0.0 to 10.0.7 to fix known high-severity vulnerabilities.

**Vulnerabilities Fixed**:
- [GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx) — High severity
- [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf) — High severity

## Changes

- ✅ Updated `System.Security.Cryptography.Xml` from `10.0.0` → `10.0.7` in `Casazen.Infrastructure.csproj`
- ✅ Verified no vulnerabilities remain (`dotnet list package --vulnerable`)
- ✅ All 185 tests passing

## Test Plan

- [x] Build succeeds (`dotnet build`)
- [x] No security warnings during restore
- [x] All tests pass (185 passed, 0 failed)
- [x] Vulnerability scan clean

## Security Notes

This is a patch-level update with no breaking changes. The package is used transitively in the Infrastructure layer for cryptographic operations.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)