### PR TITLE
fix: resolve user ID from ClaimTypes.NameIdentifier for Auth0 tokens

### DIFF
--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -27,13 +27,23 @@ public class PropertiesController(
         logger.LogInformation("GetAll properties called");
         logger.LogInformation($"User authenticated: {User.Identity?.IsAuthenticated}");
         logger.LogInformation($"User identity name: {User.Identity?.Name}");
-        
-        var userId = User.FindFirst("sub")?.Value;
-        logger.LogInformation($"User ID from sub claim: {userId}");
-        
+
+        // Try multiple claim types to find user ID
+        var userId = User.FindFirst("sub")?.Value
+                     ?? User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                     ?? User.FindFirst("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")?.Value;
+
+        logger.LogInformation($"User ID from claims: {userId}");
+
+        // DEBUG: Log all claims
+        foreach (var claim in User.Claims)
+        {
+            logger.LogInformation($"Claim: {claim.Type} = {claim.Value}");
+        }
+
         if (string.IsNullOrEmpty(userId))
         {
-            logger.LogWarning("No sub claim found in token");
+            logger.LogWarning("No user ID claim found in token");
             return Unauthorized();
         }
 


### PR DESCRIPTION
## Problem

Auth0 JWT tokens were causing 401 Unauthorized on `/api/properties` endpoint despite valid authentication.

**Root Cause**: Controller searched for `"sub"` claim, but Auth0 maps the user ID to `ClaimTypes.NameIdentifier` (`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier`) instead.

## Solution

Updated `PropertiesController.GetAll()` to search multiple claim types:
1. `"sub"` (standard)
2. `ClaimTypes.NameIdentifier` (Auth0 uses this) ✅
3. Full namespace claim as fallback

Added debug logging to output all claims for troubleshooting.

## Changes

**File**: `Casazen.Web/Controllers/PropertiesController.cs`

- Search user ID across multiple claim types
- Log all claims for debugging
- Graceful fallback if claim not found

## Test Results

✅ **User authenticated**: True  
✅ **User ID found**: `google-oauth2|105415611601118516118`  
✅ **Claim used**: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier`  
✅ **Response**: 200 OK

## Related

- Frontend PR: casazen/frontend#51
- Fixes 401 errors reported in casazen/frontend#42

## Test Plan

1. Login with Auth0 in frontend
2. Navigate to Properties page
3. Verify GET /api/properties returns 200 OK
4. Check backend logs show "User ID from claims: {user-id}"

🤖 Generated with [Claude Code](https://claude.com/claude-code)