### PR TITLE
feat(task-155): PropertyDocument repository, service, and property detail aggregate query

### DIFF
--- a/Casazen.Core/Entities/Guest.cs
+++ b/Casazen.Core/Entities/Guest.cs
@@ -43,7 +43,7 @@ public class Guest
     [MaxLength(100)]
     public string Nationality { get; set; } = string.Empty;
 
-    public DocumentType? DocumentType { get; set; }
+    public GuestDocumentType? DocumentType { get; set; }
 
     [MaxLength(50)]
     public string DocumentNumber { get; set; } = string.Empty;
@@ -121,7 +121,7 @@ public class Guest
     public virtual ICollection<AlloggiatiWebReport> AlloggiatiWebReports { get; set; } = new List<AlloggiatiWebReport>();
 }
 
-public enum DocumentType
+public enum GuestDocumentType
 {
     Passport,
     IdentityCard,

--- a/Casazen.Core/Repositories/IPropertyDocumentRepository.cs
+++ b/Casazen.Core/Repositories/IPropertyDocumentRepository.cs
@@ -1,0 +1,11 @@
+using Casazen.Core.Entities;
+
+namespace Casazen.Core.Repositories;
+
+public interface IPropertyDocumentRepository
+{
+    Task<IEnumerable<PropertyDocument>> GetByPropertyIdAsync(Guid propertyId);
+    Task<PropertyDocument?> GetByIdAsync(Guid id);
+    Task<PropertyDocument> AddAsync(PropertyDocument document);
+    Task DeleteAsync(Guid id);
+}

--- a/Casazen.Core/Repositories/IPropertyRepositories.cs
+++ b/Casazen.Core/Repositories/IPropertyRepositories.cs
@@ -12,4 +12,5 @@ public interface IPropertyRepository
     Task<Property> UpdateAsync(Property property);
     Task DeleteAsync(Guid id);
     Task<bool> ExistsAsync(Guid id);
+    Task<Property?> GetPropertyDetailAsync(Guid id);
 }

--- a/Casazen.Core/Services/IPropertyDocumentService.cs
+++ b/Casazen.Core/Services/IPropertyDocumentService.cs
@@ -1,0 +1,12 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Enums;
+using Microsoft.AspNetCore.Http;
+
+namespace Casazen.Core.Services;
+
+public interface IPropertyDocumentService
+{
+    Task<PropertyDocument> UploadDocumentAsync(Guid propertyId, IFormFile file, DocumentType documentType, string uploadedBy);
+    Task<IEnumerable<PropertyDocument>> GetByPropertyIdAsync(Guid propertyId);
+    Task DeleteDocumentAsync(Guid documentId);
+}

--- a/Casazen.Core/Services/IPropertyService.cs
+++ b/Casazen.Core/Services/IPropertyService.cs
@@ -1,4 +1,5 @@
-﻿using Casazen.Core.Entities;
+﻿using Casazen.Core.DTOs;
+using Casazen.Core.Entities;
 
 namespace Casazen.Core.Services;
 
@@ -13,4 +14,5 @@ public interface IPropertyService
     Task<Property> AddImageAsync(Guid propertyId, string imageUrl);
     Task<Property> RemoveImageAsync(Guid propertyId, int imageIndex);
     Task<Property> ReorderImagesAsync(Guid propertyId, List<string> orderedImageUrls);
+    Task<PropertyDetailResponse> GetPropertyDetailAsync(Guid propertyId);
 }

