### PR TITLE
feat: add Swagger docs and XML comments for pricing-adapter endpoints

### DIFF
--- a/Casazen.Web/Casazen.Web.csproj
+++ b/Casazen.Web/Casazen.Web.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
     <PackageReference Include="SendGrid.Extensions.DependencyInjection" Version="1.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Casazen.Web/Controllers/PricingAdapterController.cs
+++ b/Casazen.Web/Controllers/PricingAdapterController.cs
@@ -5,6 +5,7 @@ using Casazen.Web.DTOs;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace Casazen.Web.Controllers;
 
@@ -14,6 +15,7 @@ namespace Casazen.Web.Controllers;
 [ApiController]
 [Route("api/pricing-adapter")]
 [Authorize]
+[SwaggerTag("Pricing Adapter")]
 public class PricingAdapterController(
     IPricingAdapterService pricingService,
     IPropertyService propertyService,

--- a/Casazen.Web/DTOs/PricingAdapterConfigRequest.cs
+++ b/Casazen.Web/DTOs/PricingAdapterConfigRequest.cs
@@ -1,17 +1,28 @@
 using System.ComponentModel.DataAnnotations;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace Casazen.Web.DTOs;
 
+/// <summary>
+/// Request body for creating or updating the AI pricing adapter configuration for a property.
+/// </summary>
 public class PricingAdapterConfigRequest
 {
+    /// <summary>Whether AI-driven dynamic pricing is active for this property.</summary>
     [Required]
     public bool IsEnabled { get; set; }
 
+    /// <summary>
+    /// How often the pricing engine runs. Allowed values: <c>daily</c>, <c>weekly</c>.
+    /// </summary>
     [Required]
     [RegularExpression("^(daily|weekly)$", ErrorMessage = "AdaptationFrequency must be 'daily' or 'weekly'")]
+    [SwaggerSchema("Pricing recalculation frequency. Allowed values: daily, weekly.")]
     public string AdaptationFrequency { get; set; } = string.Empty;
 
+    /// <summary>When <c>true</c>, the engine applies seasonal demand multipliers.</summary>
     public bool IncludeSeasonality { get; set; }
 
+    /// <summary>When <c>true</c>, the engine applies Italian public-holiday surge multipliers.</summary>
     public bool IncludePublicHolidays { get; set; }
 }

--- a/Casazen.Web/DTOs/PricingAdapterConfigResponse.cs
+++ b/Casazen.Web/DTOs/PricingAdapterConfigResponse.cs
@@ -1,14 +1,34 @@
 namespace Casazen.Web.DTOs;
 
+/// <summary>
+/// Current AI pricing adapter configuration for a property.
+/// </summary>
 public class PricingAdapterConfigResponse
 {
+    /// <summary>The property this configuration belongs to.</summary>
     public Guid PropertyId { get; set; }
+
+    /// <summary>Whether AI-driven dynamic pricing is active.</summary>
     public bool IsEnabled { get; set; }
+
+    /// <summary>UTC timestamp of the next scheduled pricing run, or <c>null</c> if not scheduled.</summary>
     public DateTime? NextScheduledRunAt { get; set; }
+
+    /// <summary>Pricing recalculation frequency: <c>daily</c> or <c>weekly</c>.</summary>
     public string AdaptationFrequency { get; set; } = string.Empty;
+
+    /// <summary>Whether seasonal demand multipliers are applied.</summary>
     public bool IncludeSeasonality { get; set; }
+
+    /// <summary>Whether Italian public-holiday surge multipliers are applied.</summary>
     public bool IncludePublicHolidays { get; set; }
+
+    /// <summary>UTC timestamp of the last successful pricing adaptation, or <c>null</c> if never run.</summary>
     public DateTime? LastAdaptedAt { get; set; }
+
+    /// <summary>UTC timestamp when this configuration was created.</summary>
     public DateTime CreatedAt { get; set; }
+
+    /// <summary>UTC timestamp of the most recent update to this configuration.</summary>
     public DateTime UpdatedAt { get; set; }
 }

--- a/Casazen.Web/DTOs/PricingHistoryDto.cs
+++ b/Casazen.Web/DTOs/PricingHistoryDto.cs
@@ -1,22 +1,52 @@
 namespace Casazen.Web.DTOs;
 
+/// <summary>
+/// A single AI-driven price change event recorded for a property.
+/// </summary>
 public class PricingHistoryDto
 {
+    /// <summary>Unique identifier of this history record.</summary>
     public Guid Id { get; set; }
+
+    /// <summary>The property this price change applies to.</summary>
     public Guid PropertyId { get; set; }
+
+    /// <summary>UTC date when the pricing adaptation was computed.</summary>
     public DateTime AdaptationDate { get; set; }
+
+    /// <summary>Nightly rate before the adaptation (EUR).</summary>
     public decimal PreviousPrice { get; set; }
+
+    /// <summary>Nightly rate after the adaptation (EUR).</summary>
     public decimal NewPrice { get; set; }
+
+    /// <summary>Human-readable explanation of why the price changed.</summary>
     public string ChangeReason { get; set; } = string.Empty;
+
+    /// <summary>AI model confidence score between 0.0 and 1.0.</summary>
     public decimal AiConfidence { get; set; }
+
+    /// <summary>Comma-separated list of OTA platforms the new price was synced to.</summary>
     public string OtasSynced { get; set; } = string.Empty;
+
+    /// <summary>OTA sync outcome: <c>synced</c>, <c>partial</c>, or <c>failed</c>.</summary>
     public string SyncStatus { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp when this record was created.</summary>
     public DateTime CreatedAt { get; set; }
 }
 
+/// <summary>
+/// Paginated collection of pricing history records.
+/// </summary>
 public class PricingHistoryPagedResponse
 {
+    /// <summary>Price change records for the requested page.</summary>
     public IEnumerable<PricingHistoryDto> Items { get; set; } = Enumerable.Empty<PricingHistoryDto>();
+
+    /// <summary>Total number of records matching the filter (across all pages).</summary>
     public int Total { get; set; }
+
+    /// <summary>Current page number (1-based).</summary>
     public int Page { get; set; }
 }

--- a/Casazen.Web/DTOs/PricingPreviewDayDto.cs
+++ b/Casazen.Web/DTOs/PricingPreviewDayDto.cs
@@ -1,14 +1,28 @@
 namespace Casazen.Web.DTOs;
 
+/// <summary>
+/// Suggested price for a single day in a pricing preview.
+/// </summary>
 public class PricingPreviewDayDto
 {
+    /// <summary>Calendar date in <c>yyyy-MM-dd</c> format.</summary>
     public string Date { get; set; } = string.Empty;
+
+    /// <summary>AI-suggested nightly rate for this date (EUR).</summary>
     public decimal SuggestedPrice { get; set; }
+
+    /// <summary>Property's current base nightly rate (EUR), before multipliers.</summary>
     public decimal BasePrice { get; set; }
+
+    /// <summary>Short explanation of the factors that drove the suggested price.</summary>
     public string Reason { get; set; } = string.Empty;
 }
 
+/// <summary>
+/// 90-day forward-looking pricing preview for a property.
+/// </summary>
 public class PricingPreviewResponse
 {
+    /// <summary>Suggested daily prices for the next 90 days.</summary>
     public IEnumerable<PricingPreviewDayDto> Prices { get; set; } = Enumerable.Empty<PricingPreviewDayDto>();
 }

--- a/Casazen.Web/Program.cs
+++ b/Casazen.Web/Program.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Casazen.Core.Repositories;
 using Casazen.Core.Services;
 using Casazen.Infrastructure.Data;
@@ -159,6 +160,12 @@ builder.Services.AddSwaggerGen(options =>
             new List<string>()
         }
     });
