### PR TITLE
feat(task-156): extract IPropertyAuthorizationService and remove inline ownership checks

### DIFF
--- a/Casazen.Core/Services/IPropertyAuthorizationService.cs
+++ b/Casazen.Core/Services/IPropertyAuthorizationService.cs
@@ -1,0 +1,7 @@
+namespace Casazen.Core.Services;
+
+public interface IPropertyAuthorizationService
+{
+    bool CanAccess(string userId, string propertyOwnerId, IEnumerable<string> userRoles);
+    Task<bool> CanAccessPropertyAsync(string userId, Guid propertyId, IEnumerable<string> userRoles);
+}

--- a/Casazen.Infrastructure/Services/PropertyAuthorizationService.cs
+++ b/Casazen.Infrastructure/Services/PropertyAuthorizationService.cs
@@ -1,0 +1,19 @@
+using Casazen.Core.Repositories;
+using Casazen.Core.Services;
+
+namespace Casazen.Infrastructure.Services;
+
+public class PropertyAuthorizationService(IPropertyRepository propertyRepository) : IPropertyAuthorizationService
+{
+    private static readonly HashSet<string> PrivilegedRoles = ["PropertyManager", "Admin"];
+
+    public bool CanAccess(string userId, string propertyOwnerId, IEnumerable<string> userRoles)
+        => userRoles.Any(r => PrivilegedRoles.Contains(r)) || propertyOwnerId == userId;
+
+    public async Task<bool> CanAccessPropertyAsync(string userId, Guid propertyId, IEnumerable<string> userRoles)
+    {
+        if (userRoles.Any(r => PrivilegedRoles.Contains(r))) return true;
+        var property = await propertyRepository.GetByIdAsync(propertyId);
+        return property != null && property.OwnerId == userId;
+    }
+}

