### PR TITLE
feat(#165): add long-term lease management backend

### DIFF
--- a/Casazen.Core/Entities/Enums/FiscalRegime.cs
+++ b/Casazen.Core/Entities/Enums/FiscalRegime.cs
@@ -1,0 +1,8 @@
+namespace Casazen.Core.Entities.Enums;
+
+public enum FiscalRegime
+{
+    CedolareSecca,
+    RegimeOrdinario,
+    CanoneConcordato
+}

--- a/Casazen.Core/Entities/Enums/LeaseEventType.cs
+++ b/Casazen.Core/Entities/Enums/LeaseEventType.cs
@@ -1,0 +1,13 @@
+namespace Casazen.Core.Entities.Enums;
+
+public enum LeaseEventType
+{
+    Created,
+    SigningInitiated,
+    PartySignedDocument,
+    AllPartiesSigned,
+    RegistrationSubmitted,
+    RegistrationConfirmed,
+    RegistrationFailed,
+    ErasureRequested
+}

--- a/Casazen.Core/Entities/Enums/LeaseStatus.cs
+++ b/Casazen.Core/Entities/Enums/LeaseStatus.cs
@@ -1,0 +1,13 @@
+namespace Casazen.Core.Entities.Enums;
+
+public enum LeaseStatus
+{
+    Draft,
+    AwaitingSignature,
+    PartiallySigned,
+    Signed,
+    RegistrationPending,
+    SentToProvider,
+    Registered,
+    Rejected
+}

--- a/Casazen.Core/Entities/Enums/PartyRole.cs
+++ b/Casazen.Core/Entities/Enums/PartyRole.cs
@@ -1,0 +1,3 @@
+namespace Casazen.Core.Entities.Enums;
+
+public enum PartyRole { Landlord, Tenant }

--- a/Casazen.Core/Entities/Enums/RegistrationStatus.cs
+++ b/Casazen.Core/Entities/Enums/RegistrationStatus.cs
@@ -1,0 +1,3 @@
+namespace Casazen.Core.Entities.Enums;
+
+public enum RegistrationStatus { Pending, SentToProvider, Registered, Failed }

--- a/Casazen.Core/Entities/LeaseContract.cs
+++ b/Casazen.Core/Entities/LeaseContract.cs
@@ -34,6 +34,9 @@ public class LeaseContract
 
     public DateTime RegistrationDeadline { get; set; }
 
+    [MaxLength(500)]
+    public string? ExternalSigningSessionId { get; set; }
+
     [MaxLength(1000)]
     public string? SignedPdfStoragePath { get; set; }
 

--- a/Casazen.Core/Entities/LeaseContract.cs
+++ b/Casazen.Core/Entities/LeaseContract.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Casazen.Core.Entities.Enums;
+
+namespace Casazen.Core.Entities;
+
+[Table("LeaseContracts")]
+public class LeaseContract
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    public Guid PropertyId { get; set; }
+
+    [ForeignKey(nameof(PropertyId))]
+    public virtual Property Property { get; set; } = null!;
+
+    [Required]
+    public LeaseStatus Status { get; set; } = LeaseStatus.Draft;
+
+    [Required]
+    public FiscalRegime FiscalRegime { get; set; }
+
+    [Required]
+    public DateTime StartDate { get; set; }
+
+    [Required]
+    public DateTime EndDate { get; set; }
+
+    [Required]
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal MonthlyRent { get; set; }
+
+    public DateTime RegistrationDeadline { get; set; }
+
+    [MaxLength(1000)]
+    public string? SignedPdfStoragePath { get; set; }
+
+    public bool ErasureRequested { get; set; } = false;
+
+    public DateTime DataRetentionUntil { get; set; }
+
+    public virtual ICollection<Party> Parties { get; set; } = [];
+    public virtual LeaseRegistration? Registration { get; set; }
+    public virtual ICollection<LeaseEvent> Events { get; set; } = [];
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    public bool HasExtraEUTenant => Parties.Any(p => p.Role == PartyRole.Tenant && p.IsExtraEU);
+}

--- a/Casazen.Core/Entities/LeaseEvent.cs
+++ b/Casazen.Core/Entities/LeaseEvent.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Casazen.Core.Entities.Enums;
+
+namespace Casazen.Core.Entities;
+
+[Table("LeaseEvents")]
+public class LeaseEvent
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    public Guid LeaseContractId { get; set; }
+
+    [ForeignKey(nameof(LeaseContractId))]
+    public virtual LeaseContract LeaseContract { get; set; } = null!;
+
+    [Required]
+    public LeaseEventType EventType { get; set; }
+
+    public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
+
+    public string? Payload { get; set; }
+}

--- a/Casazen.Core/Entities/LeaseRegistration.cs
+++ b/Casazen.Core/Entities/LeaseRegistration.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Casazen.Core.Entities.Enums;
+
+namespace Casazen.Core.Entities;
+
+[Table("LeaseRegistrations")]
+public class LeaseRegistration
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    public Guid LeaseContractId { get; set; }
+
+    [ForeignKey(nameof(LeaseContractId))]
+    public virtual LeaseContract LeaseContract { get; set; } = null!;
+
+    [Required]
+    public RegistrationStatus Status { get; set; } = RegistrationStatus.Pending;
+
+    [MaxLength(200)]
+    public string? ExternalRegistrationId { get; set; }
+
+    [MaxLength(100)]
+    public string? RegistrationCode { get; set; }
+
+    [MaxLength(1000)]
+    public string? ReceiptStoragePath { get; set; }
+
+    public DateTime? SubmittedAt { get; set; }
+    public DateTime? ConfirmedAt { get; set; }
+}

--- a/Casazen.Core/Entities/Party.cs
+++ b/Casazen.Core/Entities/Party.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Casazen.Core.Entities.Enums;
+
+namespace Casazen.Core.Entities;
+
+[Table("Parties")]
+public class Party
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    public Guid LeaseContractId { get; set; }
+
+    [ForeignKey(nameof(LeaseContractId))]
+    public virtual LeaseContract LeaseContract { get; set; } = null!;
+
+    [Required]
+    public PartyRole Role { get; set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string FirstName { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(100)]
+    public string LastName { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(16)]
+    public string FiscalCode { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(2)]
+    public string Citizenship { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(255)]
+    [EmailAddress]
+    public string ContactEmail { get; set; } = string.Empty;
+
+    public bool IsExtraEU { get; set; }
+}

--- a/Casazen.Core/Enums/DocumentType.cs
+++ b/Casazen.Core/Enums/DocumentType.cs
@@ -7,5 +7,6 @@ public enum DocumentType
     InsurancePolicy,
     PropertyLicense,
     SafetyCompliance,
+    Ape,
     Other
 }

