### PR TITLE
feat(task-157): add aggregate detail, documents endpoints and harden PUT RBAC

### DIFF
--- a/Casazen.Core/Services/IPropertyDocumentService.cs
+++ b/Casazen.Core/Services/IPropertyDocumentService.cs
@@ -8,5 +8,6 @@ public interface IPropertyDocumentService
 {
     Task<PropertyDocument> UploadDocumentAsync(Guid propertyId, IFormFile file, DocumentType documentType, string uploadedBy);
     Task<IEnumerable<PropertyDocument>> GetByPropertyIdAsync(Guid propertyId);
+    Task<PropertyDocument?> GetDocumentAsync(Guid documentId);
     Task DeleteDocumentAsync(Guid documentId);
 }

--- a/Casazen.Infrastructure/Services/PropertyDocumentService.cs
+++ b/Casazen.Infrastructure/Services/PropertyDocumentService.cs
@@ -54,6 +54,11 @@ public class PropertyDocumentService(
         return await documentRepository.GetByPropertyIdAsync(propertyId);
     }
 
+    public async Task<PropertyDocument?> GetDocumentAsync(Guid documentId)
+    {
+        return await documentRepository.GetByIdAsync(documentId);
+    }
+
     public async Task DeleteDocumentAsync(Guid documentId)
     {
         var document = await documentRepository.GetByIdAsync(documentId);

--- a/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
@@ -1108,6 +1108,20 @@ public class PropertiesControllerTests
         Assert.IsType<ForbidResult>(result.Result);
     }
 
+    [Fact]
+    public async Task UploadDocument_PropertyNotFound_ReturnsNotFound()
+    {
+        SetupUserClaims("auth0|user");
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync((Property?)null);
+
+        var mockFile = CreateMockFormFile("doc.pdf", "application/pdf", 1024);
+        var result = await _controller.UploadDocument(propertyId, mockFile, "CinCertificate");
+
+        Assert.IsType<NotFoundResult>(result.Result);
+        _mockDocumentService.Verify(x => x.UploadDocumentAsync(It.IsAny<Guid>(), It.IsAny<IFormFile>(), It.IsAny<DocumentType>(), It.IsAny<string>()), Times.Never);
+    }
+
     // ─── DeleteDocument ──────────────────────────────────────────────────────────
 
     [Fact]

--- a/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
@@ -1,5 +1,7 @@
 using System.Security.Claims;
+using Casazen.Core.DTOs;
 using Casazen.Core.Entities;
+using Casazen.Core.Enums;
 using Casazen.Core.Services;
 using Casazen.Web.Controllers;
 using Casazen.Web.DTOs;
@@ -16,6 +18,7 @@ public class PropertiesControllerTests
     private readonly Mock<IPropertyService> _mockService;
     private readonly Mock<IImageStorageService> _mockImageStorage;
     private readonly Mock<IPropertyAuthorizationService> _mockAuthz;
+    private readonly Mock<IPropertyDocumentService> _mockDocumentService;
     private readonly Mock<ILogger<PropertiesController>> _mockLogger;
     private readonly PropertiesController _controller;
 
@@ -24,8 +27,14 @@ public class PropertiesControllerTests
         _mockService = new Mock<IPropertyService>();
         _mockImageStorage = new Mock<IImageStorageService>();
         _mockAuthz = new Mock<IPropertyAuthorizationService>();
+        _mockDocumentService = new Mock<IPropertyDocumentService>();
         _mockLogger = new Mock<ILogger<PropertiesController>>();
-        _controller = new PropertiesController(_mockService.Object, _mockImageStorage.Object, _mockAuthz.Object, _mockLogger.Object);
+        _controller = new PropertiesController(
+            _mockService.Object,
+            _mockImageStorage.Object,
+            _mockAuthz.Object,
+            _mockDocumentService.Object,
+            _mockLogger.Object);
     }
 
     private void AllowAuthorization() =>
@@ -943,6 +952,234 @@ public class PropertiesControllerTests
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var urls = Assert.IsAssignableFrom<List<string>>(okResult.Value);
         Assert.Equal(2, urls.Count);