+
+    options.EnableAnnotations();
+
+    var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+    options.IncludeXmlComments(xmlPath);
 });
 
 var app = builder.Build();


### PR DESCRIPTION
## Summary

- Added XML `<summary>` doc comments to all 6 pricing-adapter DTOs (`PricingAdapterConfigRequest/Response`, `PricingHistoryDto`, `PricingHistoryPagedResponse`, `PricingPreviewDayDto`, `PricingPreviewResponse`) and their properties
- Added `[SwaggerTag("Pricing Adapter")]` to `PricingAdapterController` so all 6 endpoints appear under a dedicated **Pricing Adapter** group in Swagger UI
- Added `[SwaggerSchema]` on `AdaptationFrequency` in the request DTO to surface the allowed values (`daily`/`weekly`) directly in Swagger UI
- Wired XML comments into Swagger (`IncludeXmlComments`) — they were generated by the build but previously not consumed by Swashbuckle
- Added `EnableAnnotations()` and the `Swashbuckle.AspNetCore.Annotations 6.8.1` package
- All 6 endpoints already had correct `[ProducesResponseType]` attributes; no 4xx/5xx responses are undocumented

> Note: `dotnet format --verify-no-changes` reports whitespace issues in files unrelated to this PR (pre-existing on `main`). Only the 7 files changed by this branch are in scope.

## Test Plan
- [x] `dotnet test` passes (266 tests, 0 failed)
- [x] Launch app locally and visit `/swagger` — all 6 `pricing-adapter` endpoints visible under **Pricing Adapter** tag
- [x] Request/response schemas show property descriptions from XML comments
- [x] `AdaptationFrequency` shows `"Pricing recalculation frequency. Allowed values: daily, weekly."` in schema description

Closes #123
Part of: casazen/backend#116

🤖 Generated with [Claude Code](https://claude.com/claude-code)