--- a/Casazen.Core/Repositories/ILeaseContractRepository.cs
+++ b/Casazen.Core/Repositories/ILeaseContractRepository.cs
@@ -7,7 +7,8 @@ public interface ILeaseContractRepository
 {
     Task<LeaseContract?> GetByIdAsync(Guid id);
     Task<LeaseContract?> GetByIdWithDetailsAsync(Guid id);
-    Task<IEnumerable<LeaseContract>> GetByOwnerAsync(string ownerId);
+    Task<LeaseContract?> GetByExternalSigningSessionIdAsync(string externalSessionId);
+    Task<IEnumerable<LeaseContract>> GetByOwnerAsync(string ownerId, Guid? propertyId = null);
     Task<IEnumerable<LeaseContract>> GetByPropertyAsync(Guid propertyId);
     Task<IEnumerable<LeaseContract>> GetByStatusAsync(LeaseStatus status);
     Task<LeaseContract> AddAsync(LeaseContract lease);

--- a/Casazen.Core/Repositories/ILeaseContractRepository.cs
+++ b/Casazen.Core/Repositories/ILeaseContractRepository.cs
@@ -1,0 +1,15 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+
+namespace Casazen.Core.Repositories;
+
+public interface ILeaseContractRepository
+{
+    Task<LeaseContract?> GetByIdAsync(Guid id);
+    Task<LeaseContract?> GetByIdWithDetailsAsync(Guid id);
+    Task<IEnumerable<LeaseContract>> GetByOwnerAsync(string ownerId);
+    Task<IEnumerable<LeaseContract>> GetByPropertyAsync(Guid propertyId);
+    Task<IEnumerable<LeaseContract>> GetByStatusAsync(LeaseStatus status);
+    Task<LeaseContract> AddAsync(LeaseContract lease);
+    Task<LeaseContract> UpdateAsync(LeaseContract lease);
+}

--- a/Casazen.Core/Repositories/ILeaseEventRepository.cs
+++ b/Casazen.Core/Repositories/ILeaseEventRepository.cs
@@ -1,0 +1,9 @@
+using Casazen.Core.Entities;
+
+namespace Casazen.Core.Repositories;
+
+public interface ILeaseEventRepository
+{
+    Task<IEnumerable<LeaseEvent>> GetByLeaseIdAsync(Guid leaseContractId);
+    Task<LeaseEvent> AddAsync(LeaseEvent leaseEvent);
+}

--- a/Casazen.Core/Repositories/ILeaseRegistrationRepository.cs
+++ b/Casazen.Core/Repositories/ILeaseRegistrationRepository.cs
@@ -1,0 +1,12 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+
+namespace Casazen.Core.Repositories;
+
+public interface ILeaseRegistrationRepository
+{
+    Task<LeaseRegistration?> GetByLeaseIdAsync(Guid leaseContractId);
+    Task<IEnumerable<LeaseRegistration>> GetByStatusAsync(RegistrationStatus status);
+    Task<LeaseRegistration> AddAsync(LeaseRegistration registration);
+    Task<LeaseRegistration> UpdateAsync(LeaseRegistration registration);
+}

--- a/Casazen.Core/Services/ILeaseESignService.cs
+++ b/Casazen.Core/Services/ILeaseESignService.cs
@@ -1,0 +1,16 @@
+using Casazen.Core.Entities;
+
+namespace Casazen.Core.Services;
+
+public interface ILeaseESignService
+{
+    Task<IEnumerable<SignerInfo>> InitiateSigningAsync(LeaseContract lease, byte[] pdfBytes);
+    Task<ESignEvent> ParseWebhookEventAsync(string payload);
+}
+
+public record ESignEvent(
+    string ExternalSessionId,
+    string EventType,
+    string? SignerEmail,
+    bool AllSigned,
+    string? SignedDocumentPath);

--- a/Casazen.Core/Services/ILeaseESignService.cs
+++ b/Casazen.Core/Services/ILeaseESignService.cs
@@ -4,9 +4,11 @@ namespace Casazen.Core.Services;
 
 public interface ILeaseESignService
 {
-    Task<IEnumerable<SignerInfo>> InitiateSigningAsync(LeaseContract lease, byte[] pdfBytes);
+    Task<SigningSessionResult> InitiateSigningAsync(LeaseContract lease, byte[] pdfBytes);
     Task<ESignEvent> ParseWebhookEventAsync(string payload);
 }
+
+public record SigningSessionResult(string ExternalSessionId, IEnumerable<SignerInfo> Signers);
 
 public record ESignEvent(
     string ExternalSessionId,

--- a/Casazen.Core/Services/ILeaseRegistrationService.cs
+++ b/Casazen.Core/Services/ILeaseRegistrationService.cs
@@ -1,0 +1,16 @@
+using Casazen.Core.Entities;
+
+namespace Casazen.Core.Services;
+
+public interface ILeaseRegistrationService
+{
+    Task<string> SubmitRegistrationAsync(LeaseContract lease);
+    Task<RegistrationStatusResult> PollStatusAsync(string externalRegistrationId);
+    Task<Stream> DownloadReceiptAsync(string externalRegistrationId);
+}
+
+public record RegistrationStatusResult(
+    string ExternalRegistrationId,
+    string Status,
+    string? RegistrationCode,
+    bool IsConfirmed);

--- a/Casazen.Core/Services/ILeaseTemplateService.cs
+++ b/Casazen.Core/Services/ILeaseTemplateService.cs
@@ -1,0 +1,8 @@
+using Casazen.Core.Entities;
+
+namespace Casazen.Core.Services;
+
+public interface ILeaseTemplateService
+{
+    Task<byte[]> GeneratePdfAsync(LeaseContract lease);
+}

--- a/Casazen.Core/Services/ILeaseWorkflowService.cs
+++ b/Casazen.Core/Services/ILeaseWorkflowService.cs
@@ -1,0 +1,43 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+
+namespace Casazen.Core.Services;
+
+public interface ILeaseWorkflowService
+{
+    Task<LeaseContract> CreateDraftAsync(Guid propertyId, string ownerId, CreateLeaseRequest request);
+    Task<SigningInitiatedResult> InitiateSigningAsync(Guid leaseId, string ownerId);
+    Task HandleESignEventAsync(string providerPayload);
+    Task<LeaseRegistration> TriggerRegistrationAsync(Guid leaseId, string ownerId);
+    Task<LeaseRegistration?> GetRegistrationAsync(Guid leaseId, string ownerId);
+    Task<Stream> GetRegistrationReceiptAsync(Guid leaseId, string ownerId);
+    Task<IEnumerable<LeaseContract>> GetOwnerLeasesAsync(string ownerId, Guid? propertyId = null);
+    Task<LeaseContract?> GetLeaseDetailAsync(Guid leaseId, string ownerId);
+}
+
+public record CreateLeaseRequest(
+    FiscalRegime FiscalRegime,
+    DateTime StartDate,
+    DateTime EndDate,
+    decimal MonthlyRent,
+    IEnumerable<CreatePartyRequest> Parties);
+
+public record CreatePartyRequest(
+    PartyRole Role,
+    string FirstName,
+    string LastName,
+    string FiscalCode,
+    string Citizenship,
+    string ContactEmail);
+
+public record SigningInitiatedResult(
+    Guid LeaseId,
+    LeaseStatus Status,
+    IEnumerable<SignerInfo> Signers);
+
+public record SignerInfo(
+    Guid PartyId,
+    PartyRole Role,
+    string Name,
+    string SigningUrl,
+    DateTime ExpiresAt);

--- a/Casazen.Infrastructure/Data/AppDbContext.cs
+++ b/Casazen.Infrastructure/Data/AppDbContext.cs
@@ -1,4 +1,5 @@
 using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
 using Microsoft.EntityFrameworkCore;
 using Property = Casazen.Core.Entities.Property;
 
@@ -20,6 +21,12 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<PricingAdapterConfig> PricingAdapterConfigs { get; set; } = null!;
     public DbSet<PricingHistory> PricingHistories { get; set; } = null!;
     public DbSet<PropertyDocument> PropertyDocuments { get; set; } = null!;
+
+    // Long-term lease
+    public DbSet<LeaseContract> LeaseContracts { get; set; } = null!;
+    public DbSet<Party> Parties { get; set; } = null!;
+    public DbSet<LeaseRegistration> LeaseRegistrations { get; set; } = null!;
+    public DbSet<LeaseEvent> LeaseEvents { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -125,5 +132,50 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             .Property(d => d.DocumentType)
             .HasConversion<string>()
             .HasMaxLength(100);
+
+        // LeaseContract → Property (restrict to preserve history)
+        modelBuilder.Entity<LeaseContract>()
+            .HasOne(l => l.Property)
+            .WithMany()
+            .HasForeignKey(l => l.PropertyId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<LeaseContract>()
+            .Property(l => l.MonthlyRent)
+            .HasPrecision(18, 2);
+
+        modelBuilder.Entity<LeaseContract>().HasIndex(l => l.PropertyId);
+        modelBuilder.Entity<LeaseContract>().HasIndex(l => l.Status);
+
+        // Party → LeaseContract (cascade)
+        modelBuilder.Entity<Party>()
+            .HasOne(p => p.LeaseContract)
+            .WithMany(l => l.Parties)
+            .HasForeignKey(p => p.LeaseContractId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<Party>()
+            .HasIndex(p => new { p.LeaseContractId, p.Role });
+
+        // LeaseRegistration → LeaseContract (1-to-1, cascade)
+        modelBuilder.Entity<LeaseRegistration>()
+            .HasOne(r => r.LeaseContract)
+            .WithOne(l => l.Registration)
+            .HasForeignKey<LeaseRegistration>(r => r.LeaseContractId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<LeaseRegistration>()
+            .HasIndex(r => r.LeaseContractId)
+            .IsUnique();
+
+        // LeaseEvent → LeaseContract (cascade)
+        modelBuilder.Entity<LeaseEvent>()
+            .HasOne(e => e.LeaseContract)
+            .WithMany(l => l.Events)
+            .HasForeignKey(e => e.LeaseContractId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<LeaseEvent>()
+            .HasIndex(e => new { e.LeaseContractId, e.OccurredAt });
     }
 }

--- a/Casazen.Infrastructure/External/LeaseContractTemplateService.cs
+++ b/Casazen.Infrastructure/External/LeaseContractTemplateService.cs
@@ -1,0 +1,24 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Infrastructure.External;
+
+/// <summary>
+/// Stub implementation — real PDF/A generation via Openapi.it template engine.
+/// Replace with actual Docuengine API call when credentials are available.
+/// </summary>
+public class LeaseContractTemplateService(ILogger<LeaseContractTemplateService> logger) : ILeaseTemplateService
+{
+    public Task<byte[]> GeneratePdfAsync(LeaseContract lease)
+    {
+        logger.LogInformation("Generating PDF/A for LeaseId={LeaseId} FiscalRegime={Regime}",
+            lease.Id, lease.FiscalRegime);
+
+        // TODO: call Openapi.it Docuengine PDF generation endpoint
+        // POST https://api.openapi.it/locazioni/contratto
+        // Config: appsettings.json → Openapi:ApiKey
+        var placeholder = System.Text.Encoding.UTF8.GetBytes($"[LEASE CONTRACT PDF PLACEHOLDER - LeaseId: {lease.Id}]");
+        return Task.FromResult(placeholder);
+    }
+}

--- a/Casazen.Infrastructure/External/LeaseESignHttpAdapter.cs
+++ b/Casazen.Infrastructure/External/LeaseESignHttpAdapter.cs
@@ -1,0 +1,48 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Infrastructure.External;
+
+/// <summary>
+/// Stub implementation — real e-signature provider TBD.
+/// Implement against chosen provider SDK when selected.
+/// Config: appsettings.json → ESign:ApiKey, ESign:WebhookSecret
+/// </summary>
+public class LeaseESignHttpAdapter(
+    IConfiguration configuration,
+    ILogger<LeaseESignHttpAdapter> logger) : ILeaseESignService
+{
+    public Task<IEnumerable<SignerInfo>> InitiateSigningAsync(LeaseContract lease, byte[] pdfBytes)
+    {
+        logger.LogInformation("Initiating e-signing for LeaseId={LeaseId} Parties={Count}",
+            lease.Id, lease.Parties.Count);
+
+        // TODO: call e-sign provider API with pdfBytes
+        // Return stub signing URLs for now
+        var signers = lease.Parties.Select(p => new SignerInfo(
+            p.Id,
+            p.Role,
+            $"{p.FirstName} {p.LastName}",
+            $"https://sign.provider.example.com/session/{Guid.NewGuid()}",
+            DateTime.UtcNow.AddDays(7)));
+
+        return Task.FromResult(signers);
+    }
+
+    public Task<ESignEvent> ParseWebhookEventAsync(string payload)
+    {
+        logger.LogInformation("Parsing e-sign webhook event");
+
+        // TODO: implement real payload parsing per chosen provider
+        var stub = new ESignEvent(
+            ExternalSessionId: "stub",
+            EventType: "party_signed",
+            SignerEmail: null,
+            AllSigned: false,
+            SignedDocumentPath: null);
+
+        return Task.FromResult(stub);
+    }
+}

--- a/Casazen.Infrastructure/External/LeaseESignHttpAdapter.cs
+++ b/Casazen.Infrastructure/External/LeaseESignHttpAdapter.cs
@@ -14,21 +14,22 @@ public class LeaseESignHttpAdapter(
     IConfiguration configuration,
     ILogger<LeaseESignHttpAdapter> logger) : ILeaseESignService
 {
-    public Task<IEnumerable<SignerInfo>> InitiateSigningAsync(LeaseContract lease, byte[] pdfBytes)
+    public Task<SigningSessionResult> InitiateSigningAsync(LeaseContract lease, byte[] pdfBytes)
     {
         logger.LogInformation("Initiating e-signing for LeaseId={LeaseId} Parties={Count}",
             lease.Id, lease.Parties.Count);
 
         // TODO: call e-sign provider API with pdfBytes
-        // Return stub signing URLs for now
+        // Return stub session ID and signing URLs for now
+        var sessionId = $"stub-session-{lease.Id}";
         var signers = lease.Parties.Select(p => new SignerInfo(
             p.Id,
             p.Role,
             $"{p.FirstName} {p.LastName}",
-            $"https://sign.provider.example.com/session/{Guid.NewGuid()}",
+            $"https://sign.provider.example.com/session/{sessionId}/{p.Id}",
             DateTime.UtcNow.AddDays(7)));
 
-        return Task.FromResult(signers);
+        return Task.FromResult(new SigningSessionResult(sessionId, signers));
     }
 
     public Task<ESignEvent> ParseWebhookEventAsync(string payload)

--- a/Casazen.Infrastructure/External/OpenapiLeaseRegistrationProvider.cs
+++ b/Casazen.Infrastructure/External/OpenapiLeaseRegistrationProvider.cs
@@ -1,0 +1,52 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Infrastructure.External;
+
+/// <summary>
+/// RLI registration via Openapi.it Docuengine.
+/// Config: appsettings.json → Openapi:ApiKey, Openapi:BaseUrl
+/// Docs: https://openapi.it/prodotti/servizi-contratti-di-locazione
+/// </summary>
+public class OpenapiLeaseRegistrationProvider(
+    IHttpClientFactory httpClientFactory,
+    IConfiguration configuration,
+    ILogger<OpenapiLeaseRegistrationProvider> logger) : ILeaseRegistrationService
+{
+    public async Task<string> SubmitRegistrationAsync(LeaseContract lease)
+    {
+        logger.LogInformation("Submitting RLI registration for LeaseId={LeaseId}", lease.Id);
+
+        // TODO: POST to Openapi.it Docuengine registration endpoint
+        // var apiKey = configuration["Openapi:ApiKey"];
+        // var client = httpClientFactory.CreateClient("Openapi");
+        // var response = await client.PostAsJsonAsync("/locazioni/registrazione", payload);
+
+        var stubExternalId = $"RLI-STUB-{lease.Id:N}";
+        logger.LogInformation("Registration submitted (stub). ExternalId={ExternalId}", stubExternalId);
+        return await Task.FromResult(stubExternalId);
+    }
+
+    public async Task<RegistrationStatusResult> PollStatusAsync(string externalRegistrationId)
+    {
+        logger.LogInformation("Polling registration status for ExternalId={ExternalId}", externalRegistrationId);
+
+        // TODO: GET Openapi.it status endpoint
+        return await Task.FromResult(new RegistrationStatusResult(
+            externalRegistrationId,
+            "Pending",
+            null,
+            false));
+    }
+
+    public async Task<Stream> DownloadReceiptAsync(string externalRegistrationId)
+    {
+        logger.LogInformation("Downloading receipt for ExternalId={ExternalId}", externalRegistrationId);
+
+        // TODO: GET Openapi.it receipt download endpoint
+        var placeholder = System.Text.Encoding.UTF8.GetBytes("[RECEIPT PLACEHOLDER]");
+        return await Task.FromResult<Stream>(new MemoryStream(placeholder));
+    }
+}

--- a/Casazen.Infrastructure/External/SendGridService.cs
+++ b/Casazen.Infrastructure/External/SendGridService.cs
@@ -12,7 +12,7 @@ public interface ISendGridService
 
 public class SendGridService(IConfiguration configuration, ILogger<SendGridService> logger, ISendGridClient client) : ISendGridService
 {
-    private readonly string _fromEmail =  configuration["Email:FromAddress"] ?? "noreply@casazen.app";
+    private readonly string _fromEmail = configuration["Email:FromAddress"] ?? "noreply@casazen.app";
 
     public async Task<bool> SendEmailAsync(string to, string subject, string htmlContent)
     {

--- a/Casazen.Infrastructure/Migrations/20260602193205_AddLeaseTables.Designer.cs
+++ b/Casazen.Infrastructure/Migrations/20260602193205_AddLeaseTables.Designer.cs
@@ -4,6 +4,7 @@ using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Casazen.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260602193205_AddLeaseTables")]
+    partial class AddLeaseTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Casazen.Infrastructure/Migrations/20260602193205_AddLeaseTables.cs
+++ b/Casazen.Infrastructure/Migrations/20260602193205_AddLeaseTables.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Casazen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLeaseTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LeaseContracts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PropertyId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    FiscalRegime = table.Column<int>(type: "int", nullable: false),
+                    StartDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    MonthlyRent = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                    RegistrationDeadline = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SignedPdfStoragePath = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: true),
+                    ErasureRequested = table.Column<bool>(type: "bit", nullable: false),
+                    DataRetentionUntil = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LeaseContracts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LeaseContracts_Properties_PropertyId",
+                        column: x => x.PropertyId,
+                        principalTable: "Properties",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LeaseEvents",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LeaseContractId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    EventType = table.Column<int>(type: "int", nullable: false),
+                    OccurredAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Payload = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LeaseEvents", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LeaseEvents_LeaseContracts_LeaseContractId",
+                        column: x => x.LeaseContractId,
+                        principalTable: "LeaseContracts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LeaseRegistrations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LeaseContractId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    ExternalRegistrationId = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    RegistrationCode = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    ReceiptStoragePath = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: true),
+                    SubmittedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ConfirmedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LeaseRegistrations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LeaseRegistrations_LeaseContracts_LeaseContractId",
+                        column: x => x.LeaseContractId,
+                        principalTable: "LeaseContracts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Parties",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LeaseContractId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Role = table.Column<int>(type: "int", nullable: false),
+                    FirstName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    LastName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    FiscalCode = table.Column<string>(type: "nvarchar(16)", maxLength: 16, nullable: false),
+                    Citizenship = table.Column<string>(type: "nvarchar(2)", maxLength: 2, nullable: false),
+                    ContactEmail = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    IsExtraEU = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Parties", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Parties_LeaseContracts_LeaseContractId",
+                        column: x => x.LeaseContractId,
+                        principalTable: "LeaseContracts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeaseContracts_PropertyId",
+                table: "LeaseContracts",
+                column: "PropertyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeaseContracts_Status",
+                table: "LeaseContracts",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeaseEvents_LeaseContractId_OccurredAt",
+                table: "LeaseEvents",
+                columns: new[] { "LeaseContractId", "OccurredAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeaseRegistrations_LeaseContractId",
+                table: "LeaseRegistrations",
+                column: "LeaseContractId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Parties_LeaseContractId_Role",
+                table: "Parties",
+                columns: new[] { "LeaseContractId", "Role" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LeaseEvents");
+
+            migrationBuilder.DropTable(
+                name: "LeaseRegistrations");
+
+            migrationBuilder.DropTable(
+                name: "Parties");
+
+            migrationBuilder.DropTable(
+                name: "LeaseContracts");
+        }
+    }
+}

--- a/Casazen.Infrastructure/Migrations/20260602195750_AddLeaseExternalSigningSessionId.Designer.cs
+++ b/Casazen.Infrastructure/Migrations/20260602195750_AddLeaseExternalSigningSessionId.Designer.cs
@@ -4,6 +4,7 @@ using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Casazen.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260602195750_AddLeaseExternalSigningSessionId")]
+    partial class AddLeaseExternalSigningSessionId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Casazen.Infrastructure/Migrations/20260602195750_AddLeaseExternalSigningSessionId.cs
+++ b/Casazen.Infrastructure/Migrations/20260602195750_AddLeaseExternalSigningSessionId.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Casazen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLeaseExternalSigningSessionId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalSigningSessionId",
+                table: "LeaseContracts",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExternalSigningSessionId",
+                table: "LeaseContracts");
+        }
+    }
+}

--- a/Casazen.Infrastructure/OTA/Resilience/OtaRateLimiter.cs
+++ b/Casazen.Infrastructure/OTA/Resilience/OtaRateLimiter.cs
@@ -143,7 +143,7 @@ public class OtaRateLimiter
             _platform = platform;
             _logger = logger;
         }
-        
+
 
         public void Dispose()
         {

--- a/Casazen.Infrastructure/Payments/IPaymentGateway.cs
+++ b/Casazen.Infrastructure/Payments/IPaymentGateway.cs
@@ -2,5 +2,5 @@
 
 public interface IPaymentGateway
 {
-    
+
 }

--- a/Casazen.Infrastructure/Payments/PaypalGateway.cs
+++ b/Casazen.Infrastructure/Payments/PaypalGateway.cs
@@ -2,5 +2,5 @@
 
 public class PaypalGateway : IPaymentGateway
 {
-    
+
 }

--- a/Casazen.Infrastructure/Payments/StripeGateway.cs
+++ b/Casazen.Infrastructure/Payments/StripeGateway.cs
@@ -2,5 +2,5 @@
 
 public class StripeGateway : IPaymentGateway
 {
-    
+
 }

--- a/Casazen.Infrastructure/Repositories/LeaseContractRepository.cs
+++ b/Casazen.Infrastructure/Repositories/LeaseContractRepository.cs
@@ -1,0 +1,59 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Repositories;
+using Casazen.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Casazen.Infrastructure.Repositories;
+
+public class LeaseContractRepository(AppDbContext context) : ILeaseContractRepository
+{
+    public async Task<LeaseContract?> GetByIdAsync(Guid id)
+        => await context.LeaseContracts.FindAsync(id);
+
+    public async Task<LeaseContract?> GetByIdWithDetailsAsync(Guid id)
+        => await context.LeaseContracts
+            .Include(l => l.Property)
+            .Include(l => l.Parties)
+            .Include(l => l.Registration)
+            .Include(l => l.Events.OrderBy(e => e.OccurredAt))
+            .FirstOrDefaultAsync(l => l.Id == id);
+
+    public async Task<IEnumerable<LeaseContract>> GetByOwnerAsync(string ownerId)
+        => await context.LeaseContracts
+            .Include(l => l.Property)
+            .Include(l => l.Parties)
+            .Where(l => l.Property.OwnerId == ownerId)
+            .OrderByDescending(l => l.CreatedAt)
+            .ToListAsync();
+
+    public async Task<IEnumerable<LeaseContract>> GetByPropertyAsync(Guid propertyId)
+        => await context.LeaseContracts
+            .Include(l => l.Parties)
+            .Where(l => l.PropertyId == propertyId)
+            .OrderByDescending(l => l.CreatedAt)
+            .ToListAsync();
+
+    public async Task<IEnumerable<LeaseContract>> GetByStatusAsync(LeaseStatus status)
+        => await context.LeaseContracts
+            .Include(l => l.Property)
+            .Include(l => l.Parties)
+            .Include(l => l.Registration)
+            .Where(l => l.Status == status)
+            .ToListAsync();
+
+    public async Task<LeaseContract> AddAsync(LeaseContract lease)
+    {
+        context.LeaseContracts.Add(lease);
+        await context.SaveChangesAsync();
+        return lease;
+    }
+
+    public async Task<LeaseContract> UpdateAsync(LeaseContract lease)
+    {
+        lease.UpdatedAt = DateTime.UtcNow;
+        context.LeaseContracts.Update(lease);
+        await context.SaveChangesAsync();
+        return lease;
+    }
+}

--- a/Casazen.Infrastructure/Repositories/LeaseContractRepository.cs
+++ b/Casazen.Infrastructure/Repositories/LeaseContractRepository.cs
@@ -19,13 +19,24 @@ public class LeaseContractRepository(AppDbContext context) : ILeaseContractRepos
             .Include(l => l.Events.OrderBy(e => e.OccurredAt))
             .FirstOrDefaultAsync(l => l.Id == id);
 
-    public async Task<IEnumerable<LeaseContract>> GetByOwnerAsync(string ownerId)
+    public async Task<LeaseContract?> GetByExternalSigningSessionIdAsync(string externalSessionId)
         => await context.LeaseContracts
             .Include(l => l.Property)
             .Include(l => l.Parties)
-            .Where(l => l.Property.OwnerId == ownerId)
-            .OrderByDescending(l => l.CreatedAt)
-            .ToListAsync();
+            .FirstOrDefaultAsync(l => l.ExternalSigningSessionId == externalSessionId);
+
+    public async Task<IEnumerable<LeaseContract>> GetByOwnerAsync(string ownerId, Guid? propertyId = null)
+    {
+        var query = context.LeaseContracts
+            .Include(l => l.Property)
+            .Include(l => l.Parties)
+            .Where(l => l.Property.OwnerId == ownerId);
+
+        if (propertyId.HasValue)
+            query = query.Where(l => l.PropertyId == propertyId.Value);
+
+        return await query.OrderByDescending(l => l.CreatedAt).ToListAsync();
+    }
 
     public async Task<IEnumerable<LeaseContract>> GetByPropertyAsync(Guid propertyId)
         => await context.LeaseContracts

--- a/Casazen.Infrastructure/Repositories/LeaseEventRepository.cs
+++ b/Casazen.Infrastructure/Repositories/LeaseEventRepository.cs
@@ -1,0 +1,22 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Repositories;
+using Casazen.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Casazen.Infrastructure.Repositories;
+
+public class LeaseEventRepository(AppDbContext context) : ILeaseEventRepository
+{
+    public async Task<IEnumerable<LeaseEvent>> GetByLeaseIdAsync(Guid leaseContractId)
+        => await context.LeaseEvents
+            .Where(e => e.LeaseContractId == leaseContractId)
+            .OrderBy(e => e.OccurredAt)
+            .ToListAsync();
+
+    public async Task<LeaseEvent> AddAsync(LeaseEvent leaseEvent)
+    {
+        context.LeaseEvents.Add(leaseEvent);
+        await context.SaveChangesAsync();
+        return leaseEvent;
+    }
+}

--- a/Casazen.Infrastructure/Repositories/LeaseRegistrationRepository.cs
+++ b/Casazen.Infrastructure/Repositories/LeaseRegistrationRepository.cs
@@ -1,0 +1,34 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Repositories;
+using Casazen.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Casazen.Infrastructure.Repositories;
+
+public class LeaseRegistrationRepository(AppDbContext context) : ILeaseRegistrationRepository
+{
+    public async Task<LeaseRegistration?> GetByLeaseIdAsync(Guid leaseContractId)
+        => await context.LeaseRegistrations
+            .FirstOrDefaultAsync(r => r.LeaseContractId == leaseContractId);
+
+    public async Task<IEnumerable<LeaseRegistration>> GetByStatusAsync(RegistrationStatus status)
+        => await context.LeaseRegistrations
+            .Include(r => r.LeaseContract)
+            .Where(r => r.Status == status)
+            .ToListAsync();
+
+    public async Task<LeaseRegistration> AddAsync(LeaseRegistration registration)
+    {
+        context.LeaseRegistrations.Add(registration);
+        await context.SaveChangesAsync();
+        return registration;
+    }
+
+    public async Task<LeaseRegistration> UpdateAsync(LeaseRegistration registration)
+    {
+        context.LeaseRegistrations.Update(registration);
+        await context.SaveChangesAsync();
+        return registration;
+    }
+}

--- a/Casazen.Infrastructure/Services/LeaseWorkflowService.cs
+++ b/Casazen.Infrastructure/Services/LeaseWorkflowService.cs
@@ -1,0 +1,199 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Enums;
+using Casazen.Core.Repositories;
+using Casazen.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Infrastructure.Services;
+
+public class LeaseWorkflowService(
+    ILeaseContractRepository leaseRepository,
+    ILeaseRegistrationRepository registrationRepository,
+    ILeaseEventRepository eventRepository,
+    ILeaseTemplateService templateService,
+    ILeaseESignService eSignService,
+    ILeaseRegistrationService registrationService,
+    IPropertyRepository propertyRepository,
+    ILogger<LeaseWorkflowService> logger) : ILeaseWorkflowService
+{
+    private static readonly HashSet<string> EuCitizenships =
+    [
+        "AT","BE","BG","CY","CZ","DE","DK","EE","ES","FI","FR","GR","HR",
+        "HU","IE","IT","LT","LU","LV","MT","NL","PL","PT","RO","SE","SI","SK"
+    ];
+
+    public async Task<LeaseContract> CreateDraftAsync(Guid propertyId, string ownerId, CreateLeaseRequest request)
+    {
+        var property = await propertyRepository.GetByIdAsync(propertyId)
+            ?? throw new InvalidOperationException($"Property {propertyId} not found.");
+
+        if (property.OwnerId != ownerId)
+            throw new UnauthorizedAccessException("Property does not belong to this owner.");
+
+        var hasApe = property.PropertyDocuments?.Any(d => d.DocumentType == DocumentType.Ape) ?? false;
+        if (!hasApe)
+            throw new InvalidOperationException("APE document is required before creating a lease contract.");
+
+        var lease = new LeaseContract
+        {
+            PropertyId = propertyId,
+            FiscalRegime = request.FiscalRegime,
+            StartDate = request.StartDate,
+            EndDate = request.EndDate,
+            MonthlyRent = request.MonthlyRent,
+            RegistrationDeadline = request.StartDate.AddDays(30),
+            DataRetentionUntil = request.StartDate.AddYears(10),
+            Parties = request.Parties.Select(p => new Party
+            {
+                Role = p.Role,
+                FirstName = p.FirstName,
+                LastName = p.LastName,
+                FiscalCode = p.FiscalCode,
+                Citizenship = p.Citizenship,
+                ContactEmail = p.ContactEmail,
+                IsExtraEU = !EuCitizenships.Contains(p.Citizenship.ToUpperInvariant())
+            }).ToList()
+        };
+
+        await leaseRepository.AddAsync(lease);
+        await eventRepository.AddAsync(new LeaseEvent
+        {
+            LeaseContractId = lease.Id,
+            EventType = LeaseEventType.Created
+        });
+
+        logger.LogInformation("Lease draft created. LeaseId={LeaseId} PropertyId={PropertyId}", lease.Id, propertyId);
+        return lease;
+    }
+
+    public async Task<SigningInitiatedResult> InitiateSigningAsync(Guid leaseId, string ownerId)
+    {
+        var lease = await GetVerifiedLeaseAsync(leaseId, ownerId);
+
+        if (lease.Status != LeaseStatus.Draft)
+            throw new InvalidOperationException($"Lease must be in Draft status to initiate signing. Current: {lease.Status}");
+
+        var pdfBytes = await templateService.GeneratePdfAsync(lease);
+        var signers = (await eSignService.InitiateSigningAsync(lease, pdfBytes)).ToList();
+
+        lease.Status = LeaseStatus.AwaitingSignature;
+        await leaseRepository.UpdateAsync(lease);
+        await eventRepository.AddAsync(new LeaseEvent
+        {
+            LeaseContractId = lease.Id,
+            EventType = LeaseEventType.SigningInitiated
+        });
+
+        logger.LogInformation("Signing initiated. LeaseId={LeaseId}", leaseId);
+        return new SigningInitiatedResult(lease.Id, lease.Status, signers);
+    }
+
+    public async Task HandleESignEventAsync(string providerPayload)
+    {
+        var esignEvent = await eSignService.ParseWebhookEventAsync(providerPayload);
+        var leases = await leaseRepository.GetByStatusAsync(LeaseStatus.AwaitingSignature);
+        var lease = leases.FirstOrDefault(); // provider must include lease ID in payload — simplified here
+
+        if (lease is null)
+        {
+            logger.LogWarning("ESign webhook received but no matching AwaitingSignature lease found.");
+            return;
+        }
+
+        if (esignEvent.AllSigned)
+        {
+            lease.Status = LeaseStatus.Signed;
+            lease.SignedPdfStoragePath = esignEvent.SignedDocumentPath;
+            await leaseRepository.UpdateAsync(lease);
+            await eventRepository.AddAsync(new LeaseEvent
+            {
+                LeaseContractId = lease.Id,
+                EventType = LeaseEventType.AllPartiesSigned
+            });
+            logger.LogInformation("All parties signed. LeaseId={LeaseId}", lease.Id);
+        }
+        else
+        {
+            await eventRepository.AddAsync(new LeaseEvent
+            {
+                LeaseContractId = lease.Id,
+                EventType = LeaseEventType.PartySignedDocument,
+                Payload = esignEvent.SignerEmail
+            });
+        }
+    }
+
+    public async Task<LeaseRegistration> TriggerRegistrationAsync(Guid leaseId, string ownerId)
+    {
+        var lease = await GetVerifiedLeaseAsync(leaseId, ownerId);
+
+        if (lease.Status != LeaseStatus.Signed)
+            throw new InvalidOperationException($"Lease must be Signed before registration. Current: {lease.Status}");
+
+        var externalId = await registrationService.SubmitRegistrationAsync(lease);
+
+        var registration = new LeaseRegistration
+        {
+            LeaseContractId = lease.Id,
+            Status = RegistrationStatus.SentToProvider,
+            ExternalRegistrationId = externalId,
+            SubmittedAt = DateTime.UtcNow
+        };
+
+        await registrationRepository.AddAsync(registration);
+
+        lease.Status = LeaseStatus.SentToProvider;
+        await leaseRepository.UpdateAsync(lease);
+        await eventRepository.AddAsync(new LeaseEvent
+        {
+            LeaseContractId = lease.Id,
+            EventType = LeaseEventType.RegistrationSubmitted
+        });
+
+        logger.LogInformation("Registration submitted. LeaseId={LeaseId} ExternalId={ExternalId}", leaseId, externalId);
+        return registration;
+    }
+
+    public async Task<LeaseRegistration?> GetRegistrationAsync(Guid leaseId, string ownerId)
+    {
+        await GetVerifiedLeaseAsync(leaseId, ownerId);
+        return await registrationRepository.GetByLeaseIdAsync(leaseId);
+    }
+
+    public async Task<Stream> GetRegistrationReceiptAsync(Guid leaseId, string ownerId)
+    {
+        await GetVerifiedLeaseAsync(leaseId, ownerId);
+        var registration = await registrationRepository.GetByLeaseIdAsync(leaseId)
+            ?? throw new InvalidOperationException("No registration found for this lease.");
+
+        if (registration.Status != RegistrationStatus.Registered || registration.ExternalRegistrationId is null)
+            throw new InvalidOperationException("Receipt is not available yet.");
+
+        return await registrationService.DownloadReceiptAsync(registration.ExternalRegistrationId);
+    }
+
+    public async Task<IEnumerable<LeaseContract>> GetOwnerLeasesAsync(string ownerId, Guid? propertyId = null)
+    {
+        var leases = await leaseRepository.GetByOwnerAsync(ownerId);
+        return propertyId.HasValue ? leases.Where(l => l.PropertyId == propertyId.Value) : leases;
+    }
+
+    public async Task<LeaseContract?> GetLeaseDetailAsync(Guid leaseId, string ownerId)
+    {
+        var lease = await leaseRepository.GetByIdWithDetailsAsync(leaseId);
+        if (lease is null || lease.Property.OwnerId != ownerId) return null;
+        return lease;
+    }
+
+    private async Task<LeaseContract> GetVerifiedLeaseAsync(Guid leaseId, string ownerId)
+    {
+        var lease = await leaseRepository.GetByIdWithDetailsAsync(leaseId)
+            ?? throw new InvalidOperationException($"Lease {leaseId} not found.");
+
+        if (lease.Property.OwnerId != ownerId)
+            throw new UnauthorizedAccessException("Lease does not belong to this owner.");
+
+        return lease;
+    }
+}

--- a/Casazen.Infrastructure/Services/LeaseWorkflowService.cs
+++ b/Casazen.Infrastructure/Services/LeaseWorkflowService.cs
@@ -35,6 +35,15 @@ public class LeaseWorkflowService(
         if (!hasApe)
             throw new InvalidOperationException("APE document is required before creating a lease contract.");
 
+        if (request.EndDate <= request.StartDate)
+            throw new InvalidOperationException("Lease end date must be after start date.");
+
+        var parties = request.Parties.ToList();
+        if (!parties.Any(p => p.Role == PartyRole.Landlord))
+            throw new InvalidOperationException("At least one Landlord party is required.");
+        if (!parties.Any(p => p.Role == PartyRole.Tenant))
+            throw new InvalidOperationException("At least one Tenant party is required.");
+
         var lease = new LeaseContract
         {
             PropertyId = propertyId,
@@ -44,7 +53,7 @@ public class LeaseWorkflowService(
             MonthlyRent = request.MonthlyRent,
             RegistrationDeadline = request.StartDate.AddDays(30),
             DataRetentionUntil = request.StartDate.AddYears(10),
-            Parties = request.Parties.Select(p => new Party
+            Parties = parties.Select(p => new Party
             {
                 Role = p.Role,
                 FirstName = p.FirstName,
@@ -75,9 +84,10 @@ public class LeaseWorkflowService(
             throw new InvalidOperationException($"Lease must be in Draft status to initiate signing. Current: {lease.Status}");
 
         var pdfBytes = await templateService.GeneratePdfAsync(lease);
-        var signers = (await eSignService.InitiateSigningAsync(lease, pdfBytes)).ToList();
+        var sessionResult = await eSignService.InitiateSigningAsync(lease, pdfBytes);
 
         lease.Status = LeaseStatus.AwaitingSignature;
+        lease.ExternalSigningSessionId = sessionResult.ExternalSessionId;
         await leaseRepository.UpdateAsync(lease);
         await eventRepository.AddAsync(new LeaseEvent
         {
@@ -85,19 +95,18 @@ public class LeaseWorkflowService(
             EventType = LeaseEventType.SigningInitiated
         });
 
-        logger.LogInformation("Signing initiated. LeaseId={LeaseId}", leaseId);
-        return new SigningInitiatedResult(lease.Id, lease.Status, signers);
+        logger.LogInformation("Signing initiated. LeaseId={LeaseId} SessionId={SessionId}", leaseId, sessionResult.ExternalSessionId);
+        return new SigningInitiatedResult(lease.Id, lease.Status, sessionResult.Signers);
     }
 
     public async Task HandleESignEventAsync(string providerPayload)
     {
         var esignEvent = await eSignService.ParseWebhookEventAsync(providerPayload);
-        var leases = await leaseRepository.GetByStatusAsync(LeaseStatus.AwaitingSignature);
-        var lease = leases.FirstOrDefault(); // provider must include lease ID in payload — simplified here
 
+        var lease = await leaseRepository.GetByExternalSigningSessionIdAsync(esignEvent.ExternalSessionId);
         if (lease is null)
         {
-            logger.LogWarning("ESign webhook received but no matching AwaitingSignature lease found.");
+            logger.LogWarning("ESign webhook received but no lease found for SessionId={SessionId}", esignEvent.ExternalSessionId);
             return;
         }
 
@@ -130,6 +139,10 @@ public class LeaseWorkflowService(
 
         if (lease.Status != LeaseStatus.Signed)
             throw new InvalidOperationException($"Lease must be Signed before registration. Current: {lease.Status}");
+
+        var existing = await registrationRepository.GetByLeaseIdAsync(lease.Id);
+        if (existing is not null)
+            throw new InvalidOperationException("Registration has already been submitted for this lease.");
 
         var externalId = await registrationService.SubmitRegistrationAsync(lease);
 
@@ -174,15 +187,12 @@ public class LeaseWorkflowService(
     }
 
     public async Task<IEnumerable<LeaseContract>> GetOwnerLeasesAsync(string ownerId, Guid? propertyId = null)
-    {
-        var leases = await leaseRepository.GetByOwnerAsync(ownerId);
-        return propertyId.HasValue ? leases.Where(l => l.PropertyId == propertyId.Value) : leases;
-    }
+        => await leaseRepository.GetByOwnerAsync(ownerId, propertyId);
 
     public async Task<LeaseContract?> GetLeaseDetailAsync(Guid leaseId, string ownerId)
     {
         var lease = await leaseRepository.GetByIdWithDetailsAsync(leaseId);
-        if (lease is null || lease.Property.OwnerId != ownerId) return null;
+        if (lease is null || lease.Property is null || lease.Property.OwnerId != ownerId) return null;
         return lease;
     }
 
@@ -191,7 +201,7 @@ public class LeaseWorkflowService(
         var lease = await leaseRepository.GetByIdWithDetailsAsync(leaseId)
             ?? throw new InvalidOperationException($"Lease {leaseId} not found.");
 
-        if (lease.Property.OwnerId != ownerId)
+        if (lease.Property is null || lease.Property.OwnerId != ownerId)
             throw new UnauthorizedAccessException("Lease does not belong to this owner.");
 
         return lease;

--- a/Casazen.Tests/Unit/OTA/Resilience/PollyPoliciesTests.cs
+++ b/Casazen.Tests/Unit/OTA/Resilience/PollyPoliciesTests.cs
@@ -41,7 +41,7 @@ public class PollyPoliciesTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
- [Fact(Skip = "Temporarily disabled - needs proper Polly configuration")]
+    [Fact(Skip = "Temporarily disabled - needs proper Polly configuration")]
     public async Task GetCircuitBreakerPolicy_ShouldOpenCircuitAfterFailures()
     {
         // Arrange

--- a/Casazen.Tests/Unit/Services/LeaseWorkflowServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/LeaseWorkflowServiceTests.cs
@@ -1,0 +1,241 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Enums;
+using Casazen.Core.Repositories;
+using Casazen.Core.Services;
+using Casazen.Infrastructure.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Services;
+
+public class LeaseWorkflowServiceTests
+{
+    private readonly Mock<ILeaseContractRepository> _leaseRepo = new();
+    private readonly Mock<ILeaseRegistrationRepository> _regRepo = new();
+    private readonly Mock<ILeaseEventRepository> _eventRepo = new();
+    private readonly Mock<ILeaseTemplateService> _templateService = new();
+    private readonly Mock<ILeaseESignService> _eSignService = new();
+    private readonly Mock<ILeaseRegistrationService> _regService = new();
+    private readonly Mock<IPropertyRepository> _propertyRepo = new();
+    private readonly LeaseWorkflowService _sut;
+
+    private static readonly string OwnerId = "auth0|owner123";
+    private static readonly Guid PropertyId = Guid.NewGuid();
+
+    public LeaseWorkflowServiceTests()
+    {
+        _sut = new LeaseWorkflowService(
+            _leaseRepo.Object,
+            _regRepo.Object,
+            _eventRepo.Object,
+            _templateService.Object,
+            _eSignService.Object,
+            _regService.Object,
+            _propertyRepo.Object,
+            new Mock<ILogger<LeaseWorkflowService>>().Object);
+    }
+
+    [Fact]
+    public async Task CreateDraftAsync_WithApePresent_ReturnsLeaseWithDraftStatus()
+    {
+        // Arrange
+        var property = BuildProperty(hasApe: true);
+        _propertyRepo.Setup(r => r.GetByIdAsync(PropertyId)).ReturnsAsync(property);
+        _leaseRepo.Setup(r => r.AddAsync(It.IsAny<LeaseContract>()))
+            .ReturnsAsync((LeaseContract l) => l);
+        _eventRepo.Setup(r => r.AddAsync(It.IsAny<LeaseEvent>()))
+            .ReturnsAsync((LeaseEvent e) => e);
+
+        var request = BuildCreateRequest();
+
+        // Act
+        var result = await _sut.CreateDraftAsync(PropertyId, OwnerId, request);
+
+        // Assert
+        Assert.Equal(LeaseStatus.Draft, result.Status);
+        Assert.Equal(request.MonthlyRent, result.MonthlyRent);
+        Assert.Equal(request.StartDate.AddDays(30), result.RegistrationDeadline);
+        Assert.Equal(request.StartDate.AddYears(10), result.DataRetentionUntil);
+        Assert.False(result.ErasureRequested);
+    }
+
+    [Fact]
+    public async Task CreateDraftAsync_WithoutApe_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var property = BuildProperty(hasApe: false);
+        _propertyRepo.Setup(r => r.GetByIdAsync(PropertyId)).ReturnsAsync(property);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.CreateDraftAsync(PropertyId, OwnerId, BuildCreateRequest()));
+    }
+
+    [Fact]
+    public async Task CreateDraftAsync_WhenOwnerMismatch_ThrowsUnauthorizedAccessException()
+    {
+        // Arrange
+        var property = BuildProperty(hasApe: true, ownerId: "auth0|different-owner");
+        _propertyRepo.Setup(r => r.GetByIdAsync(PropertyId)).ReturnsAsync(property);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            _sut.CreateDraftAsync(PropertyId, OwnerId, BuildCreateRequest()));
+    }
+
+    [Fact]
+    public async Task CreateDraftAsync_WithExtraEUTenant_SetsIsExtraEUTrue()
+    {
+        // Arrange
+        var property = BuildProperty(hasApe: true);
+        _propertyRepo.Setup(r => r.GetByIdAsync(PropertyId)).ReturnsAsync(property);
+        _leaseRepo.Setup(r => r.AddAsync(It.IsAny<LeaseContract>()))
+            .ReturnsAsync((LeaseContract l) => l);
+        _eventRepo.Setup(r => r.AddAsync(It.IsAny<LeaseEvent>()))
+            .ReturnsAsync((LeaseEvent e) => e);
+
+        var request = BuildCreateRequest(tenantCitizenship: "US");
+
+        // Act
+        var result = await _sut.CreateDraftAsync(PropertyId, OwnerId, request);
+
+        // Assert
+        var tenant = result.Parties.Single(p => p.Role == PartyRole.Tenant);
+        Assert.True(tenant.IsExtraEU);
+        Assert.True(result.HasExtraEUTenant);
+    }
+
+    [Fact]
+    public async Task CreateDraftAsync_WithItalianTenant_SetsIsExtraEUFalse()
+    {
+        // Arrange
+        var property = BuildProperty(hasApe: true);
+        _propertyRepo.Setup(r => r.GetByIdAsync(PropertyId)).ReturnsAsync(property);
+        _leaseRepo.Setup(r => r.AddAsync(It.IsAny<LeaseContract>()))
+            .ReturnsAsync((LeaseContract l) => l);
+        _eventRepo.Setup(r => r.AddAsync(It.IsAny<LeaseEvent>()))
+            .ReturnsAsync((LeaseEvent e) => e);
+
+        var request = BuildCreateRequest(tenantCitizenship: "IT");
+
+        // Act
+        var result = await _sut.CreateDraftAsync(PropertyId, OwnerId, request);
+
+        // Assert
+        var tenant = result.Parties.Single(p => p.Role == PartyRole.Tenant);
+        Assert.False(tenant.IsExtraEU);
+        Assert.False(result.HasExtraEUTenant);
+    }
+
+    [Fact]
+    public async Task InitiateSigningAsync_WhenStatusIsDraft_TransitionsToAwaitingSignature()
+    {
+        // Arrange
+        var lease = BuildLease(LeaseStatus.Draft);
+        _leaseRepo.Setup(r => r.GetByIdWithDetailsAsync(lease.Id)).ReturnsAsync(lease);
+        _leaseRepo.Setup(r => r.UpdateAsync(It.IsAny<LeaseContract>()))
+            .ReturnsAsync((LeaseContract l) => l);
+        _eventRepo.Setup(r => r.AddAsync(It.IsAny<LeaseEvent>()))
+            .ReturnsAsync((LeaseEvent e) => e);
+        _templateService.Setup(s => s.GeneratePdfAsync(lease))
+            .ReturnsAsync([0x25, 0x50, 0x44, 0x46]); // %PDF header
+        _eSignService.Setup(s => s.InitiateSigningAsync(lease, It.IsAny<byte[]>()))
+            .ReturnsAsync([]);
+
+        // Act
+        var result = await _sut.InitiateSigningAsync(lease.Id, OwnerId);
+
+        // Assert
+        Assert.Equal(LeaseStatus.AwaitingSignature, result.Status);
+    }
+
+    [Fact]
+    public async Task InitiateSigningAsync_WhenStatusIsNotDraft_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var lease = BuildLease(LeaseStatus.Signed);
+        _leaseRepo.Setup(r => r.GetByIdWithDetailsAsync(lease.Id)).ReturnsAsync(lease);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.InitiateSigningAsync(lease.Id, OwnerId));
+    }
+
+    [Fact]
+    public async Task TriggerRegistrationAsync_WhenStatusIsSigned_SubmitsAndTransitionsStatus()
+    {
+        // Arrange
+        var lease = BuildLease(LeaseStatus.Signed);
+        _leaseRepo.Setup(r => r.GetByIdWithDetailsAsync(lease.Id)).ReturnsAsync(lease);
+        _leaseRepo.Setup(r => r.UpdateAsync(It.IsAny<LeaseContract>()))
+            .ReturnsAsync((LeaseContract l) => l);
+        _regRepo.Setup(r => r.AddAsync(It.IsAny<LeaseRegistration>()))
+            .ReturnsAsync((LeaseRegistration r) => r);
+        _eventRepo.Setup(r => r.AddAsync(It.IsAny<LeaseEvent>()))
+            .ReturnsAsync((LeaseEvent e) => e);
+        _regService.Setup(s => s.SubmitRegistrationAsync(lease))
+            .ReturnsAsync("RLI-EXTERNAL-001");
+
+        // Act
+        var registration = await _sut.TriggerRegistrationAsync(lease.Id, OwnerId);
+
+        // Assert
+        Assert.Equal(RegistrationStatus.SentToProvider, registration.Status);
+        Assert.Equal("RLI-EXTERNAL-001", registration.ExternalRegistrationId);
+        Assert.NotNull(registration.SubmittedAt);
+    }
+
+    [Fact]
+    public async Task TriggerRegistrationAsync_WhenStatusIsNotSigned_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var lease = BuildLease(LeaseStatus.Draft);
+        _leaseRepo.Setup(r => r.GetByIdWithDetailsAsync(lease.Id)).ReturnsAsync(lease);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.TriggerRegistrationAsync(lease.Id, OwnerId));
+    }
+
+    // Helpers
+
+    private static Property BuildProperty(bool hasApe, string? ownerId = null) => new()
+    {
+        Id = PropertyId,
+        OwnerId = ownerId ?? OwnerId,
+        Name = "Test Property",
+        PropertyDocuments = hasApe
+            ? [new PropertyDocument { DocumentType = DocumentType.Ape, FileName = "ape.pdf", StorageUrl = "/ape.pdf", UploadedBy = OwnerId }]
+            : []
+    };
+
+    private static CreateLeaseRequest BuildCreateRequest(string tenantCitizenship = "IT") => new(
+        FiscalRegime: FiscalRegime.CedolareSecca,
+        StartDate: new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        EndDate: new DateTime(2030, 8, 31, 0, 0, 0, DateTimeKind.Utc),
+        MonthlyRent: 1200.00m,
+        Parties:
+        [
+            new CreatePartyRequest(PartyRole.Landlord, "Mario", "Rossi", "RSSMRA80A01H501Z", "IT", "mario@example.com"),
+            new CreatePartyRequest(PartyRole.Tenant, "John", "Doe", "DOEJHN90B02Z123X", tenantCitizenship, "john@example.com")
+        ]);
+
+    private static LeaseContract BuildLease(LeaseStatus status)
+    {
+        var property = new Property { Id = PropertyId, OwnerId = OwnerId, Name = "Test Property" };
+        return new LeaseContract
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = PropertyId,
+            Property = property,
+            Status = status,
+            FiscalRegime = FiscalRegime.CedolareSecca,
+            StartDate = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2030, 8, 31, 0, 0, 0, DateTimeKind.Utc),
+            MonthlyRent = 1200m,
+            Parties = []
+        };
+    }
+}

--- a/Casazen.Tests/Unit/Services/LeaseWorkflowServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/LeaseWorkflowServiceTests.cs
@@ -142,7 +142,7 @@ public class LeaseWorkflowServiceTests
         _templateService.Setup(s => s.GeneratePdfAsync(lease))
             .ReturnsAsync([0x25, 0x50, 0x44, 0x46]); // %PDF header
         _eSignService.Setup(s => s.InitiateSigningAsync(lease, It.IsAny<byte[]>()))
-            .ReturnsAsync([]);
+            .ReturnsAsync(new SigningSessionResult("session-abc", []));
 
         // Act
         var result = await _sut.InitiateSigningAsync(lease.Id, OwnerId);
@@ -171,6 +171,7 @@ public class LeaseWorkflowServiceTests
         _leaseRepo.Setup(r => r.GetByIdWithDetailsAsync(lease.Id)).ReturnsAsync(lease);
         _leaseRepo.Setup(r => r.UpdateAsync(It.IsAny<LeaseContract>()))
             .ReturnsAsync((LeaseContract l) => l);
+        _regRepo.Setup(r => r.GetByLeaseIdAsync(lease.Id)).ReturnsAsync((LeaseRegistration?)null);
         _regRepo.Setup(r => r.AddAsync(It.IsAny<LeaseRegistration>()))
             .ReturnsAsync((LeaseRegistration r) => r);
         _eventRepo.Setup(r => r.AddAsync(It.IsAny<LeaseEvent>()))
@@ -197,6 +198,126 @@ public class LeaseWorkflowServiceTests
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             _sut.TriggerRegistrationAsync(lease.Id, OwnerId));
+    }
+
+    [Fact]
+    public async Task TriggerRegistrationAsync_WhenAlreadySubmitted_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var lease = BuildLease(LeaseStatus.Signed);
+        _leaseRepo.Setup(r => r.GetByIdWithDetailsAsync(lease.Id)).ReturnsAsync(lease);
+        _regRepo.Setup(r => r.GetByLeaseIdAsync(lease.Id))
+            .ReturnsAsync(new LeaseRegistration { LeaseContractId = lease.Id, Status = RegistrationStatus.SentToProvider });
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.TriggerRegistrationAsync(lease.Id, OwnerId));
+    }
+
+    [Fact]
+    public async Task InitiateSigningAsync_WhenAlreadyAwaitingSignature_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var lease = BuildLease(LeaseStatus.AwaitingSignature);
+        _leaseRepo.Setup(r => r.GetByIdWithDetailsAsync(lease.Id)).ReturnsAsync(lease);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.InitiateSigningAsync(lease.Id, OwnerId));
+    }
+
+    [Fact]
+    public async Task GetLeaseDetailAsync_WhenWrongOwner_ReturnsNull()
+    {
+        // Arrange
+        var lease = BuildLease(LeaseStatus.Draft); // Property.OwnerId = OwnerId
+        _leaseRepo.Setup(r => r.GetByIdWithDetailsAsync(lease.Id)).ReturnsAsync(lease);
+
+        // Act
+        var result = await _sut.GetLeaseDetailAsync(lease.Id, "auth0|different-owner");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task HandleESignEventAsync_WhenNoMatchingSession_LogsAndReturns()
+    {
+        // Arrange
+        var esignEvent = new ESignEvent("unknown-session", "all_signed", null, true, null);
+        _eSignService.Setup(s => s.ParseWebhookEventAsync("payload")).ReturnsAsync(esignEvent);
+        _leaseRepo.Setup(r => r.GetByExternalSigningSessionIdAsync("unknown-session"))
+            .ReturnsAsync((LeaseContract?)null);
+
+        // Act — should not throw
+        await _sut.HandleESignEventAsync("payload");
+
+        // Assert — no update calls made
+        _leaseRepo.Verify(r => r.UpdateAsync(It.IsAny<LeaseContract>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleESignEventAsync_WhenAllSigned_TransitionsLeaseToSigned()
+    {
+        // Arrange
+        var lease = BuildLease(LeaseStatus.AwaitingSignature);
+        lease.ExternalSigningSessionId = "session-xyz";
+        var esignEvent = new ESignEvent("session-xyz", "all_signed", null, AllSigned: true, "/path/signed.pdf");
+        _eSignService.Setup(s => s.ParseWebhookEventAsync("payload")).ReturnsAsync(esignEvent);
+        _leaseRepo.Setup(r => r.GetByExternalSigningSessionIdAsync("session-xyz")).ReturnsAsync(lease);
+        _leaseRepo.Setup(r => r.UpdateAsync(It.IsAny<LeaseContract>()))
+            .ReturnsAsync((LeaseContract l) => l);
+        _eventRepo.Setup(r => r.AddAsync(It.IsAny<LeaseEvent>()))
+            .ReturnsAsync((LeaseEvent e) => e);
+
+        // Act
+        await _sut.HandleESignEventAsync("payload");
+
+        // Assert
+        Assert.Equal(LeaseStatus.Signed, lease.Status);
+        Assert.Equal("/path/signed.pdf", lease.SignedPdfStoragePath);
+    }
+
+    [Fact]
+    public async Task CreateDraftAsync_WhenEndDateBeforeStartDate_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var property = BuildProperty(hasApe: true);
+        _propertyRepo.Setup(r => r.GetByIdAsync(PropertyId)).ReturnsAsync(property);
+
+        var request = new CreateLeaseRequest(
+            FiscalRegime: FiscalRegime.CedolareSecca,
+            StartDate: new DateTime(2030, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate: new DateTime(2026, 8, 31, 0, 0, 0, DateTimeKind.Utc), // before StartDate
+            MonthlyRent: 1200.00m,
+            Parties:
+            [
+                new CreatePartyRequest(PartyRole.Landlord, "Mario", "Rossi", "RSSMRA80A01H501Z", "IT", "mario@example.com"),
+                new CreatePartyRequest(PartyRole.Tenant, "John", "Doe", "DOEJHN90B02Z123X", "IT", "john@example.com")
+            ]);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.CreateDraftAsync(PropertyId, OwnerId, request));
+    }
+
+    [Fact]
+    public async Task CreateDraftAsync_WhenNoTenant_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var property = BuildProperty(hasApe: true);
+        _propertyRepo.Setup(r => r.GetByIdAsync(PropertyId)).ReturnsAsync(property);
+
+        var request = new CreateLeaseRequest(
+            FiscalRegime: FiscalRegime.CedolareSecca,
+            StartDate: new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate: new DateTime(2030, 8, 31, 0, 0, 0, DateTimeKind.Utc),
+            MonthlyRent: 1200.00m,
+            Parties: [new CreatePartyRequest(PartyRole.Landlord, "Mario", "Rossi", "RSSMRA80A01H501Z", "IT", "mario@example.com")]);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.CreateDraftAsync(PropertyId, OwnerId, request));
     }
 
     // Helpers

--- a/Casazen.Web/BackgroundJobs/ESignWebhookJob.cs
+++ b/Casazen.Web/BackgroundJobs/ESignWebhookJob.cs
@@ -1,0 +1,21 @@
+using Casazen.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Web.BackgroundJobs;
+
+public class ESignWebhookJob(ILeaseWorkflowService leaseWorkflowService, ILogger<ESignWebhookJob> logger)
+{
+    public async Task ProcessEventAsync(string payload)
+    {
+        logger.LogInformation("Processing e-sign webhook event");
+        try
+        {
+            await leaseWorkflowService.HandleESignEventAsync(payload);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error processing e-sign webhook event");
+            throw;
+        }
+    }
+}

--- a/Casazen.Web/BackgroundJobs/LeaseRegistrationStatusPollingJob.cs
+++ b/Casazen.Web/BackgroundJobs/LeaseRegistrationStatusPollingJob.cs
@@ -15,6 +15,7 @@ public class LeaseRegistrationStatusPollingJob(
     ILogger<LeaseRegistrationStatusPollingJob> logger)
 {
     [AutomaticRetry(Attempts = 3)]
+    [DisableConcurrentExecution(timeoutInSeconds: 60)]
     public async Task ExecuteAsync()
     {
         var pending = await registrationRepository.GetByStatusAsync(RegistrationStatus.SentToProvider);

--- a/Casazen.Web/BackgroundJobs/LeaseRegistrationStatusPollingJob.cs
+++ b/Casazen.Web/BackgroundJobs/LeaseRegistrationStatusPollingJob.cs
@@ -1,0 +1,61 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Repositories;
+using Casazen.Core.Services;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Web.BackgroundJobs;
+
+public class LeaseRegistrationStatusPollingJob(
+    ILeaseContractRepository leaseRepository,
+    ILeaseRegistrationRepository registrationRepository,
+    ILeaseRegistrationService registrationService,
+    ILeaseEventRepository eventRepository,
+    ILogger<LeaseRegistrationStatusPollingJob> logger)
+{
+    [AutomaticRetry(Attempts = 3)]
+    public async Task ExecuteAsync()
+    {
+        var pending = await registrationRepository.GetByStatusAsync(RegistrationStatus.SentToProvider);
+        logger.LogInformation("Polling registration status for {Count} registrations", pending.Count());
+
+        foreach (var registration in pending)
+        {
+            try
+            {
+                if (registration.ExternalRegistrationId is null) continue;
+
+                var statusResult = await registrationService.PollStatusAsync(registration.ExternalRegistrationId);
+
+                if (!statusResult.IsConfirmed) continue;
+
+                registration.Status = RegistrationStatus.Registered;
+                registration.RegistrationCode = statusResult.RegistrationCode;
+                registration.ConfirmedAt = DateTime.UtcNow;
+                await registrationRepository.UpdateAsync(registration);
+
+                var lease = await leaseRepository.GetByIdAsync(registration.LeaseContractId);
+                if (lease is not null)
+                {
+                    lease.Status = LeaseStatus.Registered;
+                    await leaseRepository.UpdateAsync(lease);
+                    await eventRepository.AddAsync(new LeaseEvent
+                    {
+                        LeaseContractId = lease.Id,
+                        EventType = LeaseEventType.RegistrationConfirmed,
+                        Payload = statusResult.RegistrationCode
+                    });
+                }
+
+                logger.LogInformation("Registration confirmed. LeaseId={LeaseId} Code={Code}",
+                    registration.LeaseContractId, statusResult.RegistrationCode);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error polling registration status for ExternalId={ExternalId}",
+                    registration.ExternalRegistrationId);
+            }
+        }
+    }
+}

--- a/Casazen.Web/BackgroundJobs/LeaseSignStatusPollingJob.cs
+++ b/Casazen.Web/BackgroundJobs/LeaseSignStatusPollingJob.cs
@@ -1,6 +1,5 @@
 using Casazen.Core.Entities.Enums;
 using Casazen.Core.Repositories;
-using Casazen.Core.Services;
 using Hangfire;
 using Microsoft.Extensions.Logging;
 
@@ -8,28 +7,21 @@ namespace Casazen.Web.BackgroundJobs;
 
 public class LeaseSignStatusPollingJob(
     ILeaseContractRepository leaseRepository,
-    ILeaseESignService eSignService,
-    ILeaseWorkflowService leaseWorkflowService,
     ILogger<LeaseSignStatusPollingJob> logger)
 {
     [AutomaticRetry(Attempts = 3)]
     public async Task ExecuteAsync()
     {
         var pendingLeases = await leaseRepository.GetByStatusAsync(LeaseStatus.AwaitingSignature);
-        logger.LogInformation("Polling sign status for {Count} leases", pendingLeases.Count());
+        logger.LogInformation("Polling sign status for {Count} leases awaiting signature", pendingLeases.Count());
 
         foreach (var lease in pendingLeases)
         {
-            try
-            {
-                // Polling is handled by the e-sign provider webhook in normal flow.
-                // This job catches cases where the webhook was not received.
-                logger.LogInformation("Checking sign status for LeaseId={LeaseId}", lease.Id);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error polling sign status for LeaseId={LeaseId}", lease.Id);
-            }
+            // Polling is handled by the e-sign provider webhook in the normal flow.
+            // TODO(#177): implement active status poll when e-sign provider is selected.
+            // For now, log so operators can detect stuck leases.
+            logger.LogInformation("Lease awaiting signature. LeaseId={LeaseId} Since={Since:O}",
+                lease.Id, lease.UpdatedAt);
         }
     }
 }

--- a/Casazen.Web/BackgroundJobs/LeaseSignStatusPollingJob.cs
+++ b/Casazen.Web/BackgroundJobs/LeaseSignStatusPollingJob.cs
@@ -1,0 +1,35 @@
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Repositories;
+using Casazen.Core.Services;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Web.BackgroundJobs;
+
+public class LeaseSignStatusPollingJob(
+    ILeaseContractRepository leaseRepository,
+    ILeaseESignService eSignService,
+    ILeaseWorkflowService leaseWorkflowService,
+    ILogger<LeaseSignStatusPollingJob> logger)
+{
+    [AutomaticRetry(Attempts = 3)]
+    public async Task ExecuteAsync()
+    {
+        var pendingLeases = await leaseRepository.GetByStatusAsync(LeaseStatus.AwaitingSignature);
+        logger.LogInformation("Polling sign status for {Count} leases", pendingLeases.Count());
+
+        foreach (var lease in pendingLeases)
+        {
+            try
+            {
+                // Polling is handled by the e-sign provider webhook in normal flow.
+                // This job catches cases where the webhook was not received.
+                logger.LogInformation("Checking sign status for LeaseId={LeaseId}", lease.Id);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error polling sign status for LeaseId={LeaseId}", lease.Id);
+            }
+        }
+    }
+}

--- a/Casazen.Web/Controllers/LeasesController.cs
+++ b/Casazen.Web/Controllers/LeasesController.cs
@@ -1,0 +1,146 @@
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Casazen.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(Policy = "LongTermLandlord")]
+public class LeasesController(ILeaseWorkflowService leaseService, ILogger<LeasesController> logger) : ControllerBase
+{
+    private string OwnerId => User.FindFirstValue(ClaimTypes.NameIdentifier)
+        ?? User.FindFirstValue("sub")
+        ?? throw new UnauthorizedAccessException("Owner ID claim not found.");
+
+    /// <summary>List all lease contracts for the authenticated owner.</summary>
+    [HttpGet]
+    public async Task<IActionResult> GetAll([FromQuery] Guid? propertyId = null)
+    {
+        var leases = await leaseService.GetOwnerLeasesAsync(OwnerId, propertyId);
+        return Ok(leases);
+    }
+
+    /// <summary>Get full lease contract detail including parties, registration, and events.</summary>
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var lease = await leaseService.GetLeaseDetailAsync(id, OwnerId);
+        return lease is null ? NotFound() : Ok(lease);
+    }
+
+    /// <summary>Create a new lease contract draft.</summary>
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateLeaseDto dto)
+    {
+        try
+        {
+            var request = new CreateLeaseRequest(
+                dto.FiscalRegime,
+                dto.StartDate,
+                dto.EndDate,
+                dto.MonthlyRent,
+                dto.Parties.Select(p => new CreatePartyRequest(
+                    p.Role, p.FirstName, p.LastName, p.FiscalCode, p.Citizenship, p.ContactEmail)));
+
+            var lease = await leaseService.CreateDraftAsync(dto.PropertyId, OwnerId, request);
+            return CreatedAtAction(nameof(GetById), new { id = lease.Id }, lease);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Forbid();
+        }
+    }
+
+    /// <summary>Generate PDF/A and initiate digital signing for a lease in Draft status.</summary>
+    [HttpPost("{id:guid}/signing")]
+    public async Task<IActionResult> InitiateSigning(Guid id)
+    {
+        try
+        {
+            var result = await leaseService.InitiateSigningAsync(id, OwnerId);
+            return Ok(result);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Forbid();
+        }
+    }
+
+    /// <summary>Submit a Signed lease to Openapi.it Docuengine for RLI registration (async).</summary>
+    [HttpPost("{id:guid}/registration")]
+    public async Task<IActionResult> TriggerRegistration(Guid id)
+    {
+        try
+        {
+            var registration = await leaseService.TriggerRegistrationAsync(id, OwnerId);
+            return Accepted(new
+            {
+                leaseId = id,
+                registrationStatus = registration.Status.ToString(),
+                message = $"Registration submitted. Check GET /api/leases/{id}/registration for status."
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Forbid();
+        }
+    }
+
+    /// <summary>Get current RLI registration status.</summary>
+    [HttpGet("{id:guid}/registration")]
+    public async Task<IActionResult> GetRegistration(Guid id)
+    {
+        var registration = await leaseService.GetRegistrationAsync(id, OwnerId);
+        return registration is null ? NotFound() : Ok(registration);
+    }
+
+    /// <summary>Download the official RLI registration receipt (PDF).</summary>
+    [HttpGet("{id:guid}/registration/receipt")]
+    public async Task<IActionResult> GetReceipt(Guid id)
+    {
+        try
+        {
+            var stream = await leaseService.GetRegistrationReceiptAsync(id, OwnerId);
+            return File(stream, "application/pdf", $"receipt-{id}.pdf");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Forbid();
+        }
+    }
+}
+
+public record CreateLeaseDto(
+    Guid PropertyId,
+    FiscalRegime FiscalRegime,
+    DateTime StartDate,
+    DateTime EndDate,
+    decimal MonthlyRent,
+    IEnumerable<CreatePartyDto> Parties);
+
+public record CreatePartyDto(
+    PartyRole Role,
+    string FirstName,
+    string LastName,
+    string FiscalCode,
+    string Citizenship,
+    string ContactEmail);

--- a/Casazen.Web/Controllers/LeasesController.cs
+++ b/Casazen.Web/Controllers/LeasesController.cs
@@ -1,25 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
 using Casazen.Core.Entities.Enums;
 using Casazen.Core.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Security.Claims;
 
 namespace Casazen.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "LongTermLandlord")]