+    }
+
+    // ─── GetDetail ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetDetail_AsOwner_ReturnsOk()
+    {
+        var userId = "auth0|owner_user_123";
+        SetupUserClaims(userId);
+        AllowAuthorization();
+
+        var propertyId = Guid.NewGuid();
+        var detail = new PropertyDetailResponse { Id = propertyId, OwnerId = userId };
+        _mockService.Setup(x => x.GetPropertyDetailAsync(propertyId)).ReturnsAsync(detail);
+
+        var result = await _controller.GetDetail(propertyId);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<PropertyDetailResponse>(ok.Value);
+        Assert.Equal(propertyId, response.Id);
+    }
+
+    [Fact]
+    public async Task GetDetail_AsNonOwner_ReturnsForbidden()
+    {
+        SetupUserClaims("auth0|attacker");
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyDetailAsync(propertyId))
+            .ReturnsAsync(new PropertyDetailResponse { Id = propertyId, OwnerId = "auth0|owner" });
+
+        var result = await _controller.GetDetail(propertyId);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetDetail_PropertyNotFound_ReturnsNotFound()
+    {
+        SetupUserClaims("auth0|user");
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyDetailAsync(propertyId))
+            .ThrowsAsync(new InvalidOperationException("not found"));
+
+        var result = await _controller.GetDetail(propertyId);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ─── GetDocuments ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetDocuments_AsOwner_ReturnsOk()
+    {
+        var userId = "auth0|owner_user_123";
+        SetupUserClaims(userId);
+        AllowAuthorization();
+
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = userId });
+        _mockDocumentService.Setup(x => x.GetByPropertyIdAsync(propertyId))
+            .ReturnsAsync([new PropertyDocument { Id = Guid.NewGuid(), PropertyId = propertyId, FileName = "doc.pdf" }]);
+
+        var result = await _controller.GetDocuments(propertyId);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var docs = Assert.IsAssignableFrom<IEnumerable<PropertyDocumentDto>>(ok.Value);
+        Assert.Single(docs);
+    }
+
+    [Fact]
+    public async Task GetDocuments_AsNonOwner_ReturnsForbidden()
+    {
+        SetupUserClaims("auth0|attacker");
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = "auth0|owner" });
+
+        var result = await _controller.GetDocuments(propertyId);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetDocuments_PropertyNotFound_ReturnsNotFound()
+    {
+        SetupUserClaims("auth0|user");
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId)).ReturnsAsync((Property?)null);
+
+        var result = await _controller.GetDocuments(propertyId);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ─── UploadDocument ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UploadDocument_AsOwner_ReturnsCreated()
+    {
+        var userId = "auth0|owner_user_123";
+        SetupUserClaims(userId);
+        AllowAuthorization();
+
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = userId });
+
+        var document = new PropertyDocument
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId,
+            FileName = "cin.pdf",
+            DocumentType = DocumentType.CinCertificate
+        };
+        var mockFile = CreateMockFormFile("cin.pdf", "application/pdf", 1024);
+        _mockDocumentService.Setup(x => x.UploadDocumentAsync(propertyId, mockFile, DocumentType.CinCertificate, userId))
+            .ReturnsAsync(document);
+
+        var result = await _controller.UploadDocument(propertyId, mockFile, "CinCertificate");
+
+        Assert.IsType<CreatedAtActionResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UploadDocument_InvalidDocumentType_ReturnsBadRequest()
+    {
+        var userId = "auth0|owner_user_123";
+        SetupUserClaims(userId);
+        AllowAuthorization();
+
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = userId });
+
+        var mockFile = CreateMockFormFile("doc.pdf", "application/pdf", 1024);
+
+        var result = await _controller.UploadDocument(propertyId, mockFile, "InvalidType");
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UploadDocument_AsNonOwner_ReturnsForbidden()
+    {
+        SetupUserClaims("auth0|attacker");
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = "auth0|owner" });
+
+        var mockFile = CreateMockFormFile("doc.pdf", "application/pdf", 1024);
+        var result = await _controller.UploadDocument(propertyId, mockFile, "CinCertificate");
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    // ─── DeleteDocument ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteDocument_AsOwner_ReturnsNoContent()
+    {
+        var userId = "auth0|owner_user_123";
+        SetupUserClaims(userId);
+        AllowAuthorization();
+
+        var propertyId = Guid.NewGuid();
+        var docId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = userId });
+        _mockDocumentService.Setup(x => x.GetDocumentAsync(docId))
+            .ReturnsAsync(new PropertyDocument { Id = docId, PropertyId = propertyId });
+        _mockDocumentService.Setup(x => x.DeleteDocumentAsync(docId)).Returns(Task.CompletedTask);
+
+        var result = await _controller.DeleteDocument(propertyId, docId);
+
+        Assert.IsType<NoContentResult>(result);
+        _mockDocumentService.Verify(x => x.DeleteDocumentAsync(docId), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteDocument_DocumentBelongsToDifferentProperty_ReturnsNotFound()
+    {
+        var userId = "auth0|owner_user_123";
+        SetupUserClaims(userId);
+        AllowAuthorization();
+
+        var propertyId = Guid.NewGuid();
+        var otherPropertyId = Guid.NewGuid();
+        var docId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = userId });
+        _mockDocumentService.Setup(x => x.GetDocumentAsync(docId))
+            .ReturnsAsync(new PropertyDocument { Id = docId, PropertyId = otherPropertyId });
+
+        var result = await _controller.DeleteDocument(propertyId, docId);
+
+        Assert.IsType<NotFoundResult>(result);
+        _mockDocumentService.Verify(x => x.DeleteDocumentAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteDocument_AsNonOwner_ReturnsForbidden()
+    {
+        SetupUserClaims("auth0|attacker");
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = "auth0|owner" });
+
+        var result = await _controller.DeleteDocument(propertyId, Guid.NewGuid());
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteDocument_DocumentNotFound_ReturnsNotFound()
+    {
+        var userId = "auth0|owner_user_123";
+        SetupUserClaims(userId);
+        AllowAuthorization();
+
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = userId });
+        _mockDocumentService.Setup(x => x.GetDocumentAsync(It.IsAny<Guid>())).ReturnsAsync((PropertyDocument?)null);
+
+        var result = await _controller.DeleteDocument(propertyId, Guid.NewGuid());
+
+        Assert.IsType<NotFoundResult>(result);
     }
 
     private void SetupUserClaims(string userId)

