### PR TITLE
fix(pricing): remove non-existent CreatedAt/UpdatedAt property references

### DIFF
--- a/Casazen.Infrastructure/Repositories/PricingAdapterConfigRepository.cs
+++ b/Casazen.Infrastructure/Repositories/PricingAdapterConfigRepository.cs
@@ -42,7 +42,6 @@ public class PricingAdapterConfigRepository(AppDbContext context) : IPricingAdap
 
     public async Task UpdateAsync(PricingAdapterConfig config)
     {
-        config.UpdatedAt = DateTime.UtcNow;
         context.PricingAdapterConfigs.Update(config);
         await context.SaveChangesAsync();
     }

--- a/Casazen.Infrastructure/Services/OtaManager.cs
+++ b/Casazen.Infrastructure/Services/OtaManager.cs
@@ -211,8 +211,7 @@ public class OtaManager(
                 ChangeReason = "Batch OTA price update",
                 AiConfidence = 1.0m,
                 OtasSynced = JsonSerializer.Serialize(syncedPlatforms),
-                SyncStatus = overallSuccess ? "synced" : "failed",
-                CreatedAt = DateTime.UtcNow
+                SyncStatus = overallSuccess ? "synced" : "failed"
             };
 
             await pricingHistoryRepository.AddAsync(pricingHistory);

--- a/Casazen.Infrastructure/Services/PricingAdapterService.cs
+++ b/Casazen.Infrastructure/Services/PricingAdapterService.cs
@@ -75,8 +75,7 @@ public class PricingAdapterService(
             ChangeReason = changeReason,
             AiConfidence = aiConfidence,
             OtasSynced = otasSynced ?? string.Empty,
-            SyncStatus = syncStatus ?? "Pending",
-            CreatedAt = DateTime.UtcNow
+            SyncStatus = syncStatus ?? "Pending"
         };
 
         var result = await historyRepository.AddAsync(history);


### PR DESCRIPTION
Build broken on main after merge of #133.

- `PricingAdapterService.cs`: removed `CreatedAt = DateTime.UtcNow` (property doesn't exist; `AdaptationDate` already defaults to `DateTime.UtcNow`)
- `OtaManager.cs`: same fix
- `PricingAdapterConfigRepository.cs`: removed `config.UpdatedAt = DateTime.UtcNow` (`UpdatedAt` doesn't exist on the entity)