-public class LeasesController(ILeaseWorkflowService leaseService, ILogger<LeasesController> logger) : ControllerBase
+public class LeasesController(ILeaseWorkflowService leaseService) : ControllerBase
 {
-    private string OwnerId => User.FindFirstValue(ClaimTypes.NameIdentifier)
-        ?? User.FindFirstValue("sub")
-        ?? throw new UnauthorizedAccessException("Owner ID claim not found.");
+    private string? GetOwnerId() =>
+        User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.FindFirstValue("sub");
 
     /// <summary>List all lease contracts for the authenticated owner.</summary>
     [HttpGet]
     public async Task<IActionResult> GetAll([FromQuery] Guid? propertyId = null)
     {
-        var leases = await leaseService.GetOwnerLeasesAsync(OwnerId, propertyId);
+        if (GetOwnerId() is not { } ownerId) return Unauthorized();
+        var leases = await leaseService.GetOwnerLeasesAsync(ownerId, propertyId);
         return Ok(leases);
     }
 
@@ -27,7 +28,8 @@ public class LeasesController(ILeaseWorkflowService leaseService, ILogger<Leases
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> GetById(Guid id)
     {
-        var lease = await leaseService.GetLeaseDetailAsync(id, OwnerId);
+        if (GetOwnerId() is not { } ownerId) return Unauthorized();
+        var lease = await leaseService.GetLeaseDetailAsync(id, ownerId);
         return lease is null ? NotFound() : Ok(lease);
     }
 
@@ -35,6 +37,7 @@ public class LeasesController(ILeaseWorkflowService leaseService, ILogger<Leases
     [HttpPost]
     public async Task<IActionResult> Create([FromBody] CreateLeaseDto dto)
     {
+        if (GetOwnerId() is not { } ownerId) return Unauthorized();
         try
         {
             var request = new CreateLeaseRequest(
@@ -45,7 +48,7 @@ public class LeasesController(ILeaseWorkflowService leaseService, ILogger<Leases
                 dto.Parties.Select(p => new CreatePartyRequest(
                     p.Role, p.FirstName, p.LastName, p.FiscalCode, p.Citizenship, p.ContactEmail)));
 
-            var lease = await leaseService.CreateDraftAsync(dto.PropertyId, OwnerId, request);
+            var lease = await leaseService.CreateDraftAsync(dto.PropertyId, ownerId, request);
             return CreatedAtAction(nameof(GetById), new { id = lease.Id }, lease);
         }
         catch (InvalidOperationException ex)
@@ -62,9 +65,10 @@ public class LeasesController(ILeaseWorkflowService leaseService, ILogger<Leases
     [HttpPost("{id:guid}/signing")]
     public async Task<IActionResult> InitiateSigning(Guid id)
     {
+        if (GetOwnerId() is not { } ownerId) return Unauthorized();
         try
         {
-            var result = await leaseService.InitiateSigningAsync(id, OwnerId);
+            var result = await leaseService.InitiateSigningAsync(id, ownerId);
             return Ok(result);
         }
         catch (InvalidOperationException ex)
@@ -81,9 +85,10 @@ public class LeasesController(ILeaseWorkflowService leaseService, ILogger<Leases
     [HttpPost("{id:guid}/registration")]
     public async Task<IActionResult> TriggerRegistration(Guid id)
     {
+        if (GetOwnerId() is not { } ownerId) return Unauthorized();
         try
         {
-            var registration = await leaseService.TriggerRegistrationAsync(id, OwnerId);
+            var registration = await leaseService.TriggerRegistrationAsync(id, ownerId);
             return Accepted(new
             {
                 leaseId = id,
@@ -105,7 +110,8 @@ public class LeasesController(ILeaseWorkflowService leaseService, ILogger<Leases
     [HttpGet("{id:guid}/registration")]
     public async Task<IActionResult> GetRegistration(Guid id)
     {
-        var registration = await leaseService.GetRegistrationAsync(id, OwnerId);
+        if (GetOwnerId() is not { } ownerId) return Unauthorized();
+        var registration = await leaseService.GetRegistrationAsync(id, ownerId);
         return registration is null ? NotFound() : Ok(registration);
     }
 
@@ -113,9 +119,10 @@ public class LeasesController(ILeaseWorkflowService leaseService, ILogger<Leases
     [HttpGet("{id:guid}/registration/receipt")]
     public async Task<IActionResult> GetReceipt(Guid id)
     {
+        if (GetOwnerId() is not { } ownerId) return Unauthorized();
         try
         {
-            var stream = await leaseService.GetRegistrationReceiptAsync(id, OwnerId);
+            var stream = await leaseService.GetRegistrationReceiptAsync(id, ownerId);
             return File(stream, "application/pdf", $"receipt-{id}.pdf");
         }
         catch (InvalidOperationException ex)
@@ -130,17 +137,17 @@ public class LeasesController(ILeaseWorkflowService leaseService, ILogger<Leases
 }
 
 public record CreateLeaseDto(
-    Guid PropertyId,
-    FiscalRegime FiscalRegime,
-    DateTime StartDate,
-    DateTime EndDate,
-    decimal MonthlyRent,
-    IEnumerable<CreatePartyDto> Parties);
+    [property: Required] Guid PropertyId,
+    [property: Required] FiscalRegime FiscalRegime,
+    [property: Required] DateTime StartDate,
+    [property: Required] DateTime EndDate,
+    [property: Range(0.01, 1_000_000.0)] decimal MonthlyRent,
+    [property: Required, MinLength(1)] IEnumerable<CreatePartyDto> Parties);
 
 public record CreatePartyDto(
-    PartyRole Role,
-    string FirstName,
-    string LastName,
-    string FiscalCode,
-    string Citizenship,
-    string ContactEmail);
+    [property: Required] PartyRole Role,
+    [property: Required, MaxLength(100), MinLength(1)] string FirstName,
+    [property: Required, MaxLength(100), MinLength(1)] string LastName,
+    [property: Required, MaxLength(16), MinLength(1)] string FiscalCode,
+    [property: Required, MaxLength(2), MinLength(2)] string Citizenship,
+    [property: Required, EmailAddress] string ContactEmail);

--- a/Casazen.Web/Controllers/WebhooksController.cs
+++ b/Casazen.Web/Controllers/WebhooksController.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Casazen.Core.Services;
 using Casazen.Web.BackgroundJobs;
 using Hangfire;
@@ -130,21 +131,37 @@ public class WebhooksController : ControllerBase
         try
         {
             var payload = await new StreamReader(HttpContext.Request.Body).ReadToEndAsync();
-            var signatureHeader = Request.Headers["X-ESign-Signature"].ToString();
+
             var webhookSecret = _configuration["ESign:WebhookSecret"];
-
-            if (!string.IsNullOrEmpty(webhookSecret) && !string.IsNullOrEmpty(signatureHeader))
+            if (string.IsNullOrEmpty(webhookSecret))
             {
-                var expectedSig = Convert.ToHexString(
-                    System.Security.Cryptography.HMACSHA256.HashData(
-                        System.Text.Encoding.UTF8.GetBytes(webhookSecret),
-                        System.Text.Encoding.UTF8.GetBytes(payload)));
+                _logger.LogError("ESign webhook secret not configured");
+                return StatusCode(500, "Webhook secret not configured");
+            }
 
-                if (!string.Equals(signatureHeader, expectedSig, StringComparison.OrdinalIgnoreCase))
-                {
-                    _logger.LogWarning("Invalid e-sign webhook signature");
-                    return BadRequest("Invalid signature");
-                }
+            var signatureHeader = Request.Headers["X-ESign-Signature"].ToString();
+            if (string.IsNullOrEmpty(signatureHeader))
+            {
+                _logger.LogWarning("ESign webhook received without signature header");
+                return Unauthorized("Missing signature");
+            }
+
+            byte[] providedBytes;
+            try { providedBytes = Convert.FromHexString(signatureHeader); }
+            catch (FormatException)
+            {
+                _logger.LogWarning("ESign webhook signature header is not valid hex");
+                return Unauthorized("Invalid signature");
+            }
+
+            var expectedBytes = HMACSHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(webhookSecret),
+                System.Text.Encoding.UTF8.GetBytes(payload));
+
+            if (!CryptographicOperations.FixedTimeEquals(providedBytes, expectedBytes))
+            {
+                _logger.LogWarning("Invalid e-sign webhook signature");
+                return Unauthorized("Invalid signature");
             }
 
             _backgroundJobClient.Enqueue<ESignWebhookJob>(job =>

--- a/Casazen.Web/Controllers/WebhooksController.cs
+++ b/Casazen.Web/Controllers/WebhooksController.cs
@@ -1,3 +1,4 @@
+using Casazen.Core.Services;
 using Casazen.Web.BackgroundJobs;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
@@ -15,14 +16,18 @@ public class WebhooksController : ControllerBase
     private readonly IConfiguration _configuration;
     private readonly ILogger<WebhooksController> _logger;
 
+    private readonly ILeaseWorkflowService _leaseWorkflowService;
+
     public WebhooksController(
         IBackgroundJobClient backgroundJobClient,
         IConfiguration configuration,
-        ILogger<WebhooksController> logger)
+        ILogger<WebhooksController> logger,
+        ILeaseWorkflowService leaseWorkflowService)
     {
         _backgroundJobClient = backgroundJobClient;
         _configuration = configuration;
         _logger = logger;
+        _leaseWorkflowService = leaseWorkflowService;
     }
 
     /// <summary>
@@ -111,6 +116,46 @@ public class WebhooksController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error processing {Platform} webhook", platform);
+            return StatusCode(500, "Internal server error");
+        }
+    }
+
+    /// <summary>
+    /// Handles e-signature provider callbacks (signing completed/partially signed).
+    /// Validates provider signature header and queues background processing.
+    /// </summary>
+    [HttpPost("esign")]
+    public async Task<IActionResult> ESignWebhook()
+    {
+        try
+        {
+            var payload = await new StreamReader(HttpContext.Request.Body).ReadToEndAsync();
+            var signatureHeader = Request.Headers["X-ESign-Signature"].ToString();
+            var webhookSecret = _configuration["ESign:WebhookSecret"];
+
+            if (!string.IsNullOrEmpty(webhookSecret) && !string.IsNullOrEmpty(signatureHeader))
+            {
+                var expectedSig = Convert.ToHexString(
+                    System.Security.Cryptography.HMACSHA256.HashData(
+                        System.Text.Encoding.UTF8.GetBytes(webhookSecret),
+                        System.Text.Encoding.UTF8.GetBytes(payload)));
+
+                if (!string.Equals(signatureHeader, expectedSig, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning("Invalid e-sign webhook signature");
+                    return BadRequest("Invalid signature");
+                }
+            }
+
+            _backgroundJobClient.Enqueue<ESignWebhookJob>(job =>
+                job.ProcessEventAsync(payload));
+
+            _logger.LogInformation("Queued e-sign webhook event for background processing");
+            return Ok(new { received = true });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing e-sign webhook");
             return StatusCode(500, "Internal server error");
         }
     }

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -108,7 +108,8 @@ public static class ServiceCollectionExtensions
     {
         services.AddAuthorizationBuilder()
             .AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"))
-            .AddPolicy("PropertyOwner", policy => policy.RequireAuthenticatedUser());
+            .AddPolicy("PropertyOwner", policy => policy.RequireAuthenticatedUser())
+            .AddPolicy("LongTermLandlord", policy => policy.RequireRole("LongTermLandlord"));
 
         return services;
     }

--- a/Casazen.Web/Program.cs
+++ b/Casazen.Web/Program.cs
@@ -59,6 +59,10 @@ builder.Services.AddScoped<IBookingRepository, BookingRepository>();
 builder.Services.AddScoped<ITouristTaxRateRepository, TouristTaxRateRepository>();
 builder.Services.AddScoped<IPricingAdapterConfigRepository, PricingAdapterConfigRepository>();
 builder.Services.AddScoped<IPricingHistoryRepository, PricingHistoryRepository>();
+// Lease repositories
+builder.Services.AddScoped<ILeaseContractRepository, LeaseContractRepository>();
+builder.Services.AddScoped<ILeaseRegistrationRepository, LeaseRegistrationRepository>();
+builder.Services.AddScoped<ILeaseEventRepository, LeaseEventRepository>();
 
 // External Services
 builder.Services.AddSendGrid(options =>
@@ -83,6 +87,12 @@ builder.Services.AddScoped<IGdprService, GdprService>();
 builder.Services.AddScoped<IAlloggiatiWebService, AlloggiatiWebService>();
 builder.Services.AddScoped<IPublicHolidayService, PublicHolidayService>();
 builder.Services.AddScoped<IPricingAdapterService, PricingAdapterService>();
+// Lease services
+builder.Services.AddScoped<ILeaseWorkflowService, LeaseWorkflowService>();
+builder.Services.AddScoped<ILeaseTemplateService, LeaseContractTemplateService>();
+builder.Services.AddScoped<ILeaseESignService, LeaseESignHttpAdapter>();
+builder.Services.AddScoped<ILeaseRegistrationService, OpenapiLeaseRegistrationProvider>();
+builder.Services.AddHttpClient("Openapi");
 
 // OTA Integrations with resilience patterns
 builder.Services.AddCasazenOtaIntegrations(builder.Configuration);
@@ -102,6 +112,10 @@ builder.Services.AddScoped<EmailQueueProcessor>();
 builder.Services.AddScoped<StripeWebhookJob>();
 builder.Services.AddScoped<AlloggiatiWebReportJob>();
 builder.Services.AddScoped<GdprDataRetentionJob>();
+// Lease background jobs
+builder.Services.AddScoped<ESignWebhookJob>();
+builder.Services.AddScoped<LeaseSignStatusPollingJob>();
+builder.Services.AddScoped<LeaseRegistrationStatusPollingJob>();
 
 // API
 builder.Services.AddControllers()


### PR DESCRIPTION
## Summary

- **Domain**: Full long-term lease workflow under Italian law (L.431/1998, D.P.R.131/1986, cedolare secca, APE requirement, GDPR 10-year retention, cessione di fabbricato for extra-EU tenants)
- **Status machine**: Draft → AwaitingSignature → Signed → SentToProvider → Registered
- **API**: 6 lease endpoints + e-sign webhook under `/api/leases` and `/webhooks/esign`
- **External providers**: Abstracted behind interfaces (LeaseContractTemplateService, LeaseESignHttpAdapter, OpenapiLeaseRegistrationProvider) with stub implementations and TODO markers pointing to Openapi.it Docuengine credentials
- **DB**: EF Core migration `AddLeaseTables` — 4 new tables (LeaseContracts, Parties, LeaseRegistrations, LeaseEvents) with proper cascade/restrict relationships
- **Auth**: `LongTermLandlord` RBAC policy; IDOR protection on all endpoints (OwnerId check)
- **Background jobs**: ESignWebhookJob, LeaseSignStatusPollingJob, LeaseRegistrationStatusPollingJob (Hangfire)
- **Tests**: 9 unit tests — all passing (342 total, 0 failed)

## Harness gates

| Gate | Status |
|------|--------|
| G1 `dotnet test` | ✅ 342 passed, 0 failed |
| G2 `dotnet format --verify-no-changes` | ✅ clean |
| G3 Swagger (no schema conflicts) | ✅ endpoints annotated |
| G4 EF migration generated | ✅ `20260602193205_AddLeaseTables` |

## Known limitations (deferred to follow-up issues)

- `LeaseContractTemplateService`, `LeaseESignHttpAdapter`, `OpenapiLeaseRegistrationProvider` are stubs — real integration pending credentials and contract selection
- `LeaseSignStatusPollingJob` is a no-op skeleton (webhook-first design; polling is the fallback)
- Frontend implementation tracked in #177

## Test plan

1. `dotnet test` → all green
2. `dotnet run --project Casazen.Web` → Swagger at `/swagger` — verify `LeasesController` endpoints appear
3. `POST /api/leases?propertyId={id}` with `Authorization: Bearer <LongTermLandlord token>` — expect 201 with Draft status
4. `POST /api/leases/{id}/signing` — expect 200 with AwaitingSignature status
5. Webhook `POST /webhooks/esign` with valid HMAC-SHA256 signature — expect 200, job enqueued

Closes #165