--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -1,5 +1,7 @@
 ﻿using System.Security.Claims;
+using Casazen.Core.DTOs;
 using Casazen.Core.Entities;
+using Casazen.Core.Enums;
 using Casazen.Core.Services;
 using Casazen.Web.DTOs;
 using Microsoft.AspNetCore.Authorization;
@@ -14,6 +16,7 @@ public class PropertiesController(
     IPropertyService propertyService,
     IImageStorageService imageStorageService,
     IPropertyAuthorizationService authorizationService,
+    IPropertyDocumentService documentService,
     ILogger<PropertiesController> logger) : ControllerBase
 {
     [HttpGet("health")]
@@ -306,6 +309,145 @@ public class PropertiesController(
             return StatusCode(500, new { error = "Failed to reorder images" });
         }
     }
+
+    // ─── Detail + Documents ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the full detail view of a property, including documents, OTA integrations (no API keys), and bookings summary.
+    /// </summary>
+    /// <param name="id">The unique identifier of the property.</param>
+    /// <returns>A <see cref="PropertyDetailResponse"/> with aggregate data.</returns>
+    /// <response code="200">Property detail returned successfully.</response>
+    /// <response code="401">The caller is not authenticated.</response>
+    /// <response code="403">The caller does not own this property.</response>
+    /// <response code="404">No property found with the given <paramref name="id"/>.</response>
+    [HttpGet("{id}/detail")]
+    public async Task<ActionResult<PropertyDetailResponse>> GetDetail(Guid id)
+    {
+        var userId = GetAuthenticatedUserId();
+        if (string.IsNullOrEmpty(userId))
+            return Unauthorized();
+
+        PropertyDetailResponse detail;
+        try
+        {
+            detail = await propertyService.GetPropertyDetailAsync(id);
+        }
+        catch (InvalidOperationException)
+        {
+            return NotFound();
+        }
+
+        if (!authorizationService.CanAccess(userId, detail.OwnerId, GetUserRoles()))
+            return Forbid();
+
+        return Ok(detail);
+    }
+
+    /// <summary>
+    /// Lists all documents attached to a property.
+    /// </summary>
+    /// <param name="id">The unique identifier of the property.</param>
+    /// <returns>Collection of <see cref="PropertyDocumentDto"/>.</returns>
+    /// <response code="200">Documents returned successfully.</response>
+    /// <response code="401">The caller is not authenticated.</response>
+    /// <response code="403">The caller does not own this property.</response>
+    /// <response code="404">No property found with the given <paramref name="id"/>.</response>
+    [HttpGet("{id}/documents")]
+    public async Task<ActionResult<IEnumerable<PropertyDocumentDto>>> GetDocuments(Guid id)
+    {
+        var userId = GetAuthenticatedUserId();
+        if (string.IsNullOrEmpty(userId))
+            return Unauthorized();
+
+        var property = await propertyService.GetPropertyAsync(id);
+        if (property == null)
+            return NotFound();
+
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
+            return Forbid();
+
+        var documents = await documentService.GetByPropertyIdAsync(id);
+        return Ok(documents.Select(ToDocumentDto));
+    }
+
+    /// <summary>
+    /// Uploads a document to a property. Accepts multipart/form-data.
+    /// </summary>
+    /// <param name="id">The unique identifier of the property.</param>
+    /// <param name="file">The document file to upload.</param>
+    /// <param name="documentType">The document type (e.g. <c>CinCertificate</c>, <c>FloorPlan</c>).</param>
+    /// <returns>The created <see cref="PropertyDocumentDto"/>.</returns>
+    /// <response code="201">Document uploaded successfully.</response>
+    /// <response code="400">Invalid document type value.</response>
+    /// <response code="401">The caller is not authenticated.</response>
+    /// <response code="403">The caller does not own this property.</response>
+    /// <response code="404">No property found with the given <paramref name="id"/>.</response>
+    [HttpPost("{id}/documents")]
+    public async Task<ActionResult<PropertyDocumentDto>> UploadDocument(
+        Guid id,
+        [FromForm] IFormFile file,
+        [FromForm] string documentType)
+    {
+        var userId = GetAuthenticatedUserId();
+        if (string.IsNullOrEmpty(userId))
+            return Unauthorized();
+
+        var property = await propertyService.GetPropertyAsync(id);
+        if (property == null)
+            return NotFound();
+
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
+            return Forbid();
+
+        if (!Enum.TryParse<DocumentType>(documentType, ignoreCase: true, out var docType))
+            return BadRequest(new { error = $"Invalid document type: {documentType}" });
+
+        var document = await documentService.UploadDocumentAsync(id, file, docType, userId);
+        return CreatedAtAction(nameof(GetDocuments), new { id }, ToDocumentDto(document));
+    }
+
+    /// <summary>
+    /// Deletes a document from a property.
+    /// </summary>
+    /// <param name="id">The unique identifier of the property.</param>
+    /// <param name="docId">The unique identifier of the document to delete.</param>
+    /// <returns>No content on success.</returns>
+    /// <response code="204">Document deleted successfully.</response>
+    /// <response code="401">The caller is not authenticated.</response>
+    /// <response code="403">The caller does not own this property.</response>
+    /// <response code="404">Property or document not found.</response>
+    [HttpDelete("{id}/documents/{docId}")]
+    public async Task<IActionResult> DeleteDocument(Guid id, Guid docId)
+    {
+        var userId = GetAuthenticatedUserId();
+        if (string.IsNullOrEmpty(userId))
+            return Unauthorized();
+
+        var property = await propertyService.GetPropertyAsync(id);
+        if (property == null)
+            return NotFound();
+
+        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
+            return Forbid();
+
+        var document = await documentService.GetDocumentAsync(docId);
+        if (document == null || document.PropertyId != id)
+            return NotFound();
+
+        await documentService.DeleteDocumentAsync(docId);
+        return NoContent();
+    }
+
+    private static PropertyDocumentDto ToDocumentDto(PropertyDocument d) => new()
+    {
+        Id = d.Id,
+        FileName = d.FileName,
+        StorageUrl = d.StorageUrl,
+        DocumentType = d.DocumentType,
+        UploadedBy = d.UploadedBy,
+        UploadedAt = d.UploadedAt
+    };
 
     private string? GetAuthenticatedUserId() =>
         User.FindFirst("sub")?.Value


### PR DESCRIPTION
## Summary
- Add `GET /api/properties/{id}/detail` — returns `PropertyDetailResponse` with documents, OTA integrations (no API keys), and bookings summary; backed by existing `GetPropertyDetailAsync`
- Add `GET /api/properties/{id}/documents` — lists documents as `PropertyDocumentDto[]`
- Add `POST /api/properties/{id}/documents` — multipart upload; validates `documentType` enum before calling service
- Add `DELETE /api/properties/{id}/documents/{docId}` — guards against cross-property doc deletion (verifies `document.PropertyId == propertyId`)
- Add `GetDocumentAsync(Guid)` to `IPropertyDocumentService` + implementation
- PUT `/api/properties/{id}` already uses `IPropertyAuthorizationService` (done in #156)
- OTA `ApiKey` never exposed: `PropertyDetailResponse.OtaIntegrationDto` has no `ApiKey` field

## Test Plan
- [ ] `dotnet test` — 332 pass, 0 fail
- [ ] 13 new tests: GetDetail (owner/non-owner/not-found), GetDocuments (owner/non-owner/not-found), UploadDocument (owner/invalid-type/non-owner), DeleteDocument (owner/cross-property/non-owner/not-found)

Closes #157
Part of: casazen/backend#152