### PR TITLE
feat(task-153): add PropertyDocuments table and OtaIntegration sync fields migration

### DIFF
--- a/Casazen.Core/Entities/OtaIntegration.cs
+++ b/Casazen.Core/Entities/OtaIntegration.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Casazen.Core.Enums;
 
 namespace Casazen.Core.Entities;
 
@@ -30,6 +31,13 @@ public class OtaIntegration
     public bool SyncEnabled { get; set; } = true;
 
     public DateTime LastSyncAt { get; set; }
+
+    [MaxLength(50)]
+    public string? SyncStatus { get; set; }
+
+    [MaxLength(2000)]
+    public string? LastSyncError { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/Casazen.Core/Entities/OtaIntegration.cs
+++ b/Casazen.Core/Entities/OtaIntegration.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Casazen.Core.Enums;
 
 namespace Casazen.Core.Entities;
 

--- a/Casazen.Core/Entities/Property.cs
+++ b/Casazen.Core/Entities/Property.cs
@@ -82,5 +82,6 @@ public class Property
     // Navigation
     public virtual ICollection<Booking> Bookings { get; set; } = new List<Booking>();
     public virtual ICollection<OtaIntegration> OtaIntegrations { get; set; } = new List<OtaIntegration>();
+    public virtual ICollection<PropertyDocument> PropertyDocuments { get; set; } = new List<PropertyDocument>();
     public virtual PricingAdapterConfig? PricingAdapterConfig { get; set; }
 }

--- a/Casazen.Core/Entities/PropertyDocument.cs
+++ b/Casazen.Core/Entities/PropertyDocument.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Casazen.Core.Entities;
+
+[Table("PropertyDocuments")]
+public class PropertyDocument
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [ForeignKey("Property")]
+    public Guid PropertyId { get; set; }
+    public virtual Property Property { get; set; } = null!;
+
+    [Required, MaxLength(100)]
+    public string DocumentType { get; set; } = string.Empty;
+
+    [Required, MaxLength(500)]
+    public string FileName { get; set; } = string.Empty;
+
+    [Required, MaxLength(2000)]
+    public string FileUrl { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Casazen.Core/Enums/OtaSyncStatus.cs
+++ b/Casazen.Core/Enums/OtaSyncStatus.cs
@@ -1,0 +1,9 @@
+namespace Casazen.Core.Enums;
+
+public enum OtaSyncStatus
+{
+    Pending,
+    InProgress,
+    Success,
+    Failed
+}

--- a/Casazen.Infrastructure/Data/AppDbContext.cs
+++ b/Casazen.Infrastructure/Data/AppDbContext.cs
@@ -19,6 +19,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<CancellationPolicy> CancellationPolicies { get; set; } = null!;
     public DbSet<PricingAdapterConfig> PricingAdapterConfigs { get; set; } = null!;
     public DbSet<PricingHistory> PricingHistories { get; set; } = null!;
+    public DbSet<PropertyDocument> PropertyDocuments { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -89,11 +90,11 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.Entity<TouristTaxRate>().HasIndex(t => new { t.City, t.IsActive, t.EffectiveFrom });
         modelBuilder.Entity<Guest>().HasIndex(g => g.Email);
 
-        // PricingAdapterConfig → Property
+        // PricingAdapterConfig → Property (1-to-1)
         modelBuilder.Entity<PricingAdapterConfig>()
             .HasOne(c => c.Property)
-            .WithMany()
-            .HasForeignKey(c => c.PropertyId)
+            .WithOne(p => p.PricingAdapterConfig)
+            .HasForeignKey<PricingAdapterConfig>(c => c.PropertyId)
             .OnDelete(DeleteBehavior.Cascade);
 
         modelBuilder.Entity<PricingAdapterConfig>()
@@ -108,5 +109,16 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
         modelBuilder.Entity<PricingHistory>()
             .HasIndex(h => new { h.PropertyId, h.AdaptationDate });
+
+        // PropertyDocument → Property
+        modelBuilder.Entity<PropertyDocument>()
+            .HasOne(d => d.Property)
+            .WithMany(p => p.PropertyDocuments)
+            .HasForeignKey(d => d.PropertyId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<PropertyDocument>()
+            .HasIndex(d => d.PropertyId)
+            .HasDatabaseName("IX_PropertyDocuments_PropertyId");
     }
 }

--- a/Casazen.Infrastructure/Migrations/20260512161430_AddPropertyDocumentsAndOtaSyncFields.Designer.cs
+++ b/Casazen.Infrastructure/Migrations/20260512161430_AddPropertyDocumentsAndOtaSyncFields.Designer.cs
@@ -4,6 +4,7 @@ using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Casazen.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260512161430_AddPropertyDocumentsAndOtaSyncFields")]
+    partial class AddPropertyDocumentsAndOtaSyncFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Casazen.Infrastructure/Migrations/20260512161430_AddPropertyDocumentsAndOtaSyncFields.cs
+++ b/Casazen.Infrastructure/Migrations/20260512161430_AddPropertyDocumentsAndOtaSyncFields.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Casazen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPropertyDocumentsAndOtaSyncFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LastSyncError",
+                table: "OtaIntegrations",
+                type: "nvarchar(2000)",
+                maxLength: 2000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SyncStatus",
+                table: "OtaIntegrations",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "PropertyDocuments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PropertyId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DocumentType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    FileName = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    FileUrl = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PropertyDocuments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PropertyDocuments_Properties_PropertyId",
+                        column: x => x.PropertyId,
+                        principalTable: "Properties",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PropertyDocuments_PropertyId",
+                table: "PropertyDocuments",
+                column: "PropertyId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PropertyDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "LastSyncError",
+                table: "OtaIntegrations");
+
+            migrationBuilder.DropColumn(
+                name: "SyncStatus",
+                table: "OtaIntegrations");
+        }
+    }
+}

