### PR TITLE
feat: add regression tests, fix integration test bodies, update Swagger XML docs (#148)

### DIFF
--- a/Casazen.Tests/Integration/PropertiesControllerIntegrationTests.cs
+++ b/Casazen.Tests/Integration/PropertiesControllerIntegrationTests.cs
@@ -56,13 +56,12 @@ public class PropertiesControllerIntegrationTests : IClassFixture<WebApplication
     [Fact]
     public async Task Create_WithoutAuthentication_ReturnsUnauthorizedOrError()
     {
-        // Arrange
+        // Arrange — OwnerId is not included; it is always derived from JWT on the server side
         var newProperty = new
         {
             Name = "Test Property",
             City = "Rome",
             Address = "Via Roma 1",
-            OwnerId = "auth0|test_user_123",
             Bedrooms = 2,
             Bathrooms = 1,
             MaxGuests = 4,
@@ -89,14 +88,13 @@ public class PropertiesControllerIntegrationTests : IClassFixture<WebApplication
     [Fact]
     public async Task Update_WithoutAuthentication_ReturnsUnauthorizedOrError()
     {
-        // Arrange
+        // Arrange — OwnerId is not included; it is always derived from JWT on the server side
         var testId = Guid.NewGuid();
         var updateProperty = new
         {
             Name = "Updated Property",
             City = "Rome",
-            Address = "Via Roma 1",
-            OwnerId = "auth0|test_user_123"
+            Address = "Via Roma 1"
         };
 
         var json = JsonSerializer.Serialize(updateProperty);
@@ -127,6 +125,44 @@ public class PropertiesControllerIntegrationTests : IClassFixture<WebApplication
             response.StatusCode == HttpStatusCode.Unauthorized ||
             response.StatusCode == HttpStatusCode.InternalServerError,
             $"Expected Unauthorized or InternalServerError, got {response.StatusCode}"
+        );
+    }
+
+    /// <summary>
+    /// Regression test for issue #143: POST /api/properties without OwnerId in the body
+    /// must not return 400 Bad Request. OwnerId is always derived from the JWT on the server.
+    /// The test expects 401 because Auth0 is not configured in the integration test environment,
+    /// confirming the request reaches auth middleware and not model-validation (which would 400).
+    /// </summary>
+    [Fact]
+    public async Task Create_WithoutOwnerIdInBody_DoesNotReturn400()
+    {
+        // Arrange — no OwnerId field, matching the new CreatePropertyRequest DTO
+        var newProperty = new
+        {
+            Name = "Regression Property",
+            City = "Rome",
+            Address = "Via Roma 1",
+            Bedrooms = 1,
+            Bathrooms = 1,
+            MaxGuests = 2,
+            NightlyRate = 80.00m
+        };
+
+        var json = JsonSerializer.Serialize(newProperty);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        // Act — sent without an authentication token
+        var response = await _client.PostAsync("/api/properties", content);
+
+        // Assert — must NOT be 400 (which would indicate OwnerId is wrongly required in request body)
+        Assert.NotEqual(HttpStatusCode.BadRequest, response.StatusCode);
+
+        // Must be 401 or 500 (auth not configured), confirming validation passed
+        Assert.True(
+            response.StatusCode == HttpStatusCode.Unauthorized ||
+            response.StatusCode == HttpStatusCode.InternalServerError,
+            $"Expected Unauthorized or InternalServerError (not 400), got {response.StatusCode}"
         );
     }
 

--- a/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
@@ -569,6 +569,83 @@ public class PropertiesControllerTests
         Assert.Equal(authenticatedUserId, capturedProperty.OwnerId);
     }
 
+    [Fact]
+    public async Task Create_WithNameIdentifierClaim_SetsOwnerId()
+    {
+        // Arrange — simulate token that carries NameIdentifier instead of "sub"
+        var userId = "auth0|nameidentifier_user_789";
+        var claims = new List<Claim>
+        {
+            new Claim(System.Security.Claims.ClaimTypes.NameIdentifier, userId)
+            // Note: no "sub" claim — exercises the fallback path in GetAuthenticatedUserId()
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var claimsPrincipal = new ClaimsPrincipal(identity);
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = claimsPrincipal }
+        };
+
+        var request = new CreatePropertyRequest
+        {
+            Name = "NameIdentifier Property",
+            City = "Milan",
+            Address = "Via Milano 1",
+            Bedrooms = 1,
+            Bathrooms = 1,
+            MaxGuests = 2,
+            NightlyRate = 75m
+        };
+
+        Property? capturedProperty = null;
+        _mockService.Setup(x => x.CreatePropertyAsync(It.IsAny<Property>()))
+            .Callback<Property>(p => capturedProperty = p)
+            .ReturnsAsync((Property p) => p);
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert — NameIdentifier fallback is used; OwnerId matches
+        Assert.IsType<CreatedAtActionResult>(result.Result);
+        Assert.NotNull(capturedProperty);
+        Assert.Equal(userId, capturedProperty.OwnerId);
+        _mockService.Verify(x => x.CreatePropertyAsync(It.Is<Property>(p => p.OwnerId == userId)), Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_WithoutOwnerIdInRequest_SetsOwnerIdFromJwt()
+    {
+        // Arrange — CreatePropertyRequest has no OwnerId field; it must always come from JWT
+        var jwtSubject = "auth0|jwt_subject_user_456";
+        SetupUserClaims(jwtSubject);
+
+        // The DTO deliberately has no OwnerId property — this is the core fix from issue #143
+        var request = new CreatePropertyRequest
+        {
+            Name = "JWT OwnerId Property",
+            City = "Florence",
+            Address = "Via Firenze 5",
+            Bedrooms = 2,
+            Bathrooms = 1,
+            MaxGuests = 4,
+            NightlyRate = 120m
+        };
+
+        Property? capturedProperty = null;
+        _mockService.Setup(x => x.CreatePropertyAsync(It.IsAny<Property>()))
+            .Callback<Property>(p => capturedProperty = p)
+            .ReturnsAsync((Property p) => p);
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert — OwnerId is set from JWT, not from request body (there is no such field)
+        var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
+        Assert.NotNull(capturedProperty);
+        Assert.Equal(jwtSubject, capturedProperty.OwnerId);
+        _mockService.Verify(x => x.CreatePropertyAsync(It.Is<Property>(p => p.OwnerId == jwtSubject)), Times.Once);
+    }
+
     // Image Management Tests
 
     [Fact]

--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -57,6 +57,17 @@ public class PropertiesController(
         return property == null ? NotFound() : Ok(property);
     }
 
+    /// <summary>
+    /// Creates a new property for the authenticated owner.
+    /// </summary>
+    /// <remarks>
+    /// <c>OwnerId</c> is derived from the caller's JWT <c>sub</c> claim and must not be supplied
+    /// in the request body. Any client-side attempt to specify <c>OwnerId</c> is ignored.
+    /// </remarks>
+    /// <param name="request">Property details. See <see cref="CreatePropertyRequest"/> for required fields.</param>
+    /// <returns>The newly created property with its assigned <c>Id</c> and <c>OwnerId</c>.</returns>
+    /// <response code="201">Property created successfully.</response>
+    /// <response code="401">The caller is not authenticated.</response>
     [HttpPost]
     public async Task<ActionResult<Property>> Create([FromBody] CreatePropertyRequest request)
     {
@@ -71,6 +82,21 @@ public class PropertiesController(
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
     }
 
+    /// <summary>
+    /// Updates an existing property. Only the property owner may perform this operation.
+    /// </summary>
+    /// <remarks>
+    /// <c>OwnerId</c> is never accepted from the request body; ownership is always verified
+    /// against the authenticated caller's JWT <c>sub</c> claim. Sending an <c>OwnerId</c> field
+    /// in the body has no effect and will not change the property owner.
+    /// </remarks>
+    /// <param name="id">The unique identifier of the property to update.</param>
+    /// <param name="request">Updated property details. See <see cref="UpdatePropertyRequest"/> for available fields.</param>
+    /// <returns>No content on success.</returns>
+    /// <response code="204">Property updated successfully.</response>
+    /// <response code="401">The caller is not authenticated.</response>
+    /// <response code="403">The caller is not the owner of this property.</response>
+    /// <response code="404">No property found with the given <paramref name="id"/>.</response>
     [HttpPut("{id}")]
     public async Task<IActionResult> Update(Guid id, [FromBody] UpdatePropertyRequest request)
     {


### PR DESCRIPTION
## Summary
Add regression tests covering the exact bug scenario from #143 (POST without OwnerId must return 201, not 400), add unit tests for the NameIdentifier claim fallback, remove OwnerId from integration test request bodies (which previously masked the bug), and add Swagger XML doc comments to the Create and Update actions documenting that OwnerId is derived from JWT.

## Test Plan
- [x] `Create_WithNameIdentifierClaim_SetsOwnerId` — new unit test, passes
- [x] `Create_WithoutOwnerIdInRequest_SetsOwnerIdFromJwt` — new unit test, passes
- [x] `Create_WithoutOwnerIdInBody_DoesNotReturn400` — new integration test, passes (regression for #143)
- [x] `dotnet test` — all tests pass (284 passed, 25 skipped, 0 failed)
- [x] `dotnet format --verify-no-changes` — passes on all changed files

Closes #148
Part of: casazen/backend#144

🤖 Generated with [Claude Code](https://claude.com/claude-code)