--- a/Casazen.Tests/Unit/Controllers/OtaIntegrationsControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/OtaIntegrationsControllerTests.cs
@@ -1,0 +1,280 @@
+using System.Security.Claims;
+using Casazen.Core.Entities;
+using Casazen.Core.Services;
+using Casazen.Web.Controllers;
+using Casazen.Web.DTOs;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Controllers;
+
+public class OtaIntegrationsControllerTests
+{
+    private const string OwnerId = "auth0|owner_123";
+    private const string AttackerId = "auth0|attacker_456";
+
+    private readonly Mock<IOtaIntegrationService> _mockOtaService;
+    private readonly Mock<IPropertyService> _mockPropertyService;
+    private readonly Mock<IPropertyAuthorizationService> _mockAuthz;
+    private readonly Mock<ILogger<OtaIntegrationsController>> _mockLogger;
+    private readonly OtaIntegrationsController _controller;
+
+    public OtaIntegrationsControllerTests()
+    {
+        _mockOtaService = new Mock<IOtaIntegrationService>();
+        _mockPropertyService = new Mock<IPropertyService>();
+        _mockAuthz = new Mock<IPropertyAuthorizationService>();
+        _mockLogger = new Mock<ILogger<OtaIntegrationsController>>();
+        _controller = new OtaIntegrationsController(
+            _mockOtaService.Object,
+            _mockPropertyService.Object,
+            _mockAuthz.Object,
+            _mockLogger.Object);
+    }
+
+    private void SetUser(string userId)
+    {
+        var claims = new List<Claim> { new("sub", userId) };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+    }
+
+    private void AllowAuthorization() =>
+        _mockAuthz.Setup(x => x.CanAccess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+            .Returns(true);
+
+    private Property MakeProperty(Guid id) => new() { Id = id, OwnerId = OwnerId };
+
+    private OtaIntegration MakeIntegration(Guid propertyId) => new()
+    {
+        Id = Guid.NewGuid(),
+        PropertyId = propertyId,
+        Platform = "Airbnb",
+        ExternalPropertyId = "ext-123",
+        ApiKey = "secret",
+        IsActive = true,
+        CreatedAt = DateTime.UtcNow
+    };
+
+    // ─── GetAll ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAll_AsOwner_ReturnsOk()
+    {
+        var propertyId = Guid.NewGuid();
+        SetUser(OwnerId);
+        AllowAuthorization();
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+        _mockOtaService.Setup(x => x.GetPropertyIntegrationsAsync(propertyId))
+            .ReturnsAsync([MakeIntegration(propertyId)]);
+        _mockOtaService.Setup(x => x.MaskApiKey(It.IsAny<string>())).Returns("****");
+
+        var result = await _controller.GetAll(propertyId);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetAll_AsNonOwner_ReturnsForbidden()
+    {
+        var propertyId = Guid.NewGuid();
+        SetUser(AttackerId);
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+
+        var result = await _controller.GetAll(propertyId);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetAll_PropertyNotFound_ReturnsNotFound()
+    {
+        var propertyId = Guid.NewGuid();
+        SetUser(OwnerId);
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync((Property?)null);
+
+        var result = await _controller.GetAll(propertyId);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ─── Get ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_AsOwner_ReturnsOk()
+    {
+        var propertyId = Guid.NewGuid();
+        var integration = MakeIntegration(propertyId);
+        SetUser(OwnerId);
+        AllowAuthorization();
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+        _mockOtaService.Setup(x => x.GetIntegrationAsync(integration.Id)).ReturnsAsync(integration);
+        _mockOtaService.Setup(x => x.MaskApiKey(It.IsAny<string>())).Returns("****");
+
+        var result = await _controller.Get(propertyId, integration.Id);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Get_AsNonOwner_ReturnsForbidden()
+    {
+        var propertyId = Guid.NewGuid();
+        SetUser(AttackerId);
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+
+        var result = await _controller.Get(propertyId, Guid.NewGuid());
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Get_IntegrationBelongsToDifferentProperty_ReturnsNotFound()
+    {
+        var propertyId = Guid.NewGuid();
+        var otherPropertyId = Guid.NewGuid();
+        var integration = MakeIntegration(otherPropertyId);
+        SetUser(OwnerId);
+        AllowAuthorization();
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+        _mockOtaService.Setup(x => x.GetIntegrationAsync(integration.Id)).ReturnsAsync(integration);
+
+        var result = await _controller.Get(propertyId, integration.Id);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ─── Create ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_AsOwner_ReturnsCreated()
+    {
+        var propertyId = Guid.NewGuid();
+        var integration = MakeIntegration(propertyId);
+        SetUser(OwnerId);
+        AllowAuthorization();
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+        _mockOtaService.Setup(x => x.CreateIntegrationAsync(propertyId, "Airbnb", "ext-123", "key"))
+            .ReturnsAsync(integration);
+        _mockOtaService.Setup(x => x.MaskApiKey(It.IsAny<string>())).Returns("****");
+
+        var request = new CreateOtaIntegrationRequest
+        {
+            PropertyId = propertyId,
+            Platform = "Airbnb",
+            ExternalPropertyId = "ext-123",
+            ApiKey = "key"
+        };
+
+        var result = await _controller.Create(propertyId, request);
+
+        Assert.IsType<CreatedAtActionResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Create_AsNonOwner_ReturnsForbidden()
+    {
+        var propertyId = Guid.NewGuid();
+        SetUser(AttackerId);
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+
+        var request = new CreateOtaIntegrationRequest { PropertyId = propertyId };
+        var result = await _controller.Create(propertyId, request);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Create_PropertyIdMismatch_ReturnsBadRequest()
+    {
+        var propertyId = Guid.NewGuid();
+        SetUser(OwnerId);
+        AllowAuthorization();
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+
+        var request = new CreateOtaIntegrationRequest { PropertyId = Guid.NewGuid() };
+        var result = await _controller.Create(propertyId, request);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    // ─── Update ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Update_AsOwner_ReturnsNoContent()
+    {
+        var propertyId = Guid.NewGuid();
+        var integration = MakeIntegration(propertyId);
+        SetUser(OwnerId);
+        AllowAuthorization();
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+        _mockOtaService.Setup(x => x.GetIntegrationAsync(integration.Id)).ReturnsAsync(integration);
+        _mockOtaService.Setup(x => x.UpdateIntegrationAsync(integration.Id, null, null, null)).Returns(Task.CompletedTask);
+
+        var result = await _controller.Update(propertyId, integration.Id, new UpdateOtaIntegrationRequest());
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task Update_AsNonOwner_ReturnsForbidden()
+    {
+        var propertyId = Guid.NewGuid();
+        SetUser(AttackerId);
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+
+        var result = await _controller.Update(propertyId, Guid.NewGuid(), new UpdateOtaIntegrationRequest());
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    // ─── Delete ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Delete_AsOwner_ReturnsNoContent()
+    {
+        var propertyId = Guid.NewGuid();
+        var integration = MakeIntegration(propertyId);
+        SetUser(OwnerId);
+        AllowAuthorization();
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+        _mockOtaService.Setup(x => x.GetIntegrationAsync(integration.Id)).ReturnsAsync(integration);
+        _mockOtaService.Setup(x => x.DeleteIntegrationAsync(integration.Id)).Returns(Task.CompletedTask);
+
+        var result = await _controller.Delete(propertyId, integration.Id);
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task Delete_AsNonOwner_ReturnsForbidden()
+    {
+        var propertyId = Guid.NewGuid();
+        SetUser(AttackerId);
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+
+        var result = await _controller.Delete(propertyId, Guid.NewGuid());
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task Delete_IntegrationNotFound_ReturnsNotFound()
+    {
+        var propertyId = Guid.NewGuid();
+        SetUser(OwnerId);
+        AllowAuthorization();
+        _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
+        _mockOtaService.Setup(x => x.GetIntegrationAsync(It.IsAny<Guid>())).ReturnsAsync((OtaIntegration?)null);
+
+        var result = await _controller.Delete(propertyId, Guid.NewGuid());
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/Casazen.Tests/Unit/Controllers/PricingAdapterControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/PricingAdapterControllerTests.cs
@@ -19,6 +19,7 @@ public class PricingAdapterControllerTests
 {
     private readonly Mock<IPricingAdapterService> _mockPricingService;
     private readonly Mock<IPropertyService> _mockPropertyService;
+    private readonly Mock<IPropertyAuthorizationService> _mockAuthz;
     private readonly Mock<IBackgroundJobClient> _mockBackgroundJobClient;
     private readonly Mock<ILogger<PricingAdapterController>> _mockLogger;
     private readonly PricingAdapterController _controller;
@@ -30,14 +31,19 @@ public class PricingAdapterControllerTests
     {
         _mockPricingService = new Mock<IPricingAdapterService>();
         _mockPropertyService = new Mock<IPropertyService>();
+        _mockAuthz = new Mock<IPropertyAuthorizationService>();
         _mockBackgroundJobClient = new Mock<IBackgroundJobClient>();
         _mockLogger = new Mock<ILogger<PricingAdapterController>>();
         _controller = new PricingAdapterController(
             _mockPricingService.Object,
             _mockPropertyService.Object,
+            _mockAuthz.Object,
             _mockBackgroundJobClient.Object,
             _mockLogger.Object);
     }
+
+    private void AllowAuthorization() =>
+        _mockAuthz.Setup(x => x.CanAccess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>())).Returns(true);
 
     // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -82,6 +88,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
         _mockPricingService.Setup(x => x.GetConfigAsync(propertyId)).ReturnsAsync(MakeConfig(propertyId));
 
@@ -100,6 +107,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
         _mockPricingService.Setup(x => x.GetConfigAsync(propertyId)).ReturnsAsync((PricingAdapterConfig?)null);
 
@@ -116,6 +124,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync((Property?)null);
 
         // Act
@@ -163,6 +172,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
         _mockPricingService.Setup(x => x.GetConfigAsync(propertyId)).ReturnsAsync((PricingAdapterConfig?)null);
         _mockPricingService.Setup(x => x.SaveConfigAsync(It.IsAny<PricingAdapterConfig>()))
@@ -228,6 +238,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
         _mockPricingService.Setup(x => x.GetConfigAsync(propertyId)).ReturnsAsync(MakeConfig(propertyId));
         _mockPricingService.Setup(x => x.DisableConfigAsync(propertyId)).Returns(Task.CompletedTask);
@@ -246,6 +257,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
         _mockPricingService.Setup(x => x.GetConfigAsync(propertyId)).ReturnsAsync((PricingAdapterConfig?)null);
 
@@ -294,6 +306,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
 
         var items = new List<PricingHistory>
@@ -353,6 +366,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
         _mockPricingService.Setup(x => x.GetConfigAsync(propertyId)).ReturnsAsync(MakeConfig(propertyId, enabled: true));
         _mockBackgroundJobClient
@@ -374,6 +388,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
         _mockPricingService.Setup(x => x.GetConfigAsync(propertyId)).ReturnsAsync(MakeConfig(propertyId, enabled: false));
 
@@ -391,6 +406,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
         _mockPricingService.Setup(x => x.GetConfigAsync(propertyId)).ReturnsAsync((PricingAdapterConfig?)null);
 
@@ -438,6 +454,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
         _mockPricingService.Setup(x => x.GetConfigAsync(propertyId)).ReturnsAsync(MakeConfig(propertyId));
 
@@ -461,6 +478,7 @@ public class PricingAdapterControllerTests
         // Arrange
         var propertyId = Guid.NewGuid();
         SetUser(OwnerId);
+        AllowAuthorization();
         _mockPropertyService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(MakeProperty(propertyId));
         _mockPricingService.Setup(x => x.GetConfigAsync(propertyId)).ReturnsAsync((PricingAdapterConfig?)null);
 

--- a/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
@@ -15,6 +15,7 @@ public class PropertiesControllerTests
 {
     private readonly Mock<IPropertyService> _mockService;
     private readonly Mock<IImageStorageService> _mockImageStorage;
+    private readonly Mock<IPropertyAuthorizationService> _mockAuthz;
     private readonly Mock<ILogger<PropertiesController>> _mockLogger;
     private readonly PropertiesController _controller;
 
@@ -22,9 +23,13 @@ public class PropertiesControllerTests
     {
         _mockService = new Mock<IPropertyService>();
         _mockImageStorage = new Mock<IImageStorageService>();
+        _mockAuthz = new Mock<IPropertyAuthorizationService>();
         _mockLogger = new Mock<ILogger<PropertiesController>>();
-        _controller = new PropertiesController(_mockService.Object, _mockImageStorage.Object, _mockLogger.Object);
+        _controller = new PropertiesController(_mockService.Object, _mockImageStorage.Object, _mockAuthz.Object, _mockLogger.Object);
     }
+
+    private void AllowAuthorization() =>
+        _mockAuthz.Setup(x => x.CanAccess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>())).Returns(true);
 
     [Fact]
     public async Task GetAll_WithAuthenticatedUser_ReturnsUserProperties()
@@ -219,6 +224,7 @@ public class PropertiesControllerTests
         // Arrange
         var userId = "auth0|test_user_123";
         SetupUserClaims(userId);
+        AllowAuthorization();
 
         var propertyId = Guid.NewGuid();
         var existingProperty = new Property
@@ -279,6 +285,7 @@ public class PropertiesControllerTests
         // Arrange
         var userId = "auth0|owner_user_123";
         SetupUserClaims(userId);
+        AllowAuthorization();
 
         var propertyId = Guid.NewGuid();
         var existingProperty = new Property
@@ -326,7 +333,7 @@ public class PropertiesControllerTests
         {
             Id = propertyId,
             Name = "Original",
-            OwnerId = ownerId // Owned by different user
+            OwnerId = ownerId
         };
         var request = new UpdatePropertyRequest
         {
@@ -380,6 +387,7 @@ public class PropertiesControllerTests
         // Arrange
         var userId = "auth0|test_user_123";
         SetupUserClaims(userId);
+        AllowAuthorization();
 
         var propertyId = Guid.NewGuid();
         var existingProperty = new Property
@@ -426,6 +434,7 @@ public class PropertiesControllerTests
         // Arrange
         var userId = "auth0|owner_user_123";
         SetupUserClaims(userId);
+        AllowAuthorization();
 
         var propertyId = Guid.NewGuid();
         var existingProperty = new Property
@@ -460,7 +469,7 @@ public class PropertiesControllerTests
         {
             Id = propertyId,
             Name = "To Delete",
-            OwnerId = ownerId // Owned by different user
+            OwnerId = ownerId
         };
 
         _mockService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync(existingProperty);
@@ -654,6 +663,7 @@ public class PropertiesControllerTests
         // Arrange
         var userId = "auth0|owner_user_123";
         SetupUserClaims(userId);
+        AllowAuthorization();
 
         var propertyId = Guid.NewGuid();
         var property = new Property
@@ -715,6 +725,7 @@ public class PropertiesControllerTests
         // Arrange
         var userId = "auth0|owner_user_123";
         SetupUserClaims(userId);
+        AllowAuthorization();
 
         var propertyId = Guid.NewGuid();
         var property = new Property
@@ -744,6 +755,7 @@ public class PropertiesControllerTests
         // Arrange
         var userId = "auth0|owner_user_123";
         SetupUserClaims(userId);
+        AllowAuthorization();
 
         var propertyId = Guid.NewGuid();
         var property = new Property
@@ -772,6 +784,7 @@ public class PropertiesControllerTests
         // Arrange
         var userId = "auth0|owner_user_123";
         SetupUserClaims(userId);
+        AllowAuthorization();
 
         var propertyId = Guid.NewGuid();
         var imageUrl = "/uploads/properties/test.jpg";
@@ -829,6 +842,7 @@ public class PropertiesControllerTests
         // Arrange
         var userId = "auth0|owner_user_123";
         SetupUserClaims(userId);
+        AllowAuthorization();
 
         var propertyId = Guid.NewGuid();
         var property = new Property
@@ -855,6 +869,7 @@ public class PropertiesControllerTests
         // Arrange
         var userId = "auth0|owner_user_123";
         SetupUserClaims(userId);
+        AllowAuthorization();
 
         var propertyId = Guid.NewGuid();
         var property = new Property

--- a/Casazen.Tests/Unit/Services/PropertyAuthorizationServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/PropertyAuthorizationServiceTests.cs
@@ -1,0 +1,98 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Repositories;
+using Casazen.Infrastructure.Services;
+using Moq;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Services;
+
+public class PropertyAuthorizationServiceTests
+{
+    private readonly Mock<IPropertyRepository> _mockRepository;
+    private readonly PropertyAuthorizationService _service;
+
+    public PropertyAuthorizationServiceTests()
+    {
+        _mockRepository = new Mock<IPropertyRepository>();
+        _service = new PropertyAuthorizationService(_mockRepository.Object);
+    }
+
+    // ─── CanAccess (sync) ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CanAccess_WhenUserIsOwner_ReturnsTrue()
+    {
+        var result = _service.CanAccess("auth0|owner", "auth0|owner", []);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void CanAccess_WhenUserIsNotOwnerAndHasNoPrivilegedRole_ReturnsFalse()
+    {
+        var result = _service.CanAccess("auth0|attacker", "auth0|owner", ["PropertyOwner"]);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void CanAccess_WhenUserHasPropertyManagerRole_ReturnsTrueRegardlessOfOwnership()
+    {
+        var result = _service.CanAccess("auth0|manager", "auth0|owner", ["PropertyManager"]);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void CanAccess_WhenUserHasAdminRole_ReturnsTrueRegardlessOfOwnership()
+    {
+        var result = _service.CanAccess("auth0|admin", "auth0|owner", ["Admin"]);
+        Assert.True(result);
+    }
+
+    // ─── CanAccessPropertyAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CanAccessPropertyAsync_WhenUserIsOwner_ReturnsTrue()
+    {
+        var propertyId = Guid.NewGuid();
+        _mockRepository.Setup(x => x.GetByIdAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = "auth0|owner" });
+
+        var result = await _service.CanAccessPropertyAsync("auth0|owner", propertyId, []);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task CanAccessPropertyAsync_WhenUserIsNotOwner_ReturnsFalse()
+    {
+        var propertyId = Guid.NewGuid();
+        _mockRepository.Setup(x => x.GetByIdAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = "auth0|owner" });
+
+        var result = await _service.CanAccessPropertyAsync("auth0|attacker", propertyId, []);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task CanAccessPropertyAsync_WhenPropertyNotFound_ReturnsFalse()
+    {
+        var propertyId = Guid.NewGuid();
+        _mockRepository.Setup(x => x.GetByIdAsync(propertyId)).ReturnsAsync((Property?)null);
+
+        var result = await _service.CanAccessPropertyAsync("auth0|user", propertyId, []);
+
+        Assert.False(result);
+        _mockRepository.Verify(x => x.GetByIdAsync(propertyId), Times.Once);
+    }
+
+    [Fact]
+    public async Task CanAccessPropertyAsync_WhenUserHasPropertyManagerRole_ReturnsTrueWithoutFetchingProperty()
+    {
+        var propertyId = Guid.NewGuid();
+
+        var result = await _service.CanAccessPropertyAsync("auth0|manager", propertyId, ["PropertyManager"]);
+
+        Assert.True(result);
+        _mockRepository.Verify(x => x.GetByIdAsync(It.IsAny<Guid>()), Times.Never);
+    }
+}

--- a/Casazen.Web/Controllers/OtaIntegrationsController.cs
+++ b/Casazen.Web/Controllers/OtaIntegrationsController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Casazen.Core.Services;
 using Casazen.Web.DTOs;
 using Microsoft.AspNetCore.Authorization;
@@ -10,11 +11,22 @@ namespace Casazen.Web.Controllers;
 [Authorize(Policy = "PropertyOwner")]
 public class OtaIntegrationsController(
     IOtaIntegrationService otaIntegrationService,
+    IPropertyService propertyService,
+    IPropertyAuthorizationService authorizationService,
     ILogger<OtaIntegrationsController> logger) : ControllerBase
 {
     [HttpGet]
     public async Task<ActionResult<IEnumerable<OtaIntegrationDto>>> GetAll(Guid propertyId)
     {
+        var userId = GetUserId();
+        if (userId == null) return Unauthorized();
+
+        var property = await propertyService.GetPropertyAsync(propertyId);
+        if (property == null) return NotFound();
+
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
+            return Forbid();
+
         logger.LogInformation("Getting OTA integrations for property {PropertyId}", propertyId);
         var integrations = await otaIntegrationService.GetPropertyIntegrationsAsync(propertyId);
 
@@ -36,6 +48,15 @@ public class OtaIntegrationsController(
     [HttpGet("{id}")]
     public async Task<ActionResult<OtaIntegrationDto>> Get(Guid propertyId, Guid id)
     {
+        var userId = GetUserId();
+        if (userId == null) return Unauthorized();
+
+        var property = await propertyService.GetPropertyAsync(propertyId);
+        if (property == null) return NotFound();
+
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
+            return Forbid();
+
         logger.LogInformation("Getting OTA integration {Id} for property {PropertyId}", id, propertyId);
         var integration = await otaIntegrationService.GetIntegrationAsync(id);
 
@@ -62,6 +83,15 @@ public class OtaIntegrationsController(
         Guid propertyId,
         [FromBody] CreateOtaIntegrationRequest request)
     {
+        var userId = GetUserId();
+        if (userId == null) return Unauthorized();
+
+        var property = await propertyService.GetPropertyAsync(propertyId);
+        if (property == null) return NotFound();
+
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
+            return Forbid();
+
         if (request.PropertyId != propertyId)
             return BadRequest("Property ID in URL must match request body");
 
@@ -95,6 +125,15 @@ public class OtaIntegrationsController(
         Guid id,
         [FromBody] UpdateOtaIntegrationRequest request)
     {
+        var userId = GetUserId();
+        if (userId == null) return Unauthorized();
+
+        var property = await propertyService.GetPropertyAsync(propertyId);
+        if (property == null) return NotFound();
+
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
+            return Forbid();
+
         logger.LogInformation("Updating OTA integration {Id} for property {PropertyId}", id, propertyId);
 
         var existing = await otaIntegrationService.GetIntegrationAsync(id);
@@ -113,6 +152,15 @@ public class OtaIntegrationsController(
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(Guid propertyId, Guid id)
     {
+        var userId = GetUserId();
+        if (userId == null) return Unauthorized();
+
+        var property = await propertyService.GetPropertyAsync(propertyId);
+        if (property == null) return NotFound();
+
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
+            return Forbid();
+
         logger.LogInformation("Deleting OTA integration {Id} for property {PropertyId}", id, propertyId);
 
         var existing = await otaIntegrationService.GetIntegrationAsync(id);
@@ -123,4 +171,12 @@ public class OtaIntegrationsController(
 
         return NoContent();
     }
+
+    private string? GetUserId() =>
+        User.FindFirst("sub")?.Value
+        ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+        ?? User.FindFirst("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")?.Value;
+
+    private IEnumerable<string> GetUserRoles() =>
+        User.FindAll(ClaimTypes.Role).Select(c => c.Value);
 }

--- a/Casazen.Web/Controllers/PricingAdapterController.cs
+++ b/Casazen.Web/Controllers/PricingAdapterController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Casazen.Core.Entities;
 using Casazen.Core.Services;
 using Casazen.Web.BackgroundJobs;
@@ -19,6 +20,7 @@ namespace Casazen.Web.Controllers;
 public class PricingAdapterController(
     IPricingAdapterService pricingService,
     IPropertyService propertyService,
+    IPropertyAuthorizationService authorizationService,
     IBackgroundJobClient backgroundJobClient,
     ILogger<PricingAdapterController> logger) : ControllerBase
 {
@@ -46,7 +48,7 @@ public class PricingAdapterController(
 
         var property = await propertyService.GetPropertyAsync(propertyId);
         if (property == null) return NotFound();
-        if (property.OwnerId != userId)
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
         {
             logger.LogWarning("User {UserId} attempted to update pricing config for property {PropertyId} owned by {OwnerId}",
                 userId, propertyId, property.OwnerId);
@@ -90,7 +92,7 @@ public class PricingAdapterController(
 
         var property = await propertyService.GetPropertyAsync(propertyId);
         if (property == null) return NotFound();
-        if (property.OwnerId != userId)
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
         {
             logger.LogWarning("User {UserId} attempted to read pricing config for property {PropertyId} owned by {OwnerId}",
                 userId, propertyId, property.OwnerId);
@@ -123,7 +125,7 @@ public class PricingAdapterController(
 
         var property = await propertyService.GetPropertyAsync(propertyId);
         if (property == null) return NotFound();
-        if (property.OwnerId != userId)
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
         {
             logger.LogWarning("User {UserId} attempted to disable pricing config for property {PropertyId} owned by {OwnerId}",
                 userId, propertyId, property.OwnerId);
@@ -168,7 +170,7 @@ public class PricingAdapterController(
 
         var property = await propertyService.GetPropertyAsync(propertyId);
         if (property == null) return NotFound();
-        if (property.OwnerId != userId)
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
         {
             logger.LogWarning("User {UserId} attempted to read pricing history for property {PropertyId} owned by {OwnerId}",
                 userId, propertyId, property.OwnerId);
@@ -227,7 +229,7 @@ public class PricingAdapterController(
 
         var property = await propertyService.GetPropertyAsync(propertyId);
         if (property == null) return NotFound();
-        if (property.OwnerId != userId)
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
         {
             logger.LogWarning("User {UserId} attempted to trigger pricing sync for property {PropertyId} owned by {OwnerId}",
                 userId, propertyId, property.OwnerId);
@@ -264,7 +266,7 @@ public class PricingAdapterController(
 
         var property = await propertyService.GetPropertyAsync(propertyId);
         if (property == null) return NotFound();
-        if (property.OwnerId != userId)
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
         {
             logger.LogWarning("User {UserId} attempted to preview pricing for property {PropertyId} owned by {OwnerId}",
                 userId, propertyId, property.OwnerId);
@@ -292,8 +294,11 @@ public class PricingAdapterController(
 
     private string? GetUserId() =>
         User.FindFirst("sub")?.Value
-        ?? User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+        ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value
         ?? User.FindFirst("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")?.Value;
+
+    private IEnumerable<string> GetUserRoles() =>
+        User.FindAll(ClaimTypes.Role).Select(c => c.Value);
 
     private static PricingAdapterConfigResponse ToResponse(PricingAdapterConfig config) => new()
     {

--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -1,4 +1,5 @@
-﻿using Casazen.Core.Entities;
+﻿using System.Security.Claims;
+using Casazen.Core.Entities;
 using Casazen.Core.Services;
 using Casazen.Web.DTOs;
 using Microsoft.AspNetCore.Authorization;
@@ -12,6 +13,7 @@ namespace Casazen.Web.Controllers;
 public class PropertiesController(
     IPropertyService propertyService,
     IImageStorageService imageStorageService,
+    IPropertyAuthorizationService authorizationService,
     ILogger<PropertiesController> logger) : ControllerBase
 {
     [HttpGet("health")]
@@ -108,8 +110,7 @@ public class PropertiesController(
         if (existing == null)
             return NotFound();
 
-        // Authorization check: verify ownership
-        if (existing.OwnerId != userId)
+        if (!authorizationService.CanAccess(userId, existing.OwnerId, GetUserRoles()))
         {
             logger.LogWarning("User {UserId} attempted to update property {PropertyId} owned by {OwnerId}",
                 userId, id, existing.OwnerId);
@@ -133,8 +134,7 @@ public class PropertiesController(
         if (existing == null)
             return NotFound();
 
-        // Authorization check: verify ownership
-        if (existing.OwnerId != userId)
+        if (!authorizationService.CanAccess(userId, existing.OwnerId, GetUserRoles()))
         {
             logger.LogWarning("User {UserId} attempted to delete property {PropertyId} owned by {OwnerId}",
                 userId, id, existing.OwnerId);
@@ -166,12 +166,11 @@ public class PropertiesController(
         if (string.IsNullOrEmpty(userId))
             return Unauthorized();
 
-        // Verify ownership
         var property = await propertyService.GetPropertyAsync(id);
         if (property == null)
             return NotFound();
 
-        if (property.OwnerId != userId)
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
         {
             logger.LogWarning("User {UserId} attempted to upload images to property {PropertyId} owned by {OwnerId}",
                 userId, id, property.OwnerId);
@@ -231,12 +230,11 @@ public class PropertiesController(
         if (string.IsNullOrEmpty(userId))
             return Unauthorized();
 
-        // Verify ownership
         var property = await propertyService.GetPropertyAsync(id);
         if (property == null)
             return NotFound();
 
-        if (property.OwnerId != userId)
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
         {
             logger.LogWarning("User {UserId} attempted to delete image from property {PropertyId} owned by {OwnerId}",
                 userId, id, property.OwnerId);
@@ -281,12 +279,11 @@ public class PropertiesController(
         if (string.IsNullOrEmpty(userId))
             return Unauthorized();
 
-        // Verify ownership
         var property = await propertyService.GetPropertyAsync(id);
         if (property == null)
             return NotFound();
 
-        if (property.OwnerId != userId)
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
         {
             logger.LogWarning("User {UserId} attempted to reorder images for property {PropertyId} owned by {OwnerId}",
                 userId, id, property.OwnerId);
@@ -312,6 +309,9 @@ public class PropertiesController(
 
     private string? GetAuthenticatedUserId() =>
         User.FindFirst("sub")?.Value
-        ?? User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+        ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value
         ?? User.FindFirst("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")?.Value;
+
+    private IEnumerable<string> GetUserRoles() =>
+        User.FindAll(ClaimTypes.Role).Select(c => c.Value);
 }

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -109,10 +109,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddAuthorizationBuilder()
             .AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"))
-            // DEVELOPMENT: Allow any authenticated user (remove role requirement for testing)
-            .AddPolicy("PropertyOwner", policy => policy.RequireAuthenticatedUser());
-        // PRODUCTION: Uncomment below and remove above line
-        // .AddPolicy("PropertyOwner", policy => policy.RequireRole("PropertyOwner", "Admin"));
+            .AddPolicy("PropertyOwner", policy => policy.RequireRole("PropertyOwner", "PropertyManager", "Admin"));
 
         return services;
     }
@@ -161,6 +158,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IOtaIntegrationService, OtaIntegrationService>();
         services.AddScoped<IPropertyDocumentService, PropertyDocumentService>();
         services.AddScoped<IImageStorageService, LocalImageStorageService>();
+        services.AddScoped<IPropertyAuthorizationService, PropertyAuthorizationService>();
         return services;
     }
 


### PR DESCRIPTION
## Summary
- Extract `IPropertyAuthorizationService` interface with `CanAccess` (sync) and `CanAccessPropertyAsync` methods
- `PropertyAuthorizationService` implementation grants access to owner OR any user with `PropertyManager`/`Admin` role, bypassing DB lookup for privileged roles
- Replace all inline `OwnerId != userId` checks in `PropertiesController` and `PricingAdapterController` with `authorizationService.CanAccess(...)`
- Fix security gap: `OtaIntegrationsController` previously had no ownership checks — all 5 endpoints now guarded
- `PropertyOwner` policy updated from `RequireAuthenticatedUser()` to `RequireRole("PropertyOwner", "PropertyManager", "Admin")`
- `IPropertyAuthorizationService` registered in DI container

## Test Plan
- [ ] `dotnet test` — 305 pass, 0 fail
- [ ] 8 new unit tests for `PropertyAuthorizationService` covering owner, non-owner, role bypass, not-found, and DB-skip for privileged roles
- [ ] `PropertiesController` and `PricingAdapterController` tests updated with `AllowAuthorization()` helper for happy-path cases

Closes #156
Part of: casazen/backend#152