--- a/Casazen.Web/Controllers/HealthController.cs
+++ b/Casazen.Web/Controllers/HealthController.cs
@@ -19,9 +19,9 @@ public class HealthController : ControllerBase
     public IActionResult Get()
     {
         _logger.LogInformation("Health check endpoint called");
-        return Ok(new 
-        { 
-            status = "healthy", 
+        return Ok(new
+        {
+            status = "healthy",
             message = "Backend is running without authentication",
             timestamp = DateTime.UtcNow,
             environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
@@ -34,10 +34,10 @@ public class HealthController : ControllerBase
         _logger.LogInformation("Auth test endpoint called");
         _logger.LogInformation($"User authenticated: {User.Identity?.IsAuthenticated}");
         _logger.LogInformation($"User name: {User.Identity?.Name}");
-        
+
         var claims = User.Claims.Select(c => new { c.Type, c.Value }).ToList();
         _logger.LogInformation($"Claims count: {claims.Count}");
-        
+
         return Ok(new
         {
             isAuthenticated = User.Identity?.IsAuthenticated ?? false,

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -111,8 +111,8 @@ public static class ServiceCollectionExtensions
             .AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"))
             // DEVELOPMENT: Allow any authenticated user (remove role requirement for testing)
             .AddPolicy("PropertyOwner", policy => policy.RequireAuthenticatedUser());
-            // PRODUCTION: Uncomment below and remove above line
-            // .AddPolicy("PropertyOwner", policy => policy.RequireRole("PropertyOwner", "Admin"));
+        // PRODUCTION: Uncomment below and remove above line
+        // .AddPolicy("PropertyOwner", policy => policy.RequireRole("PropertyOwner", "Admin"));
 
         return services;
     }
@@ -124,7 +124,7 @@ public static class ServiceCollectionExtensions
             options.AddPolicy("AllowFrontend", policy =>
             {
                 policy
-                    .WithOrigins("http://localhost:3000", "http://localhost:5173","http://localhost:5174","http://localhost:5175", "https://casazen.app")
+                    .WithOrigins("http://localhost:3000", "http://localhost:5173", "http://localhost:5174", "http://localhost:5175", "https://casazen.app")
                     .AllowAnyMethod()
                     .AllowAnyHeader()
                     .AllowCredentials();


### PR DESCRIPTION
## Summary

- Adds `PropertyDocuments` table with `IX_PropertyDocuments_PropertyId` index and cascade-delete FK to `Properties`
- Adds `SyncStatus` (`nvarchar(50)`, nullable) and `LastSyncError` (`nvarchar(2000)`, nullable) columns to `OtaIntegrations`
- Introduces `PropertyDocument` entity and `OtaSyncStatus` enum (Pending, InProgress, Success, Failed)
- Fixes a pre-existing `PricingAdapterConfig` relationship misconfiguration (`WithMany` → `WithOne`) that was generating a spurious `PropertyId1` shadow FK
- Fixes pre-existing whitespace formatting in `HealthController` and `ServiceCollectionExtensions`

## Test Plan

- [x] `dotnet build` — no errors, 1 pre-existing xUnit warning
- [x] `dotnet test` — 284 passed, 25 skipped, 0 failed
- [x] `dotnet format --verify-no-changes` — clean
- [x] Migration runs cleanly (`dotnet ef database update`)
- [x] `IX_PropertyDocuments_PropertyId` index present in migration script
- [x] `OtaIntegrations` has `SyncStatus` and `LastSyncError` columns in migration script

Closes #153
Part of: casazen/backend#152

🤖 Generated with [Claude Code](https://claude.com/claude-code)