--- a/Casazen.Infrastructure/Repositories/PropertyDocumentRepository.cs
+++ b/Casazen.Infrastructure/Repositories/PropertyDocumentRepository.cs
@@ -1,0 +1,39 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Repositories;
+using Casazen.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Casazen.Infrastructure.Repositories;
+
+public class PropertyDocumentRepository(AppDbContext context) : IPropertyDocumentRepository
+{
+    public async Task<IEnumerable<PropertyDocument>> GetByPropertyIdAsync(Guid propertyId)
+    {
+        return await context.PropertyDocuments
+            .Where(d => d.PropertyId == propertyId)
+            .ToListAsync();
+    }
+
+    public async Task<PropertyDocument?> GetByIdAsync(Guid id)
+    {
+        return await context.PropertyDocuments
+            .FirstOrDefaultAsync(d => d.Id == id);
+    }
+
+    public async Task<PropertyDocument> AddAsync(PropertyDocument document)
+    {
+        context.PropertyDocuments.Add(document);
+        await context.SaveChangesAsync();
+        return document;
+    }
+
+    public async Task DeleteAsync(Guid id)
+    {
+        var document = await context.PropertyDocuments.FindAsync(id);
+        if (document != null)
+        {
+            context.PropertyDocuments.Remove(document);
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/Casazen.Infrastructure/Repositories/PropertyRepositories.cs
+++ b/Casazen.Infrastructure/Repositories/PropertyRepositories.cs
@@ -32,13 +32,13 @@ public class PropertyRepository(AppDbContext context) : IPropertyRepository
     public async Task<IEnumerable<Property>> SearchAsync(string? city, int? bedrooms, decimal? maxPrice)
     {
         var query = context.Properties.AsQueryable();
-        
+
         if (!string.IsNullOrEmpty(city))
             query = query.Where(p => p.City.ToLower().Contains(city.ToLower()));
-        
+
         if (bedrooms.HasValue)
             query = query.Where(p => p.Bedrooms >= bedrooms.Value);
-        
+
         if (maxPrice.HasValue)
             query = query.Where(p => p.NightlyRate <= maxPrice.Value);
 
@@ -72,5 +72,14 @@ public class PropertyRepository(AppDbContext context) : IPropertyRepository
     public async Task<bool> ExistsAsync(Guid id)
     {
         return await context.Properties.AnyAsync(p => p.Id == id);
+    }
+
+    public async Task<Property?> GetPropertyDetailAsync(Guid id)
+    {
+        return await context.Properties
+            .Include(p => p.PropertyDocuments)
+            .Include(p => p.OtaIntegrations)
+            .Include(p => p.Bookings)
+            .FirstOrDefaultAsync(p => p.Id == id && p.IsActive);
     }
 }

--- a/Casazen.Infrastructure/Services/PropertyDocumentService.cs
+++ b/Casazen.Infrastructure/Services/PropertyDocumentService.cs
@@ -23,20 +23,30 @@ public class PropertyDocumentService(
 
         var storageUrl = await storageService.UploadImageAsync(file, propertyId);
 
-        var document = new PropertyDocument
+        try
         {
-            PropertyId = propertyId,
-            FileName = file.FileName,
-            StorageUrl = storageUrl,
-            DocumentType = documentType,
-            UploadedBy = uploadedBy,
-            UploadedAt = DateTime.UtcNow
-        };
+            var document = new PropertyDocument
+            {
+                PropertyId = propertyId,
+                FileName = file.FileName,
+                StorageUrl = storageUrl,
+                DocumentType = documentType,
+                UploadedBy = uploadedBy,
+                UploadedAt = DateTime.UtcNow
+            };
 
-        logger.LogInformation("Uploading document {FileName} of type {DocumentType} for property {PropertyId} by {UploadedBy}",
-            file.FileName, documentType, propertyId, uploadedBy);
+            logger.LogInformation("Uploading document {FileName} of type {DocumentType} for property {PropertyId} by {UploadedBy}",
+                file.FileName, documentType, propertyId, uploadedBy);
 
-        return await documentRepository.AddAsync(document);
+            return await documentRepository.AddAsync(document);
+        }
+        catch
+        {
+            logger.LogWarning("DB save failed after storage upload for property {PropertyId}; rolling back storage file {StorageUrl}",
+                propertyId, storageUrl);
+            await storageService.DeleteImageAsync(storageUrl);
+            throw;
+        }
     }
 
     public async Task<IEnumerable<PropertyDocument>> GetByPropertyIdAsync(Guid propertyId)

--- a/Casazen.Infrastructure/Services/PropertyDocumentService.cs
+++ b/Casazen.Infrastructure/Services/PropertyDocumentService.cs
@@ -54,7 +54,7 @@ public class PropertyDocumentService(
 
         logger.LogInformation("Deleting document {DocumentId} with storage URL {StorageUrl}", documentId, document.StorageUrl);
 
-        await storageService.DeleteImageAsync(document.StorageUrl);
         await documentRepository.DeleteAsync(documentId);
+        await storageService.DeleteImageAsync(document.StorageUrl);
     }
 }

--- a/Casazen.Infrastructure/Services/PropertyDocumentService.cs
+++ b/Casazen.Infrastructure/Services/PropertyDocumentService.cs
@@ -1,0 +1,60 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Enums;
+using Casazen.Core.Repositories;
+using Casazen.Core.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Infrastructure.Services;
+
+public class PropertyDocumentService(
+    IPropertyDocumentRepository documentRepository,
+    IImageStorageService storageService,
+    IPropertyRepository propertyRepository,
+    ILogger<PropertyDocumentService> logger) : IPropertyDocumentService
+{
+    public async Task<PropertyDocument> UploadDocumentAsync(Guid propertyId, IFormFile file, DocumentType documentType, string uploadedBy)
+    {
+        var exists = await propertyRepository.ExistsAsync(propertyId);
+        if (!exists)
+        {
+            throw new InvalidOperationException($"Property {propertyId} not found");
+        }
+
+        var storageUrl = await storageService.UploadImageAsync(file, propertyId);
+
+        var document = new PropertyDocument
+        {
+            PropertyId = propertyId,
+            FileName = file.FileName,
+            StorageUrl = storageUrl,
+            DocumentType = documentType,
+            UploadedBy = uploadedBy,
+            UploadedAt = DateTime.UtcNow
+        };
+
+        logger.LogInformation("Uploading document {FileName} of type {DocumentType} for property {PropertyId} by {UploadedBy}",
+            file.FileName, documentType, propertyId, uploadedBy);
+
+        return await documentRepository.AddAsync(document);
+    }
+
+    public async Task<IEnumerable<PropertyDocument>> GetByPropertyIdAsync(Guid propertyId)
+    {
+        return await documentRepository.GetByPropertyIdAsync(propertyId);
+    }
+
+    public async Task DeleteDocumentAsync(Guid documentId)
+    {
+        var document = await documentRepository.GetByIdAsync(documentId);
+        if (document == null)
+        {
+            throw new InvalidOperationException($"Document {documentId} not found");
+        }
+
+        logger.LogInformation("Deleting document {DocumentId} with storage URL {StorageUrl}", documentId, document.StorageUrl);
+
+        await storageService.DeleteImageAsync(document.StorageUrl);
+        await documentRepository.DeleteAsync(documentId);
+    }
+}

--- a/Casazen.Infrastructure/Services/PropertyService.cs
+++ b/Casazen.Infrastructure/Services/PropertyService.cs
@@ -1,4 +1,7 @@
-﻿using Casazen.Core.Entities;
+﻿using System.Text.RegularExpressions;
+using Casazen.Core.DTOs;
+using Casazen.Core.Entities;
+using Casazen.Core.Enums;
 using Casazen.Core.Repositories;
 using Casazen.Core.Services;
 using Microsoft.Extensions.Logging;
@@ -106,5 +109,74 @@ public class PropertyService(IPropertyRepository repository, ILogger<PropertySer
 
         logger.LogInformation("Reordering images for property {PropertyId}", propertyId);
         return await repository.UpdateAsync(property);
+    }
+
+    public async Task<PropertyDetailResponse> GetPropertyDetailAsync(Guid propertyId)
+    {
+        var property = await repository.GetPropertyDetailAsync(propertyId)
+            ?? throw new InvalidOperationException($"Property {propertyId} not found");
+
+        var now = DateTime.UtcNow;
+        return new PropertyDetailResponse
+        {
+            Id = property.Id,
+            OwnerId = property.OwnerId,
+            Name = property.Name,
+            Description = property.Description,
+            Address = property.Address,
+            City = property.City,
+            PostalCode = property.PostalCode,
+            Bedrooms = property.Bedrooms,
+            Bathrooms = property.Bathrooms,
+            MaxGuests = property.MaxGuests,
+            NightlyRate = property.NightlyRate,
+            CleaningFee = property.CleaningFee,
+            DamageDeposit = property.DamageDeposit,
+            CinCode = property.CinCode,
+            CinStatus = ResolveCinStatus(property.CinCode),
+            IsActive = property.IsActive,
+            CreatedAt = property.CreatedAt,
+            UpdatedAt = property.UpdatedAt,
+            Documents = property.PropertyDocuments.Select(d => new PropertyDocumentDto
+            {
+                Id = d.Id,
+                FileName = d.FileName,
+                StorageUrl = d.StorageUrl,
+                DocumentType = d.DocumentType,
+                UploadedBy = d.UploadedBy,
+                UploadedAt = d.UploadedAt
+            }).ToList(),
+            OtaIntegrations = property.OtaIntegrations.Select(o => new OtaIntegrationDto
+            {
+                Id = o.Id,
+                Platform = o.Platform,
+                ExternalPropertyId = o.ExternalPropertyId,
+                IsActive = o.IsActive,
+                SyncEnabled = o.SyncEnabled,
+                LastSyncAt = o.LastSyncAt,
+                SyncStatus = o.SyncStatus != null && Enum.TryParse<OtaSyncStatus>(o.SyncStatus, out var status) ? status : null,
+                LastSyncError = o.LastSyncError
+            }).ToList(),
+            BookingsSummary = new BookingsSummaryDto
+            {
+                TotalBookings = property.Bookings.Count,
+                UpcomingBookings = property.Bookings.Count(b =>
+                    b.CheckInDate > now && b.Status == BookingStatus.Confirmed),
+                ActiveBookings = property.Bookings.Count(b =>
+                    b.CheckInDate <= now && b.CheckOutDate > now && b.Status == BookingStatus.CheckedIn),
+                NextCheckIn = property.Bookings
+                    .Where(b => b.CheckInDate > now)
+                    .MinBy(b => b.CheckInDate)?.CheckInDate,
+                NextCheckOut = property.Bookings
+                    .Where(b => b.CheckOutDate > now)
+                    .MinBy(b => b.CheckOutDate)?.CheckOutDate
+            }
+        };
+    }
+
+    private static CinStatus ResolveCinStatus(string? cinCode)
+    {
+        if (string.IsNullOrWhiteSpace(cinCode)) return CinStatus.Missing;
+        return Regex.IsMatch(cinCode, @"^IT-\d{5}-\d{10}$") ? CinStatus.Valid : CinStatus.Invalid;
     }
 }

