### PR TITLE
feat: add CreatePropertyRequest and UpdatePropertyRequest DTOs

### DIFF
--- a/Casazen.Web/DTOs/CreatePropertyRequest.cs
+++ b/Casazen.Web/DTOs/CreatePropertyRequest.cs
@@ -1,0 +1,130 @@
+using System.ComponentModel.DataAnnotations;
+using Casazen.Core.Entities;
+using Casazen.Core.Enums;
+using Casazen.Core.Validation;
+
+namespace Casazen.Web.DTOs;
+
+/// <summary>
+/// Request body for creating a new property. Excludes server-managed fields
+/// (<c>Id</c>, <c>OwnerId</c>, <c>CreatedAt</c>, <c>UpdatedAt</c>).
+/// </summary>
+public class CreatePropertyRequest
+{
+    /// <summary>Display name of the property.</summary>
+    [Required(ErrorMessage = "Name is required")]
+    [MaxLength(100, ErrorMessage = "Name cannot exceed 100 characters")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Full description shown to guests.</summary>
+    [MaxLength(2000, ErrorMessage = "Description cannot exceed 2000 characters")]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Street address of the property.</summary>
+    [Required(ErrorMessage = "Address is required")]
+    [MaxLength(500, ErrorMessage = "Address cannot exceed 500 characters")]
+    public string Address { get; set; } = string.Empty;
+
+    /// <summary>City where the property is located.</summary>
+    [Required(ErrorMessage = "City is required")]
+    [MaxLength(50, ErrorMessage = "City cannot exceed 50 characters")]
+    public string City { get; set; } = string.Empty;
+
+    /// <summary>Postal / ZIP code.</summary>
+    [MaxLength(10, ErrorMessage = "Postal code cannot exceed 10 characters")]
+    public string PostalCode { get; set; } = string.Empty;
+
+    /// <summary>Geographic latitude of the property.</summary>
+    public decimal Latitude { get; set; }
+
+    /// <summary>Geographic longitude of the property.</summary>
+    public decimal Longitude { get; set; }
+
+    /// <summary>Number of bedrooms (1–100).</summary>
+    [Range(1, 100, ErrorMessage = "Bedrooms must be between 1 and 100")]
+    public int Bedrooms { get; set; }
+
+    /// <summary>Number of bathrooms (1–50).</summary>
+    [Range(1, 50, ErrorMessage = "Bathrooms must be between 1 and 50")]
+    public int Bathrooms { get; set; }
+
+    /// <summary>Maximum number of guests allowed (1–100).</summary>
+    [Range(1, 100, ErrorMessage = "Max guests must be between 1 and 100")]
+    public int MaxGuests { get; set; }
+
+    /// <summary>Base nightly rate in euros (€0.01–€100,000).</summary>
+    [Range(0.01, 100000, ErrorMessage = "Nightly rate must be between €0.01 and €100,000")]
+    public decimal NightlyRate { get; set; }
+
+    /// <summary>One-time cleaning fee in euros (€0–€10,000).</summary>
+    [Range(0, 10000, ErrorMessage = "Cleaning fee must be between €0 and €10,000")]
+    public decimal CleaningFee { get; set; }
+
+    /// <summary>Refundable damage deposit in euros (€0–€50,000).</summary>
+    [Range(0, 50000, ErrorMessage = "Damage deposit must be between €0 and €50,000")]
+    public decimal DamageDeposit { get; set; }
+
+    /// <summary>List of amenities available at the property.</summary>
+    public List<PropertyAmenity> Amenities { get; set; } = new();
+
+    /// <summary>Ordered list of photo URLs for the property listing.</summary>
+    public List<string> PhotoUrls { get; set; } = new();
+
+    /// <summary>House rules presented to guests before booking.</summary>
+    [MaxLength(1000, ErrorMessage = "House rules cannot exceed 1000 characters")]
+    public string HouseRules { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Italian Codice Identificativo Nazionale (CIN) — format <c>IT-XXXXX-XXXXXXXXXX</c>.
+    /// Required by D.L. 145/2023 for short-term rentals.
+    /// </summary>
+    [MaxLength(25, ErrorMessage = "CIN code cannot exceed 25 characters")]
+    [CinCode]
+    public string? CinCode { get; set; }
+
+    /// <summary>
+    /// IANA timezone identifier used for booking date calculations
+    /// (e.g. <c>Europe/Rome</c>). Defaults to <c>Europe/Rome</c>.
+    /// </summary>
+    [MaxLength(50, ErrorMessage = "Timezone cannot exceed 50 characters")]
+    public string Timezone { get; set; } = "Europe/Rome";
+
+    /// <summary>Optional reference to the cancellation policy applied to new bookings.</summary>
+    public Guid? CancellationPolicyId { get; set; }
+
+    /// <summary>Whether the property is visible and bookable. Defaults to <c>true</c>.</summary>
+    public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// Maps the DTO to a new <see cref="Property"/> entity.
+    /// <paramref name="ownerId"/> is taken from the caller's JWT claim and
+    /// must not be supplied by the client.
+    /// </summary>
+    /// <param name="ownerId">Auth0 subject claim of the authenticated user.</param>
+    public Property ToProperty(string ownerId) => new()
+    {
+        OwnerId = ownerId,
+        Name = Name,
+        Description = Description,
+        Address = Address,
+        City = City,
+        PostalCode = PostalCode,
+        Latitude = Latitude,
+        Longitude = Longitude,
+        Bedrooms = Bedrooms,
+        Bathrooms = Bathrooms,
+        MaxGuests = MaxGuests,
+        NightlyRate = NightlyRate,
+        CleaningFee = CleaningFee,
+        DamageDeposit = DamageDeposit,
+        Amenities = Amenities,
+        PhotoUrls = PhotoUrls,
+        HouseRules = HouseRules,
+        CinCode = CinCode,
+        Timezone = Timezone,
+        CancellationPolicyId = CancellationPolicyId,
+        IsActive = IsActive,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+    };
+}

--- a/Casazen.Web/DTOs/UpdatePropertyRequest.cs
+++ b/Casazen.Web/DTOs/UpdatePropertyRequest.cs
@@ -1,0 +1,129 @@
+using System.ComponentModel.DataAnnotations;
+using Casazen.Core.Entities;
+using Casazen.Core.Enums;
+using Casazen.Core.Validation;
+
+namespace Casazen.Web.DTOs;
+
+/// <summary>
+/// Request body for updating an existing property. Excludes server-managed fields
+/// (<c>Id</c>, <c>OwnerId</c>, <c>CreatedAt</c>, <c>UpdatedAt</c>).
+/// Kept as a separate class from <see cref="CreatePropertyRequest"/> for API versioning safety.
+/// </summary>
+public class UpdatePropertyRequest
+{
+    /// <summary>Display name of the property.</summary>
+    [Required(ErrorMessage = "Name is required")]
+    [MaxLength(100, ErrorMessage = "Name cannot exceed 100 characters")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Full description shown to guests.</summary>
+    [MaxLength(2000, ErrorMessage = "Description cannot exceed 2000 characters")]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Street address of the property.</summary>
+    [Required(ErrorMessage = "Address is required")]
+    [MaxLength(500, ErrorMessage = "Address cannot exceed 500 characters")]
+    public string Address { get; set; } = string.Empty;
+
+    /// <summary>City where the property is located.</summary>
+    [Required(ErrorMessage = "City is required")]
+    [MaxLength(50, ErrorMessage = "City cannot exceed 50 characters")]
+    public string City { get; set; } = string.Empty;
+
+    /// <summary>Postal / ZIP code.</summary>
+    [MaxLength(10, ErrorMessage = "Postal code cannot exceed 10 characters")]
+    public string PostalCode { get; set; } = string.Empty;
+
+    /// <summary>Geographic latitude of the property.</summary>
+    public decimal Latitude { get; set; }
+
+    /// <summary>Geographic longitude of the property.</summary>
+    public decimal Longitude { get; set; }
+
+    /// <summary>Number of bedrooms (1–100).</summary>
+    [Range(1, 100, ErrorMessage = "Bedrooms must be between 1 and 100")]
+    public int Bedrooms { get; set; }
+
+    /// <summary>Number of bathrooms (1–50).</summary>
+    [Range(1, 50, ErrorMessage = "Bathrooms must be between 1 and 50")]
+    public int Bathrooms { get; set; }
+
+    /// <summary>Maximum number of guests allowed (1–100).</summary>
+    [Range(1, 100, ErrorMessage = "Max guests must be between 1 and 100")]
+    public int MaxGuests { get; set; }
+
+    /// <summary>Base nightly rate in euros (€0.01–€100,000).</summary>
+    [Range(0.01, 100000, ErrorMessage = "Nightly rate must be between €0.01 and €100,000")]
+    public decimal NightlyRate { get; set; }
+
+    /// <summary>One-time cleaning fee in euros (€0–€10,000).</summary>
+    [Range(0, 10000, ErrorMessage = "Cleaning fee must be between €0 and €10,000")]
+    public decimal CleaningFee { get; set; }
+
+    /// <summary>Refundable damage deposit in euros (€0–€50,000).</summary>
+    [Range(0, 50000, ErrorMessage = "Damage deposit must be between €0 and €50,000")]
+    public decimal DamageDeposit { get; set; }
+
+    /// <summary>List of amenities available at the property.</summary>
+    public List<PropertyAmenity> Amenities { get; set; } = new();
+
+    /// <summary>Ordered list of photo URLs for the property listing.</summary>
+    public List<string> PhotoUrls { get; set; } = new();
+
+    /// <summary>House rules presented to guests before booking.</summary>
+    [MaxLength(1000, ErrorMessage = "House rules cannot exceed 1000 characters")]
+    public string HouseRules { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Italian Codice Identificativo Nazionale (CIN) — format <c>IT-XXXXX-XXXXXXXXXX</c>.
+    /// Required by D.L. 145/2023 for short-term rentals.
+    /// </summary>
+    [MaxLength(25, ErrorMessage = "CIN code cannot exceed 25 characters")]
+    [CinCode]
+    public string? CinCode { get; set; }
+
+    /// <summary>
+    /// IANA timezone identifier used for booking date calculations
+    /// (e.g. <c>Europe/Rome</c>). Defaults to <c>Europe/Rome</c>.
+    /// </summary>
+    [MaxLength(50, ErrorMessage = "Timezone cannot exceed 50 characters")]
+    public string Timezone { get; set; } = "Europe/Rome";
+
+    /// <summary>Optional reference to the cancellation policy applied to new bookings.</summary>
+    public Guid? CancellationPolicyId { get; set; }
+
+    /// <summary>Whether the property is visible and bookable.</summary>
+    public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// Applies all client-supplied values to an existing <see cref="Property"/> entity in place.
+    /// <c>OwnerId</c>, <c>Id</c>, <c>CreatedAt</c> are never touched; only <c>UpdatedAt</c>
+    /// is refreshed automatically.
+    /// </summary>
+    /// <param name="property">The tracked entity to update.</param>
+    public void ApplyTo(Property property)
+    {
+        property.Name = Name;
+        property.Description = Description;
+        property.Address = Address;
+        property.City = City;
+        property.PostalCode = PostalCode;
+        property.Latitude = Latitude;
+        property.Longitude = Longitude;
+        property.Bedrooms = Bedrooms;
+        property.Bathrooms = Bathrooms;
+        property.MaxGuests = MaxGuests;
+        property.NightlyRate = NightlyRate;
+        property.CleaningFee = CleaningFee;
+        property.DamageDeposit = DamageDeposit;
+        property.Amenities = Amenities;
+        property.PhotoUrls = PhotoUrls;
+        property.HouseRules = HouseRules;
+        property.CinCode = CinCode;
+        property.Timezone = Timezone;
+        property.CancellationPolicyId = CancellationPolicyId;
+        property.IsActive = IsActive;
+        property.UpdatedAt = DateTime.UtcNow;
+    }
+}


### PR DESCRIPTION
## Summary
Add `CreatePropertyRequest` and `UpdatePropertyRequest` DTOs to `Casazen.Web/DTOs/`. These DTOs exclude `OwnerId`, `Id`, `CreatedAt`, and `UpdatedAt` from the client-facing API contract — fixing the security gap where clients could supply arbitrary owner IDs and enabling the controller to populate `OwnerId` from the JWT claim without being blocked by model validation.

- `CreatePropertyRequest.ToProperty(ownerId)` maps the DTO to a new `Property` entity, taking the owner ID from the caller's JWT claim
- `UpdatePropertyRequest.ApplyTo(property)` patches an existing tracked entity in place, leaving `OwnerId`, `Id`, and `CreatedAt` untouched
- All validation attributes from `Property.cs` are preserved on the corresponding DTO properties
- All public properties carry XML doc comments matching the style of existing DTOs in the project
- No AutoMapper, no EF Core migration required

## Test Plan
- [x] `dotnet build --configuration Release` passes with 0 errors, 0 warnings
- [x] `dotnet test --configuration Release` passes — 281 passed, 0 failed, 25 skipped (pre-existing skips)

Closes #146
Part of: casazen/backend#144

🤖 Generated with [Claude Code](https://claude.com/claude-code)