### PR TITLE
docs: add project documentation (BUSINESS, TECHNICAL, PROJECT)

### DIFF
--- a/docs/BUSINESS.md
+++ b/docs/BUSINESS.md
@@ -1,0 +1,192 @@
+# CasaZen — Business Documentation
+
+> CasaZen is a vacation rental management platform built for the Italian short-term rental market. It enables property owners to manage bookings, guests, and pricing across multiple Online Travel Agency (OTA) channels while staying fully compliant with Italian law — including CIN registration (D.L. 145/2023), police guest reporting (Alloggiati Web), tourist tax collection, and GDPR data protection.
+
+---
+
+## Overview
+
+### Purpose
+CasaZen gives Italian vacation rental owners a single platform to manage their properties, accept bookings from guests and OTA platforms, process payments, and meet all mandatory Italian regulatory obligations. Owners no longer need to juggle spreadsheets, manual police reports, or per-platform dashboards.
+
+### Target users
+- **Property owners** — individuals or small businesses renting short-term in Italy
+- **Property managers** — professionals managing multiple properties on behalf of owners
+- **Guests** — travellers who book directly or via OTA platforms (Airbnb, Booking.com, etc.)
+
+### Core value proposition
+CasaZen automates the most burdensome parts of Italian vacation rental management: real-time multi-channel synchronisation, compliant tourist tax calculation, mandatory police reporting (Alloggiati Web), and AI-driven dynamic pricing — all in one API-first platform.
+
+---
+
+## Domain Entities
+
+> The core objects the system works with. Each entity represents a real-world concept in the business domain.
+
+### Property
+- **Purpose**: A vacation rental property listed by an owner.
+- **Key attributes**: Name, address, city, bedrooms, bathrooms, max guests, nightly rate, cleaning fee, damage deposit, amenities, house rules, CIN code, timezone.
+- **Relationships**: Owned by a user (`OwnerId`); has many `Booking`s, `OtaIntegration`s, an optional `CancellationPolicy`, and one `PricingAdapterConfig`.
+- **Business significance**: The central asset. Every booking, payment, OTA sync, and pricing decision is attached to a property. Italian law (D.L. 145/2023) requires each property to carry a CIN code in the format `IT-XXXXX-XXXXXXXXXX`.
+
+### Booking
+- **Purpose**: A confirmed or pending stay at a property.
+- **Key attributes**: Check-in date, check-out date, number of guests (adults / children), status, source platform, base price, tourist tax amount, total price, special requests.
+- **Relationships**: Belongs to a `Property` and a `Guest`; has many `Payment`s and `AlloggiatiWebReport`s.
+- **Business significance**: The core transactional record. Tourist tax is calculated per booking based on city rates. Status follows a strict lifecycle: Pending → Confirmed → CheckedIn → CheckedOut (or Cancelled). Check-in triggers a mandatory police report.
+
+### Guest
+- **Purpose**: A person who makes or participates in a booking.
+- **Key attributes**: Name, email, phone, address, date of birth, nationality, document type and number, GDPR consent dates, data retention expiry.
+- **Relationships**: Has many `Booking`s and `AlloggiatiWebReport`s.
+- **Business significance**: Italian law requires full identity verification for police reporting. GDPR rules govern how long data may be retained (default 7 years) and mandate erasure on request (Article 17).
+
+### Payment
+- **Purpose**: A financial transaction linked to a booking.
+- **Key attributes**: Amount, refunded amount, status, payment method, Stripe payment intent ID, transaction ID, processed timestamp.
+- **Relationships**: Belongs to a `Booking`.
+- **Business significance**: Payments flow through Stripe. Partial refunds are tracked separately via `RefundedAmount`. Status lifecycle: Pending → Processing → Completed / Failed / Refunded / PartiallyRefunded.
+
+### TouristTaxRate
+- **Purpose**: City-specific tourist tax rates mandated by Italian municipalities.
+- **Key attributes**: Region, city, rate per night, maximum nights subject to tax, effective date range.
+- **Relationships**: Referenced by the tax calculation service at booking creation time.
+- **Business significance**: Tourist tax rates vary by city and change over time. They are stored in the database and must never be hardcoded. The system applies the rate valid at the time of the booking's check-in date.
+
+### OtaIntegration
+- **Purpose**: A connection between a property and an OTA platform.
+- **Key attributes**: Platform name, external property ID, API key, last sync timestamp.
+- **Relationships**: Belongs to a `Property`.
+- **Business significance**: Enables bidirectional sync — pulling bookings from OTAs and pushing pricing and availability updates. Six platforms supported: Airbnb, Booking.com, Expedia, VRBO, TripAdvisor, Agoda.
+
+### AlloggiatiWebReport
+- **Purpose**: A record of a guest data submission to the Italian police database (Alloggiati Web).
+- **Relationships**: Linked to a `Booking` and a `Guest`.
+- **Business significance**: Italian law (D.L. 286/1998, Art. 7) requires accommodation providers to report guest identities to the police within 24 hours of check-in. This entity tracks submission status.
+
+### PricingAdapterConfig / PricingHistory
+- **Purpose**: Configuration and audit trail for AI-driven dynamic pricing.
+- **Key attributes**: Enabled flag, adaptation frequency, seasonality and public holiday flags, next scheduled run, last adapted timestamp, AI confidence score.
+- **Business significance**: Allows owners to opt into automated price adjustments. Each price change is logged in `PricingHistory` with an AI confidence score for transparency.
+
+---
+
+## Business Processes
+
+### New Booking Flow
+
+**Trigger**: A property owner or guest submits a booking request (direct or OTA-sourced).
+
+**Steps**:
+1. System checks property availability for the requested dates.
+2. If unavailable, the request is rejected with a clear error message.
+3. Tourist tax is calculated using the city rate valid for the check-in date.
+4. Total price = base price + tourist tax.
+5. Booking is saved with status `Pending`.
+6. Owner or OTA confirms the booking; status moves to `Confirmed`.
+
+**Outcome**: A `Booking` record exists with a confirmed status and a correct, legally compliant total price.
+
+**Business rules applied**: Property availability check; tourist tax calculation from `TouristTaxRate` entity; status lifecycle enforcement.
+
+---
+
+### Guest Check-In and Police Reporting
+
+**Trigger**: A property owner marks a booking as checked-in via the API.
+
+**Steps**:
+1. System validates the booking is in `Confirmed` status.
+2. System validates today's date is on or after the check-in date.
+3. Booking status is updated to `CheckedIn`.
+4. A background job is immediately enqueued to submit guest identity data to Alloggiati Web (Italian police system).
+
+**Outcome**: Booking is active; Italian police registration obligation is fulfilled within 24 hours.
+
+**Business rules applied**: Status must be `Confirmed`; check-in date must not be in the future; Alloggiati Web submission is mandatory and asynchronous to keep the API response fast.
+
+---
+
+### Payment Processing and Refund
+
+**Trigger**: A payment record is created and then explicitly processed for a confirmed booking.
+
+**Steps**:
+1. A `Payment` record is created (status `Pending`) linked to the booking.
+2. Owner or system triggers payment processing via Stripe.
+3. On success, status becomes `Completed` and the processed timestamp is recorded.
+4. If a refund is needed, a refund action initiates a Stripe refund (full or partial).
+5. `RefundedAmount` is updated; status becomes `Refunded` or `PartiallyRefunded`.
+
+**Outcome**: Payment is settled; revenue is attributable to a property and date range.
+
+**Business rules applied**: Stripe webhook signatures must be verified before updating state; partial refund tracking via `RefundedAmount`.
+
+---
+
+### OTA Synchronisation
+
+**Trigger**: Scheduled automatically (hourly full sync, every 15 minutes booking pull) or triggered manually.
+
+**Steps**:
+1. For each active `OtaIntegration`, the system connects to the platform API using stored credentials.
+2. New bookings on the OTA are pulled and imported as local `Booking` records with the appropriate `BookingSource`.
+3. Local availability and pricing updates are pushed to the OTA calendar.
+4. Sync status and timestamp are recorded.
+5. On transient failure, the system retries with exponential backoff (2s, 4s, 8s). After 5 consecutive failures the circuit breaker opens for 60 seconds.
+
+**Outcome**: All connected OTA platforms reflect the latest availability and pricing; new OTA bookings appear in CasaZen.
+
+**Business rules applied**: Rate limits respected per platform; OTA webhooks must respond within 3 seconds (long work offloaded to background jobs).
+
+---
+
+## Business Rules
+
+| Rule | Description | Where enforced |
+|---|---|---|
+| CIN format | Property CIN code must match `IT-XXXXX-XXXXXXXXXX` | `CinCodeAttribute` validator on `Property` |
+| Tourist tax source | Rates must come from the `TouristTaxRate` entity — never hardcoded | `TaxCalculationService` |
+| Booking status machine | Only valid transitions: Pending→Confirmed→CheckedIn→CheckedOut; any state→Cancelled | `BookingsController` check-in/check-out actions |
+| Check-in date validation | Cannot check in before the booking's check-in date | `BookingsController.CheckIn` |
+| Availability check | A property cannot have overlapping confirmed bookings | `IBookingService.IsPropertyAvailableAsync` |
+| GDPR data retention | Guest data retained for 7 years by default; erasure on request (Article 17) | `GdprService`, `GdprDataRetentionJob` |
+| Police reporting | Guest data must be submitted to Alloggiati Web within 24 hours of check-in | `AlloggiatiWebReportJob` (background job) |
+| Ownership authorisation | Only the property owner may modify or access data for their own property | `PropertiesController`, `BookingsController`, `PricingAdapterController` |
+| Image limit | Maximum 20 photos per property | `PropertiesController.UploadImages` |
+| OTA webhook response time | Must respond within 3 seconds; long operations use background jobs | Architecture convention |
+| Payment refund tracking | Partial refund amount tracked in `RefundedAmount`; status reflects actual state | `PaymentService` / `PaymentsController` |
+
+---
+
+## Glossary
+
+| Term | Definition |
+|---|---|
+| CIN | Codice Identificativo Nazionale — a unique national identification code assigned to each short-term rental property in Italy under D.L. 145/2023. Format: `IT-XXXXX-XXXXXXXXXX`. |
+| Alloggiati Web | The Italian Police (Polizia di Stato) online portal for accommodation providers to register guest identities within 24 hours of check-in, as required by D.L. 286/1998, Art. 7. |
+| Tourist tax (tassa di soggiorno) | A per-night fee collected by accommodation providers on behalf of Italian municipalities. Rates vary by city and are capped at a maximum number of nights. |
+| OTA | Online Travel Agency — third-party booking platforms such as Airbnb, Booking.com, Expedia, VRBO, TripAdvisor, and Agoda. |
+| Cedolare secca | A flat-rate tax regime for individual property owners in Italy covering rental income. Relevant to how owners report revenue. |
+| BookingSource | The channel through which a booking originated: Direct, Airbnb, BookingCom, Expedia, Vrbo, TripAdvisor, Agoda, or Local. |
+| BookingStatus | The lifecycle state of a booking: Pending, Confirmed, CheckedIn, CheckedOut, Cancelled. |
+| Circuit breaker | A resilience pattern that halts calls to an external service after repeated failures, preventing cascading errors. Used for all OTA integrations. |
+| GDPR | General Data Protection Regulation — EU regulation governing the collection, storage, and erasure of personal data. Applies to all guest personal data. |
+| Dynamic pricing | AI-driven automatic adjustment of nightly rates based on seasonality, demand signals, and public holidays. Managed via `PricingAdapterConfig`. |
+
+---
+
+## External Integrations (Business Perspective)
+
+| Integration | Business purpose | Data exchanged |
+|---|---|---|
+| Airbnb | Sync bookings and availability; push pricing | Booking details in; availability and nightly prices out |
+| Booking.com | Sync bookings and availability; push pricing | Same as Airbnb |
+| Expedia | Sync bookings and availability; push pricing | Same as Airbnb |
+| VRBO | Sync bookings and availability; push pricing | Same as Airbnb |
+| TripAdvisor | Sync bookings and availability; push pricing | Same as Airbnb |
+| Agoda | Sync bookings and availability; push pricing | Same as Airbnb |
+| Stripe | Payment processing and refunds | Charge amounts, refund amounts, webhook payment events |
+| Alloggiati Web | Mandatory police guest registration | Guest identity data (name, DOB, document details, nationality) |
+| SendGrid | Transactional email notifications | Booking confirmations, receipts, reminders |
+| Auth0 | User identity and authentication | JWT tokens validated on every API request |

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -1,0 +1,122 @@
+# PROJECT.md — AI Context for CasaZen Backend
+
+## What this project does
+CasaZen is a vacation-rental property management platform targeting the Italian short-term
+rental market. It enables property managers to list properties, manage bookings, collect
+payments, sync inventory across OTA channels (Airbnb, Booking.com, Expedia, VRBO,
+TripAdvisor, Agoda), and comply with Italian regulations (CIN D.L. 145/2023, Alloggiati
+Web reporting, tourist tax, GDPR).
+
+## Stack snapshot
+- **Language**: C# 13 / .NET 10 (global.json sdk `10.0.0`)
+- **Framework**: ASP.NET Core Web API with Swagger/OpenAPI
+- **Database**: SQL Server (EF Core 10, code-first migrations)
+- **Auth**: Auth0 — JWT Bearer validated on every `/api` endpoint
+- **Background jobs**: Hangfire (OTA sync hourly, booking pull every 15 min, GDPR retention, pricing)
+- **Payments**: Stripe (webhook signature verification required)
+- **Email**: SendGrid (template IDs only — no inline HTML)
+- **OTA resilience**: Polly (retry + circuit-breaker + rate-limit per platform)
+- **Tests**: xUnit (unit + integration), AAA pattern
+- **CI/CD**: GitHub Actions (`.github/workflows/ci-cd.yml`, `step-transitions.yml`)
+
+## Repo layout
+```
+Casazen.sln
+├── Casazen.Core/              # Domain layer — entities, interfaces, validation
+│   ├── Entities/              # All EF Core entity classes (14 entities)
+│   ├── Repositories/          # Repository interfaces
+│   ├── Services/              # Service interfaces
+│   ├── Validation/            # CinCodeAttribute, BookingValidator
+│   ├── Utilities/             # TimezoneHelper (Europe/Rome default)
+│   └── Enums/                 # PropertyAmenity enum
+├── Casazen.Infrastructure/    # Data + external services layer
+│   ├── Data/                  # AppDbContext, AppDbContextFactory
+│   ├── Migrations/            # EF Core migration files
+│   ├── Repositories/          # Concrete repository implementations
+│   ├── Services/              # Concrete service implementations
+│   ├── External/              # AlloggiatiWebService, SendGridService, StripeService, StripeWebhookHandler
+│   ├── OTA/                   # Channel adapters: Airbnb, BookingCom, Expedia, VRBO, TripAdvisor, Agoda
+│   │   └── Resilience/        # Polly policy factories per platform
+│   └── Payments/              # Stripe payment processing
+├── Casazen.Web/               # Presentation layer — ASP.NET Core host
+│   ├── Controllers/           # 12 API controllers
+│   ├── DTOs/                  # Request/response transfer objects
+│   ├── BackgroundJobs/        # Hangfire job classes (7 jobs)
+│   ├── Middleware/            # ErrorHandlingMiddleware
+│   ├── Extensions/            # DI registration helpers
+│   └── Program.cs             # App entry point, DI, middleware pipeline
+├── Casazen.Tests/
+│   ├── Unit/                  # Services, controllers, entities, OTA, repositories
+│   └── Integration/           # API, migration, resilience, controller integration tests
+├── docs/                      # Project documentation (this folder)
+├── Dockerfile                 # Multi-stage build
+├── docker-compose.yml         # API + SQL Server services
+└── .github/workflows/         # CI/CD pipelines
+```
+
+## Key conventions
+- **Async**: all I/O methods suffixed `Async` (e.g. `GetBookingAsync`). Never `.Result`/`.Wait()`.
+- **Naming**: PascalCase classes/methods; `I` prefix for interfaces; `*Controller`, `*Service`, `*Repository` suffixes.
+- **Tests**: `MethodName_Scenario_ExpectedBehavior` format; AAA pattern; mock via `Mock<IRepository>`.
+- **Coverage targets**: critical paths 100%, services 80%, controllers 70%.
+- **DateTime**: always `DateTime.UtcNow` internally; convert to local only for display.
+- **Validation**: data annotations on entities + `[ApiController]` automatic model-state validation at API boundary.
+- **Commits**: Conventional Commits (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`). No "Co-Authored-By: Claude" lines.
+- **Branches**: `feature/<name>` / `fix/<name>` / `hotfix/<name>` — never push directly to `main`.
+- **Language**: all code, docs, commit messages in English; UI text for end-users in Italian.
+
+## Where to find things
+
+| Thing | Where |
+|---|---|
+| Domain entities | `Casazen.Core/Entities/*.cs` (14 files) |
+| Repository interfaces | `Casazen.Core/Repositories/I*Repositories.cs` |
+| Service interfaces | `Casazen.Core/Services/I*Service.cs` |
+| Service implementations | `Casazen.Infrastructure/Services/*.cs` |
+| Repository implementations | `Casazen.Infrastructure/Repositories/*.cs` |
+| EF Core DbContext | `Casazen.Infrastructure/Data/AppDbContext.cs` |
+| Database migrations | `Casazen.Infrastructure/Migrations/` |
+| API controllers | `Casazen.Web/Controllers/*Controller.cs` (12 controllers) |
+| DTOs | `Casazen.Web/DTOs/` |
+| DI / app setup | `Casazen.Web/Program.cs` + `Casazen.Web/Extensions/` |
+| Background jobs | `Casazen.Web/BackgroundJobs/` (7 Hangfire jobs) |
+| OTA adapters | `Casazen.Infrastructure/OTA/*Adapter.cs` |
+| OTA channel factory | `Casazen.Infrastructure/OTA/ChannelFactory.cs` |
+| External integrations | `Casazen.Infrastructure/External/` (Alloggiati, SendGrid, Stripe) |
+| Stripe webhook handler | `Casazen.Infrastructure/External/StripeWebhookHandler.cs` |
+| CIN validation | `Casazen.Core/Validation/CinCodeAttribute.cs` |
+| Italian tax rates | `Casazen.Core/Entities/TouristTaxRate.cs` |
+| App configuration | `Casazen.Web/appsettings.json` (keys: Auth0, Stripe, Email, OTA, Hangfire) |
+| Unit tests | `Casazen.Tests/Unit/` |
+| Integration tests | `Casazen.Tests/Integration/` |
+| CI/CD pipeline | `.github/workflows/ci-cd.yml` |
+
+## Non-obvious rules / gotchas
+- **CIN code**: every `Property` must store an Italian CIN (`IT-XXXXX-XXXXXXXXXX`). Validated by `[CinCode]` attribute. Required by D.L. 145/2023.
+- **Tourist tax**: stored in `TouristTaxRate` entity — rates vary per city/region. **Never hardcode** a tax amount.
+- **OTA webhooks**: must respond within 3 seconds. Long-running work goes through Hangfire queue — do not process inline in the webhook controller.
+- **DbContext scope**: `AppDbContext` is scoped per request. Never store it in a static field or singleton; always dispose.
+- **Alloggiati Web**: guest data submitted via `AlloggiatiWebService` for Italian police reporting. GDPR retention rules apply.
+- **OTA adapters**: implement `IChannelAdapter`; accessed via `ChannelFactory`. Each platform has independent Polly resilience config in `appsettings.json → OTA.Resilience.<Platform>`.
+- **Stripe webhook signatures**: `StripeWebhookHandler` must verify the `Stripe-Signature` header — never skip this check.
+- **Migrations**: run `dotnet ef migrations add Add<Feature> --project Casazen.Infrastructure` for every schema change; test locally before committing.
+- **Property timezone**: stored as IANA string (`Europe/Rome` default) — use `TimezoneHelper` for conversions, never raw `TimeZoneInfo`.
+- **Auth**: all `/api` endpoints require Auth0 JWT Bearer token. `HealthController` is the only public endpoint.
+- **GDPR**: `GdprDataRetentionJob` handles automatic deletion. `IGdprService` / `GdprController` expose data export/delete for GDPR requests.
+- **Before every commit**: `dotnet test` + `dotnet format --verify-no-changes` — no compiler warnings allowed.
+
+## External integrations
+
+| Integration | Purpose | Config location |
+|---|---|---|
+| Auth0 | JWT authentication for all API endpoints | `appsettings.json → Auth0` |
+| Stripe | Payment processing + webhook events | `appsettings.json → Stripe`; handler in `Casazen.Infrastructure/External/StripeWebhookHandler.cs` |
+| SendGrid | Transactional email (booking confirmations, notifications) | `appsettings.json → Email`; template IDs managed in SendGrid dashboard |
+| Alloggiati Web | Italian police guest reporting (mandatory by law) | `Casazen.Infrastructure/External/AlloggiatiWebService.cs` |
+| Airbnb | OTA booking sync + pricing/availability push | `appsettings.json → OTA.Airbnb` |
+| Booking.com | OTA booking sync + pricing/availability push | `appsettings.json → OTA.BookingCom` |
+| Expedia | OTA booking sync + pricing/availability push | `appsettings.json → OTA.Expedia` |
+| VRBO | OTA booking sync + pricing/availability push | `appsettings.json → OTA.Resilience.Vrbo` |
+| TripAdvisor | OTA booking sync + pricing/availability push | `appsettings.json → OTA.Resilience.TripAdvisor` |
+| Agoda | OTA booking sync + pricing/availability push | `appsettings.json → OTA.Resilience.Agoda` |
+| Hangfire | Background job scheduling and processing | `appsettings.json → Hangfire`; dashboard at `/hangfire` |

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -1,0 +1,388 @@
+# CasaZen — Technical Documentation
+
+> ASP.NET Core 10 REST API following a layered architecture (Presentation → Business Logic → Data Access), with SQL Server via EF Core, Auth0 JWT authentication, and Hangfire background jobs.
+
+---
+
+## Architecture
+
+### Layer diagram
+
+```mermaid
+graph TD
+    A[Casazen.Web - Controllers / Middleware / DTOs] --> B[Casazen.Core - Entities / Service Interfaces / Repository Interfaces]
+    A --> C[Casazen.Infrastructure - Service Implementations / Repository Implementations / OTA Adapters]
+    C --> B
+    C --> D[(SQL Server via EF Core)]
+    A --> E[Hangfire Background Jobs]
+    E --> C
+```
+
+### Layer responsibilities
+
+| Layer | Directory | Responsibility |
+|---|---|---|
+| Presentation | `Casazen.Web/` | HTTP controllers, DTOs, middleware, Swagger config, auth wiring, background job registration |
+| Business Logic | `Casazen.Core/` | Domain entities, service interfaces, repository interfaces, enums, validators, utilities |
+| Data Access | `Casazen.Infrastructure/` | EF Core DbContext, repository implementations, service implementations, OTA adapters, Stripe/SendGrid clients |
+| Tests | `Casazen.Tests/` | Unit and integration tests |
+
+### Dependency rule
+`Casazen.Core` has no external project dependencies — it defines only interfaces and entities. `Casazen.Infrastructure` depends on `Casazen.Core` (implements its interfaces). `Casazen.Web` depends on both `Casazen.Core` (for interface injection) and `Casazen.Infrastructure` (registered in DI). This ensures the domain is framework-agnostic.
+
+---
+
+## Tech Stack
+
+| Component | Technology | Version | Notes |
+|---|---|---|---|
+| Language | C# | 13 | Nullable reference types enabled |
+| Framework | ASP.NET Core | 10.0 | Minimal hosting model in `Program.cs` |
+| Database | SQL Server | 2022+ | In-memory DB used in CI / tests |
+| ORM | Entity Framework Core | 10.x | Code-first, migrations in `Casazen.Infrastructure/Migrations/` |
+| Authentication | Auth0 + JWT Bearer | — | `sub` claim used as user ID |
+| Background jobs | Hangfire | 1.8.x | SQL Server storage; dashboard at `/hangfire` |
+| Payment processing | Stripe .NET SDK | — | Webhook signature verification required |
+| Email | SendGrid SDK | — | Template-based, no inline HTML |
+| OTA resilience | Polly | — | Retry, circuit breaker, timeout, rate limiting per platform |
+| Test framework | xUnit | — | `Casazen.Tests/` |
+| API docs | Swashbuckle / Swagger | — | Swagger UI at `/swagger` (dev only) |
+
+---
+
+## API Reference
+
+### Base URL
+`/api`
+
+### Authentication
+All endpoints require a `Bearer` JWT token in the `Authorization` header (issued by Auth0), except:
+- `GET /api/properties/health` — anonymous health check
+- `GET /api/properties/search` — anonymous property search
+
+### Endpoints
+
+#### Properties
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/properties` | List properties owned by the authenticated user |
+| `GET` | `/api/properties/{id}` | Get a single property |
+| `POST` | `/api/properties` | Create a new property |
+| `PUT` | `/api/properties/{id}` | Update a property (owner only) |
+| `DELETE` | `/api/properties/{id}` | Delete a property (owner only) |
+| `GET` | `/api/properties/search` | Search properties by city, bedrooms, max price (anonymous) |
+| `POST` | `/api/properties/{id}/images` | Upload photos (max 20, JPEG/PNG/WebP, 10 MB each) |
+| `GET` | `/api/properties/{id}/images` | List photo URLs |
+| `DELETE` | `/api/properties/{id}/images/{imageIndex}` | Delete a photo by index |
+| `PUT` | `/api/properties/{id}/images/order` | Reorder photos |
+| `GET` | `/api/properties/health` | Anonymous health check |
+
+#### Bookings
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/bookings` | List bookings (filter by `?propertyId=`) |
+| `GET` | `/api/bookings/{id}` | Get a single booking |
+| `POST` | `/api/bookings` | Create a booking (availability check + tourist tax calculation) |
+| `PUT` | `/api/bookings/{id}` | Update a booking |
+| `DELETE` | `/api/bookings/{id}` | Cancel a booking |
+| `GET` | `/api/bookings/calendar` | Calendar view (`?propertyId&startDate&endDate&timezone`) |
+| `POST` | `/api/bookings/{id}/check-in` | Perform check-in (enqueues Alloggiati Web report) |
+| `POST` | `/api/bookings/{id}/check-out` | Perform check-out |
+| `GET` | `/api/bookings/{id}/alloggiati-status` | Get Alloggiati Web submission status |
+
+#### Guests
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/guests` | List guests |
+| `GET` | `/api/guests/{id}` | Get a single guest |
+| `POST` | `/api/guests` | Create a guest record |
+| `PUT` | `/api/guests/{id}` | Update guest details |
+| `DELETE` | `/api/guests/{id}` | Delete a guest |
+
+#### Payments
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/payments` | List all payments |
+| `GET` | `/api/payments/{id}` | Get a single payment |
+| `POST` | `/api/payments` | Create a payment record |
+| `POST` | `/api/payments/{id}/process` | Charge the guest via Stripe |
+| `POST` | `/api/payments/{id}/refund` | Refund a payment (full or `?amount=` for partial) |
+| `GET` | `/api/payments/revenue` | Revenue report (`?propertyId&startDate&endDate`) |
+
+#### Pricing Adapter (AI Dynamic Pricing)
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/pricing-adapter/config/{propertyId}` | Enable / update AI pricing config |
+| `GET` | `/api/pricing-adapter/config/{propertyId}` | Get current AI pricing config |
+| `DELETE` | `/api/pricing-adapter/config/{propertyId}` | Disable AI pricing |
+| `GET` | `/api/pricing-adapter/history/{propertyId}` | Paginated price change history |
+| `POST` | `/api/pricing-adapter/sync/{propertyId}` | Trigger a manual pricing sync (returns `jobId`) |
+| `GET` | `/api/pricing-adapter/preview/{propertyId}` | Preview suggested prices for next 90 days |
+
+#### OTA Channel Management
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/ota/sync` | Sync all OTA platforms |
+| `GET` | `/api/ota/status` | Get OTA sync status |
+| `PUT` | `/api/ota/pricing` | Push pricing update to OTAs |
+| `GET` | `/api/ota/bookings` | Fetch bookings from a specific OTA platform |
+| `PUT` | `/api/ota/availability` | Push availability update to OTAs |
+| `POST` | `/api/ota/validate` | Validate OTA API credentials |
+
+#### Other
+
+| Method | Path | Description |
+|---|---|---|
+| `GET/POST` | `/api/touristtaxrates` | Manage tourist tax rates |
+| `POST` | `/api/gdpr/consent` | Record GDPR consent |
+| `GET` | `/api/gdpr/export/{guestId}` | Export guest personal data |
+| `DELETE` | `/api/gdpr/erasure/{guestId}` | Request guest data erasure (Art. 17) |
+| `POST` | `/api/webhooks/stripe` | Stripe webhook receiver (signature-verified) |
+| `GET` | `/api/health` | Service health check |
+
+---
+
+## Data Model
+
+### Entity-Relationship diagram
+
+```mermaid
+erDiagram
+    PROPERTY {
+        guid Id PK
+        string OwnerId
+        string Name
+        string City
+        string CinCode
+        decimal NightlyRate
+        decimal CleaningFee
+        decimal DamageDeposit
+        guid CancellationPolicyId FK
+    }
+    BOOKING {
+        guid Id PK
+        guid PropertyId FK
+        guid GuestId FK
+        datetime CheckInDate
+        datetime CheckOutDate
+        string Status
+        string Source
+        decimal BasePrice
+        decimal TouristTax
+        decimal TotalPrice
+    }
+    GUEST {
+        guid Id PK
+        string Email
+        string Nationality
+        string DocumentNumber
+        datetime DataRetentionUntil
+        bool ErasureRequested
+    }
+    PAYMENT {
+        guid Id PK
+        guid BookingId FK
+        decimal Amount
+        decimal RefundedAmount
+        string Status
+        string StripePaymentIntentId
+    }
+    TOURISTTAXRATE {
+        guid Id PK
+        string Region
+        string City
+        decimal RatePerNight
+        int MaxNights
+        datetime EffectiveFrom
+    }
+    OTAINTEGRATION {
+        guid Id PK
+        guid PropertyId FK
+        string Platform
+        string ExternalPropertyId
+        datetime LastSyncAt
+    }
+    ALLOGGIATIWEBREPORT {
+        guid Id PK
+        guid BookingId FK
+        guid GuestId FK
+    }
+    PRICINGADAPTERCONFIG {
+        guid Id PK
+        guid PropertyId FK
+        bool IsEnabled
+        int AdaptationFrequency
+        datetime NextScheduledRunAt
+    }
+
+    PROPERTY ||--o{ BOOKING : "has"
+    PROPERTY ||--o{ OTAINTEGRATION : "linked to"
+    PROPERTY ||--|| PRICINGADAPTERCONFIG : "has"
+    BOOKING }o--|| GUEST : "belongs to"
+    BOOKING ||--o{ PAYMENT : "has"
+    BOOKING ||--o{ ALLOGGIATIWEBREPORT : "generates"
+    GUEST ||--o{ ALLOGGIATIWEBREPORT : "subject of"
+```
+
+### Key entities
+
+#### `Property`
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `Id` | `Guid` | PK | Auto-generated primary key |
+| `OwnerId` | `string` | Required, max 255 | Auth0 `sub` claim of the owner |
+| `Name` | `string` | Required, max 100 | Display name |
+| `CinCode` | `string?` | Max 25, `[CinCode]` validated | Italian national ID code `IT-XXXXX-XXXXXXXXXX` |
+| `NightlyRate` | `decimal` | Range €0.01–€100,000 | Base nightly rate |
+| `Timezone` | `string` | Default `Europe/Rome` | IANA timezone for date handling |
+
+#### `Booking`
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `Id` | `Guid` | PK | Auto-generated |
+| `PropertyId` | `Guid` | FK | Owning property |
+| `GuestId` | `Guid` | FK | Lead guest |
+| `Status` | `BookingStatus` | Required | Pending / Confirmed / CheckedIn / CheckedOut / Cancelled |
+| `Source` | `BookingSource` | Required | Direct / Airbnb / BookingCom / Expedia / … |
+| `TouristTax` | `decimal(18,2)` | — | Calculated at creation from `TouristTaxRate` |
+| `TotalPrice` | `decimal(18,2)` | — | BasePrice + TouristTax |
+
+#### `Guest`
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `Id` | `Guid` | PK | Auto-generated |
+| `Email` | `string` | Required, EmailAddress | Unique contact address |
+| `DocumentType` | `DocumentType?` | — | Passport / IdentityCard / DriversLicense / Other |
+| `DataRetentionUntil` | `datetime` | Default UtcNow+7yr | GDPR retention deadline |
+| `ErasureRequested` | `bool` | Default false | GDPR Article 17 erasure flag |
+
+#### `Payment`
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `Id` | `Guid` | PK | Auto-generated |
+| `BookingId` | `Guid` | FK | Associated booking |
+| `Amount` | `decimal(18,2)` | — | Charged amount |
+| `RefundedAmount` | `decimal(18,2)` | Default 0 | Cumulative refunded total |
+| `Status` | `PaymentStatus` | Required | Pending / Processing / Completed / Failed / Refunded / PartiallyRefunded |
+| `StripePaymentIntentId` | `string?` | Max 255 | Stripe reference |
+
+---
+
+## Design Patterns
+
+| Pattern | Where used | Purpose |
+|---|---|---|
+| Repository | `Casazen.Infrastructure/Repositories/`, `Casazen.Core/Repositories/` (interfaces) | Abstracts EF Core data access; enables unit testing with mocks |
+| Service layer | `Casazen.Core/Services/` (interfaces), `Casazen.Infrastructure/Services/` (implementations) | Encapsulates business logic away from controllers |
+| Background jobs (Queue) | `Casazen.Web/BackgroundJobs/` via Hangfire | Decouples long-running work (OTA sync, police reporting, pricing, email) from HTTP request cycle |
+| Circuit breaker + Retry (Polly) | `Casazen.Infrastructure/OTA/Resilience/` | Production-grade fault tolerance for all OTA HTTP calls |
+| Adapter | `Casazen.Infrastructure/OTA/` — implements `IOtaAdapter` | Uniform interface across 6 OTA platforms; swap implementations without changing business logic |
+| Middleware pipeline | `Casazen.Web/Middleware/` | Global error handling, authentication, CORS applied as middleware |
+| Webhook handler | `Casazen.Infrastructure/External/StripeWebhookHandler.cs` | Isolated, signature-verified handler for Stripe events |
+
+---
+
+## Infrastructure
+
+### Database
+- **Type**: SQL Server 2022+ (in-memory fallback for tests / CI when no connection string)
+- **Connection**: Connection string key `DefaultConnection` in `appsettings.json`
+- **Migrations**: EF Core code-first migrations in `Casazen.Infrastructure/Migrations/`; apply with `dotnet ef database update`
+
+### Configuration
+
+- **Config files**: `Casazen.Web/appsettings.json` (committed defaults), `appsettings.Development.json` (local secrets — **never commit**)
+- **Key sections**: `Auth0`, `Stripe`, `Email` (SendGrid), `OTA` (per-platform credentials and resilience settings)
+
+### Background jobs
+
+| Job | Schedule | Purpose |
+|---|---|---|
+| `OtaSyncJob` | Hourly | Full OTA availability and booking sync |
+| `BookingPullJob` | Every 15 minutes | Pull new bookings from all OTA platforms |
+| `DynamicPricingJob` | Daily at 02:00 UTC | AI-driven nightly rate adaptation |
+| `AlloggiatiWebReportJob` | On check-in (enqueued) | Submit guest identity to Italian police system |
+| `GdprDataRetentionJob` | Scheduled | Anonymise guest data past retention expiry |
+| `EmailQueueProcessor` | Continuous | Process queued email notifications via SendGrid |
+| `StripeWebhookJob` | On Stripe event (enqueued) | Process Stripe webhook events asynchronously |
+
+### Deployment
+- **Containerisation**: `Dockerfile` and `docker-compose.yml` at repo root; `docker-compose up -d` starts the API
+- **CI/CD**: GitHub Actions — build + test on push; deploy on release tag (`.github/workflows/ci-cd.yml`)
+- **Environments**: Development (local), staging, production
+
+### External service integrations
+
+| Service | SDK / Client | Config location | Purpose |
+|---|---|---|---|
+| Auth0 | Microsoft JWT Bearer middleware | `appsettings.json → Auth0` | JWT validation on all `/api` endpoints |
+| Stripe | Stripe .NET SDK | `appsettings.json → Stripe` | Payment processing and refunds |
+| SendGrid | SendGrid SDK | `appsettings.json → Email:SendGridApiKey` | Transactional emails |
+| Alloggiati Web | Custom HTTP client | `AlloggiatiWebService.cs` | Italian police guest registration |
+| OTA platforms (6) | `IOtaAdapter` implementations | `appsettings.json → OTA` | Booking sync and pricing push |
+| Public holidays API | `PublicHolidayService` | Configured in service | Feeds AI pricing seasonality |
+
+---
+
+## Testing
+
+| Type | Framework | Location | Coverage target |
+|---|---|---|---|
+| Unit tests | xUnit | `Casazen.Tests/Unit/` | 80% for services, 100% for critical paths |
+| Integration tests | xUnit | `Casazen.Tests/Integration/` | Critical API paths |
+
+### Running tests
+
+```bash
+# Run all tests
+dotnet test
+
+# Run specific test class
+dotnet test --filter "PropertyServiceTests"
+
+# With coverage
+dotnet test /p:CollectCoverage=true
+
+# Check formatting
+dotnet format --verify-no-changes
+```
+
+---
+
+## Development Setup
+
+```bash
+# Clone and restore
+git clone https://github.com/casazen/casazen-backend.git
+cd casazen-backend
+dotnet restore
+
+# Configure
+cp Casazen.Web/appsettings.json Casazen.Web/appsettings.Development.json
+# Edit connection string and secrets in appsettings.Development.json
+
+# Apply database migrations
+dotnet ef database update --project Casazen.Infrastructure
+
+# Run
+dotnet run --project Casazen.Web
+
+# Swagger UI (dev mode only)
+# https://localhost:5001/swagger
+
+# Run tests
+dotnet test
+
+# Check formatting before committing
+dotnet format --verify-no-changes
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,24 @@
+# CasaZen Backend — Documentation
+
+> ASP.NET Core 10 vacation rental management API for the Italian market — bookings, payments, OTA sync, tourist tax, and full Italian regulatory compliance.
+
+## Documents
+
+| Document | Purpose | Audience |
+|---|---|---|
+| [BUSINESS.md](BUSINESS.md) | Domain entities, business processes, rules, glossary | Product Owner, Business Analyst, stakeholders |
+| [TECHNICAL.md](TECHNICAL.md) | Architecture, API reference, data model, design patterns, infrastructure | Developers |
+| [PROJECT.md](PROJECT.md) | Compressed AI context — stack, layout, conventions, gotchas | AI agents, onboarding developers |
+
+## Quick links
+
+- [Domain entities](BUSINESS.md#domain-entities)
+- [Business processes](BUSINESS.md#business-processes)
+- [Glossary](BUSINESS.md#glossary)
+- [Architecture diagram](TECHNICAL.md#architecture)
+- [API reference](TECHNICAL.md#api-reference)
+- [Data model](TECHNICAL.md#data-model)
+- [Design patterns](TECHNICAL.md#design-patterns)
+- [Background jobs](TECHNICAL.md#background-jobs)
+- [Where to find things](PROJECT.md#where-to-find-things)
+- [Gotchas](PROJECT.md#non-obvious-rules--gotchas)


### PR DESCRIPTION
## Summary

- Add `docs/BUSINESS.md` — domain entities, business processes, business rules, glossary, external integrations from a business perspective
- Add `docs/TECHNICAL.md` — layered architecture diagram (Mermaid), full tech stack table, complete API reference (50+ endpoints), ER data model diagram (Mermaid), design patterns, infrastructure, dev setup
- Add `docs/PROJECT.md` — compressed AI context file: stack snapshot, annotated repo layout, key conventions, where-to-find-things lookup table, non-obvious gotchas
- Add `docs/index.md` — navigation index with links to all three documents and quick-link anchors

## Why

The codebase had no structured documentation. This addition covers:
- **Onboarding**: developers new to the project can read TECHNICAL.md + PROJECT.md and be productive immediately
- **AI context**: PROJECT.md is optimised to be included as system context for AI agents working on the repo
- **Business alignment**: BUSINESS.md documents domain logic, Italian regulatory rules (CIN, Alloggiati Web, tourist tax, GDPR), and processes in non-technical language for POs and stakeholders

## Test plan

- [ ] Verify Mermaid diagrams render correctly in GitHub (architecture layer diagram, ER diagram)
- [ ] Verify all internal links in `index.md` resolve correctly
- [ ] Spot-check API endpoint table against actual controllers in `Casazen.Web/Controllers/`
- [ ] Spot-check entity field tables against `Casazen.Core/Entities/`