--- a/Casazen.Infrastructure/Services/PropertyService.cs
+++ b/Casazen.Infrastructure/Services/PropertyService.cs
@@ -174,9 +174,11 @@ public class PropertyService(IPropertyRepository repository, ILogger<PropertySer
         };
     }
 
+    private static readonly Regex CinRegex = new(@"^IT-\d{5}-\d{10}$", RegexOptions.Compiled);
+
     private static CinStatus ResolveCinStatus(string? cinCode)
     {
         if (string.IsNullOrWhiteSpace(cinCode)) return CinStatus.Missing;
-        return Regex.IsMatch(cinCode, @"^IT-\d{5}-\d{10}$") ? CinStatus.Valid : CinStatus.Invalid;
+        return CinRegex.IsMatch(cinCode) ? CinStatus.Valid : CinStatus.Invalid;
     }
 }

--- a/Casazen.Tests/Unit/Services/PropertyDocumentServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/PropertyDocumentServiceTests.cs
@@ -1,0 +1,187 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Enums;
+using Casazen.Core.Repositories;
+using Casazen.Core.Services;
+using Casazen.Infrastructure.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Services;
+
+public class PropertyDocumentServiceTests
+{
+    private readonly Mock<IPropertyDocumentRepository> _mockDocumentRepository;
+    private readonly Mock<IImageStorageService> _mockStorageService;
+    private readonly Mock<IPropertyRepository> _mockPropertyRepository;
+    private readonly PropertyDocumentService _service;
+
+    public PropertyDocumentServiceTests()
+    {
+        _mockDocumentRepository = new Mock<IPropertyDocumentRepository>();
+        _mockStorageService = new Mock<IImageStorageService>();
+        _mockPropertyRepository = new Mock<IPropertyRepository>();
+        _service = new PropertyDocumentService(
+            _mockDocumentRepository.Object,
+            _mockStorageService.Object,
+            _mockPropertyRepository.Object,
+            new Mock<ILogger<PropertyDocumentService>>().Object);
+    }
+
+    [Fact]
+    public async Task UploadDocumentAsync_WithValidPropertyAndFile_ReturnsDocument()
+    {
+        // Arrange
+        var propertyId = Guid.NewGuid();
+        var storageUrl = "/uploads/properties/test-doc.pdf";
+        var mockFile = CreateMockFile("test-doc.pdf");
+        var expectedDocument = new PropertyDocument
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId,
+            FileName = "test-doc.pdf",
+            StorageUrl = storageUrl,
+            DocumentType = DocumentType.CinCertificate,
+            UploadedBy = "user@example.com",
+            UploadedAt = DateTime.UtcNow
+        };
+
+        _mockPropertyRepository.Setup(x => x.ExistsAsync(propertyId)).ReturnsAsync(true);
+        _mockStorageService.Setup(x => x.UploadImageAsync(mockFile.Object, propertyId)).ReturnsAsync(storageUrl);
+        _mockDocumentRepository.Setup(x => x.AddAsync(It.IsAny<PropertyDocument>())).ReturnsAsync(expectedDocument);
+
+        // Act
+        var result = await _service.UploadDocumentAsync(propertyId, mockFile.Object, DocumentType.CinCertificate, "user@example.com");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedDocument.Id, result.Id);
+        Assert.Equal(propertyId, result.PropertyId);
+        _mockDocumentRepository.Verify(x => x.AddAsync(It.IsAny<PropertyDocument>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UploadDocumentAsync_WithNonExistentProperty_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var propertyId = Guid.NewGuid();
+        var mockFile = CreateMockFile("test-doc.pdf");
+
+        _mockPropertyRepository.Setup(x => x.ExistsAsync(propertyId)).ReturnsAsync(false);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.UploadDocumentAsync(propertyId, mockFile.Object, DocumentType.CinCertificate, "user@example.com"));
+
+        _mockStorageService.Verify(x => x.UploadImageAsync(It.IsAny<IFormFile>(), It.IsAny<Guid>()), Times.Never);
+        _mockDocumentRepository.Verify(x => x.AddAsync(It.IsAny<PropertyDocument>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadDocumentAsync_WithValidFile_CallsStorageServiceWithCorrectParams()
+    {
+        // Arrange
+        var propertyId = Guid.NewGuid();
+        var mockFile = CreateMockFile("floor-plan.png");
+        var storageUrl = "/uploads/properties/floor-plan.png";
+        var savedDocument = new PropertyDocument { Id = Guid.NewGuid(), PropertyId = propertyId };
+
+        _mockPropertyRepository.Setup(x => x.ExistsAsync(propertyId)).ReturnsAsync(true);
+        _mockStorageService.Setup(x => x.UploadImageAsync(mockFile.Object, propertyId)).ReturnsAsync(storageUrl);
+        _mockDocumentRepository.Setup(x => x.AddAsync(It.IsAny<PropertyDocument>())).ReturnsAsync(savedDocument);
+
+        // Act
+        await _service.UploadDocumentAsync(propertyId, mockFile.Object, DocumentType.FloorPlan, "owner@example.com");
+
+        // Assert
+        _mockStorageService.Verify(x => x.UploadImageAsync(mockFile.Object, propertyId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByPropertyIdAsync_WithDocuments_ReturnsDocuments()
+    {
+        // Arrange
+        var propertyId = Guid.NewGuid();
+        var documents = new List<PropertyDocument>
+        {
+            new() { Id = Guid.NewGuid(), PropertyId = propertyId, FileName = "doc1.pdf" },
+            new() { Id = Guid.NewGuid(), PropertyId = propertyId, FileName = "doc2.pdf" }
+        };
+
+        _mockDocumentRepository.Setup(x => x.GetByPropertyIdAsync(propertyId)).ReturnsAsync(documents);
+
+        // Act
+        var result = await _service.GetByPropertyIdAsync(propertyId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count());
+        _mockDocumentRepository.Verify(x => x.GetByPropertyIdAsync(propertyId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByPropertyIdAsync_WithNoDocuments_ReturnsEmptyList()
+    {
+        // Arrange
+        var propertyId = Guid.NewGuid();
+
+        _mockDocumentRepository.Setup(x => x.GetByPropertyIdAsync(propertyId)).ReturnsAsync(new List<PropertyDocument>());
+
+        // Act
+        var result = await _service.GetByPropertyIdAsync(propertyId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+        _mockDocumentRepository.Verify(x => x.GetByPropertyIdAsync(propertyId), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteDocumentAsync_WithExistingDocument_DeletesFromRepositoryAndStorage()
+    {
+        // Arrange
+        var documentId = Guid.NewGuid();
+        var document = new PropertyDocument
+        {
+            Id = documentId,
+            PropertyId = Guid.NewGuid(),
+            FileName = "doc.pdf",
+            StorageUrl = "/uploads/properties/doc.pdf"
+        };
+
+        _mockDocumentRepository.Setup(x => x.GetByIdAsync(documentId)).ReturnsAsync(document);
+        _mockStorageService.Setup(x => x.DeleteImageAsync(document.StorageUrl)).Returns(Task.CompletedTask);
+        _mockDocumentRepository.Setup(x => x.DeleteAsync(documentId)).Returns(Task.CompletedTask);
+
+        // Act
+        await _service.DeleteDocumentAsync(documentId);
+
+        // Assert
+        _mockStorageService.Verify(x => x.DeleteImageAsync(document.StorageUrl), Times.Once);
+        _mockDocumentRepository.Verify(x => x.DeleteAsync(documentId), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteDocumentAsync_WithNonExistentDocument_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var documentId = Guid.NewGuid();
+
+        _mockDocumentRepository.Setup(x => x.GetByIdAsync(documentId)).ReturnsAsync((PropertyDocument?)null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _service.DeleteDocumentAsync(documentId));
+
+        _mockStorageService.Verify(x => x.DeleteImageAsync(It.IsAny<string>()), Times.Never);
+        _mockDocumentRepository.Verify(x => x.DeleteAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    private static Mock<IFormFile> CreateMockFile(string fileName)
+    {
+        var mockFile = new Mock<IFormFile>();
+        mockFile.Setup(f => f.FileName).Returns(fileName);
+        mockFile.Setup(f => f.Length).Returns(1024);
+        return mockFile;
+    }
+}

--- a/Casazen.Tests/Unit/Services/PropertyServiceGetDetailTests.cs
+++ b/Casazen.Tests/Unit/Services/PropertyServiceGetDetailTests.cs
@@ -1,0 +1,237 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Enums;
+using Casazen.Core.Repositories;
+using Casazen.Infrastructure.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Services;
+
+public class PropertyServiceGetDetailTests
+{
+    private readonly Mock<IPropertyRepository> _mockRepository;
+    private readonly PropertyService _service;
+
+    public PropertyServiceGetDetailTests()
+    {
+        _mockRepository = new Mock<IPropertyRepository>();
+        _service = new PropertyService(_mockRepository.Object, new Mock<ILogger<PropertyService>>().Object);
+    }
+
+    [Fact]
+    public async Task GetPropertyDetailAsync_WithValidId_ReturnsPropertyDetailResponse()
+    {
+        // Arrange
+        var propertyId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var property = new Property
+        {
+            Id = propertyId,
+            OwnerId = "auth0|owner123",
+            Name = "Villa Roma",
+            Description = "Beautiful villa",
+            Address = "Via Roma 1",
+            City = "Rome",
+            PostalCode = "00100",
+            Bedrooms = 3,
+            Bathrooms = 2,
+            MaxGuests = 6,
+            NightlyRate = 150m,
+            CleaningFee = 50m,
+            DamageDeposit = 200m,
+            CinCode = "IT-12345-0123456789",
+            IsActive = true,
+            CreatedAt = now.AddDays(-30),
+            UpdatedAt = now
+        };
+
+        property.PropertyDocuments.Add(new PropertyDocument
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId,
+            FileName = "cin-cert.pdf",
+            StorageUrl = "/uploads/properties/cin-cert.pdf",
+            DocumentType = DocumentType.CinCertificate,
+            UploadedBy = "owner@example.com",
+            UploadedAt = now.AddDays(-10)
+        });
+
+        property.OtaIntegrations.Add(new OtaIntegration
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId,
+            Platform = "Airbnb",
+            ExternalPropertyId = "airbnb-123",
+            IsActive = true,
+            SyncEnabled = true,
+            LastSyncAt = now.AddHours(-1),
+            SyncStatus = "Success"
+        });
+
+        property.Bookings.Add(new Booking
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId,
+            GuestId = Guid.NewGuid(),
+            CheckInDate = now.AddDays(10),
+            CheckOutDate = now.AddDays(15),
+            Status = BookingStatus.Confirmed
+        });
+
+        _mockRepository.Setup(x => x.GetPropertyDetailAsync(propertyId)).ReturnsAsync(property);
+
+        // Act
+        var result = await _service.GetPropertyDetailAsync(propertyId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(propertyId, result.Id);
+        Assert.Equal("Villa Roma", result.Name);
+        Assert.Equal("Rome", result.City);
+        Assert.Single(result.Documents);
+        Assert.Single(result.OtaIntegrations);
+        Assert.Equal(1, result.BookingsSummary.TotalBookings);
+        Assert.Equal(1, result.BookingsSummary.UpcomingBookings);
+        _mockRepository.Verify(x => x.GetPropertyDetailAsync(propertyId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetPropertyDetailAsync_WithNonExistentId_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var propertyId = Guid.NewGuid();
+
+        _mockRepository.Setup(x => x.GetPropertyDetailAsync(propertyId)).ReturnsAsync((Property?)null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _service.GetPropertyDetailAsync(propertyId));
+        _mockRepository.Verify(x => x.GetPropertyDetailAsync(propertyId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetPropertyDetailAsync_OtaIntegrations_DoNotExposeApiKey()
+    {
+        // Arrange
+        var propertyId = Guid.NewGuid();
+        var property = new Property
+        {
+            Id = propertyId,
+            OwnerId = "auth0|owner123",
+            Name = "Test Property",
+            Address = "Via Test 1",
+            City = "Milan",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        property.OtaIntegrations.Add(new OtaIntegration
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId,
+            Platform = "Booking.com",
+            ExternalPropertyId = "booking-456",
+            ApiKey = "secret-api-key-12345",
+            ApiSecret = "secret-api-secret-67890",
+            IsActive = true,
+            SyncEnabled = true
+        });
+
+        _mockRepository.Setup(x => x.GetPropertyDetailAsync(propertyId)).ReturnsAsync(property);
+
+        // Act
+        var result = await _service.GetPropertyDetailAsync(propertyId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.OtaIntegrations);
+
+        var otaDto = result.OtaIntegrations[0];
+        var otaDtoType = otaDto.GetType();
+
+        Assert.Null(otaDtoType.GetProperty("ApiKey"));
+        Assert.Null(otaDtoType.GetProperty("ApiSecret"));
+    }
+
+    [Fact]
+    public async Task GetPropertyDetailAsync_WithValidCinCode_SetsCinStatusValid()
+    {
+        // Arrange
+        var propertyId = Guid.NewGuid();
+        var property = new Property
+        {
+            Id = propertyId,
+            OwnerId = "auth0|owner123",
+            Name = "Test Property",
+            Address = "Via Test 1",
+            City = "Rome",
+            CinCode = "IT-12345-0123456789",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        _mockRepository.Setup(x => x.GetPropertyDetailAsync(propertyId)).ReturnsAsync(property);
+
+        // Act
+        var result = await _service.GetPropertyDetailAsync(propertyId);
+
+        // Assert
+        Assert.Equal(CinStatus.Valid, result.CinStatus);
+    }
+
+    [Fact]
+    public async Task GetPropertyDetailAsync_WithNullCinCode_SetsCinStatusMissing()
+    {
+        // Arrange
+        var propertyId = Guid.NewGuid();
+        var property = new Property
+        {
+            Id = propertyId,
+            OwnerId = "auth0|owner123",
+            Name = "Test Property",
+            Address = "Via Test 1",
+            City = "Rome",
+            CinCode = null,
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        _mockRepository.Setup(x => x.GetPropertyDetailAsync(propertyId)).ReturnsAsync(property);
+
+        // Act
+        var result = await _service.GetPropertyDetailAsync(propertyId);
+
+        // Assert
+        Assert.Equal(CinStatus.Missing, result.CinStatus);
+    }
+
+    [Fact]
+    public async Task GetPropertyDetailAsync_WithInvalidCinCode_SetsCinStatusInvalid()
+    {
+        // Arrange
+        var propertyId = Guid.NewGuid();
+        var property = new Property
+        {
+            Id = propertyId,
+            OwnerId = "auth0|owner123",
+            Name = "Test Property",
+            Address = "Via Test 1",
+            City = "Rome",
+            CinCode = "INVALID",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        _mockRepository.Setup(x => x.GetPropertyDetailAsync(propertyId)).ReturnsAsync(property);
+
+        // Act
+        var result = await _service.GetPropertyDetailAsync(propertyId);
+
+        // Assert
+        Assert.Equal(CinStatus.Invalid, result.CinStatus);
+    }
+}

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -144,6 +144,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IAlloggiatiWebReportRepository, AlloggiatiWebReportRepository>();
         services.AddScoped<ITaxRateRepository, TaxRateRepository>();
         services.AddScoped<IOtaIntegrationRepository, OtaIntegrationRepository>();
+        services.AddScoped<IPropertyDocumentRepository, PropertyDocumentRepository>();
         return services;
     }
 
@@ -158,6 +159,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITouristTaxService, TouristTaxService>();
         services.AddScoped<IGdprService, GdprService>();
         services.AddScoped<IOtaIntegrationService, OtaIntegrationService>();
+        services.AddScoped<IPropertyDocumentService, PropertyDocumentService>();
+        services.AddScoped<IImageStorageService, LocalImageStorageService>();
         return services;
     }
 


### PR DESCRIPTION
## Summary
- Add `IPropertyDocumentRepository` / `PropertyDocumentRepository` — EF Core CRUD for `PropertyDocuments` table
- Add `IPropertyDocumentService` / `PropertyDocumentService` — upload (via `IImageStorageService`), list by property, delete
- Extend `IPropertyRepository` / `PropertyRepository` with `GetPropertyDetailAsync` (eager-loads documents, OTA integrations, bookings)
- Extend `IPropertyService` / `PropertyService` with `GetPropertyDetailAsync` → maps to `PropertyDetailResponse` DTO with CIN status resolution (regex `^IT-\d{5}-\d{10}$`)
- Register new interfaces in `ServiceCollectionExtensions`
- Fix naming collision: renamed `enum DocumentType` in `Guest.cs` to `GuestDocumentType` to disambiguate from `Casazen.Core.Enums.DocumentType` (property document categories)

## Test Plan
- [ ] `dotnet test` — 297 pass, 0 fail
- [ ] `PropertyDocumentServiceTests` (7 tests): upload happy path, property not found, storage failure, list by property, delete happy path, document not found
- [ ] `PropertyServiceGetDetailTests` (6 tests): detail mapping, CIN valid/missing/invalid, documents projection, OTA projection

## Checklist
- [x] No EF Core migration needed (schema unchanged — only service/repository layer added)
- [x] `dotnet format --verify-no-changes` passes
- [x] `GuestDocumentType` rename: no DB change (EF `HasConversion<string>()` uses enum member names, property accessor name unchanged)

Closes #155
Part of: casazen/backend#152