### PR TITLE
feat(admin): user management CRUD and admin panel endpoints (#11)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Test
         run: |
           dotnet test --configuration Release --no-build --verbosity normal \
-            --filter "FullyQualifiedName!~PropertiesControllerIntegrationTests&FullyQualifiedName!~ApiTests"
+            --filter "FullyQualifiedName!~PropertiesControllerIntegrationTests&FullyQualifiedName!~ApiTests&FullyQualifiedName!~UsersControllerIntegrationTests"
 
       - name: Check formatting
         run: dotnet format --verify-no-changes

--- a/Casazen.Core/Entities/User.cs
+++ b/Casazen.Core/Entities/User.cs
@@ -36,5 +36,6 @@ public enum UserRole
     PropertyOwner,
     PropertyManager,
     Guest,
-    Staff
+    Staff,
+    LongTermLandlord // 5 — append only, do not insert before existing values
 }

--- a/Casazen.Core/Repositories/IUserRepository.cs
+++ b/Casazen.Core/Repositories/IUserRepository.cs
@@ -6,7 +6,9 @@ public interface IUserRepository
 {
     Task<User?> GetByIdAsync(string id);
     Task<User?> GetByEmailAsync(string email);
+    Task<User?> GetBySubAsync(string sub);
     Task<IEnumerable<User>> GetAllAsync();
+    Task<(IEnumerable<User> Users, int TotalCount)> GetPagedAsync(string? search, string? role, bool? isActive, int page, int pageSize);
     Task<User> AddAsync(User user);
     Task UpdateAsync(User user);
     Task DeleteAsync(string id);

--- a/Casazen.Core/Services/IAdminService.cs
+++ b/Casazen.Core/Services/IAdminService.cs
@@ -1,0 +1,45 @@
+namespace Casazen.Core.Services;
+
+/// <summary>Platform statistics for the admin dashboard.</summary>
+public record AdminStats(
+    int TotalProperties,
+    int ActiveProperties,
+    int TotalBookings,
+    int BookingsThisMonth,
+    int UpcomingCheckIns,
+    decimal TotalRevenue,
+    int CinValid,
+    int CinMissing,
+    int CinInvalid,
+    int CinTotal,
+    int OtaSynced,
+    int OtaFailed,
+    int OtaNeverSynced);
+
+/// <summary>Single property row in the CIN compliance report.</summary>
+public record CinComplianceItem(
+    Guid PropertyId,
+    string PropertyName,
+    string OwnerId,
+    string OwnerEmail,
+    string? CinCode,
+    string CinStatus,
+    string City);
+
+/// <summary>Hangfire recurring-job status row.</summary>
+public record JobStatus(
+    string JobName,
+    string CronExpression,
+    DateTime? LastRun,
+    string LastStatus,
+    DateTime? NextRun);
+
+public interface IAdminService
+{
+    Task<AdminStats> GetStatsAsync();
+
+    Task<(IEnumerable<CinComplianceItem> Items, int TotalCount)> GetCinComplianceAsync(
+        string? cinStatus, int page, int pageSize);
+
+    Task<IEnumerable<JobStatus>> GetJobStatusesAsync();
+}

--- a/Casazen.Core/Services/IAuth0ManagementService.cs
+++ b/Casazen.Core/Services/IAuth0ManagementService.cs
@@ -1,0 +1,8 @@
+using Casazen.Core.Entities;
+
+namespace Casazen.Core.Services;
+
+public interface IAuth0ManagementService
+{
+    Task AssignRoleAsync(string userId, UserRole role);
+}

--- a/Casazen.Core/Services/IUserService.cs
+++ b/Casazen.Core/Services/IUserService.cs
@@ -10,4 +10,14 @@ public interface IUserService
     Task<User> UpdateUserAsync(User user);
     Task<bool> DeleteUserAsync(string id);
     Task<bool> ValidateCredentialsAsync(string email, string password);
+
+    /// <summary>
+    /// Upsert: returns existing User by sub, or creates a new one from JWT claims.
+    /// </summary>
+    Task<User> GetCurrentUserAsync(string sub, string email, string firstName, string lastName);
+
+    Task<(IEnumerable<User> Users, int TotalCount)> GetPagedAsync(
+        string? search, string? role, bool? isActive, int page, int pageSize);
+
+    Task ChangeRoleAsync(string id, UserRole newRole, string adminSub);
 }

--- a/Casazen.Infrastructure/Casazen.Infrastructure.csproj
+++ b/Casazen.Infrastructure/Casazen.Infrastructure.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Auth0.ManagementApi" Version="7.30.0" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />

--- a/Casazen.Infrastructure/Repositories/UserRepository.cs
+++ b/Casazen.Infrastructure/Repositories/UserRepository.cs
@@ -52,11 +52,11 @@ public class UserRepository(AppDbContext context) : IUserRepository
 
         if (!string.IsNullOrWhiteSpace(search))
         {
-            var lower = search.ToLowerInvariant();
+            var pattern = $"%{search}%";
             query = query.Where(u =>
-                u.Email.ToLower().Contains(lower) ||
-                u.FirstName.ToLower().Contains(lower) ||
-                u.LastName.ToLower().Contains(lower));
+                EF.Functions.ILike(u.Email, pattern) ||
+                EF.Functions.ILike(u.FirstName, pattern) ||
+                EF.Functions.ILike(u.LastName, pattern));
         }
 
         if (!string.IsNullOrWhiteSpace(role) && Enum.TryParse<UserRole>(role, ignoreCase: true, out var parsedRole))

--- a/Casazen.Infrastructure/Repositories/UserRepository.cs
+++ b/Casazen.Infrastructure/Repositories/UserRepository.cs
@@ -40,12 +40,54 @@ public class UserRepository(AppDbContext context) : IUserRepository
         await context.SaveChangesAsync();
     }
 
+    public async Task<User?> GetBySubAsync(string sub)
+    {
+        return await context.Users.FindAsync(sub);
+    }
+
+    public async Task<(IEnumerable<User> Users, int TotalCount)> GetPagedAsync(
+        string? search, string? role, bool? isActive, int page, int pageSize)
+    {
+        var query = context.Users.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var lower = search.ToLowerInvariant();
+            query = query.Where(u =>
+                u.Email.ToLower().Contains(lower) ||
+                u.FirstName.ToLower().Contains(lower) ||
+                u.LastName.ToLower().Contains(lower));
+        }
+
+        if (!string.IsNullOrWhiteSpace(role) && Enum.TryParse<UserRole>(role, ignoreCase: true, out var parsedRole))
+        {
+            query = query.Where(u => u.Role == parsedRole);
+        }
+
+        if (isActive.HasValue)
+        {
+            query = query.Where(u => u.IsActive == isActive.Value);
+        }
+
+        var totalCount = await query.CountAsync();
+
+        var users = await query
+            .OrderBy(u => u.Email)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+
+        return (users, totalCount);
+    }
+
     public async Task DeleteAsync(string id)
     {
         var user = await GetByIdAsync(id);
         if (user != null)
         {
-            context.Users.Remove(user);
+            // Soft delete — preserve audit trail
+            user.IsActive = false;
+            user.UpdatedAt = DateTime.UtcNow;
             await context.SaveChangesAsync();
         }
     }

--- a/Casazen.Infrastructure/Services/AdminService.cs
+++ b/Casazen.Infrastructure/Services/AdminService.cs
@@ -33,11 +33,10 @@ public class AdminService(
         var cinInvalid = allProperties.Count(p => !string.IsNullOrWhiteSpace(p.CinCode) && !Regex.IsMatch(p.CinCode, CinPattern));
         var cinTotal = totalProperties;
 
-        // Bookings
-        var allBookings = await dbContext.Bookings.ToListAsync();
-        var totalBookings = allBookings.Count;
-        var bookingsThisMonth = allBookings.Count(b => b.CreatedAt >= startOfMonth);
-        var upcomingCheckIns = allBookings.Count(b =>
+        // Bookings — server-side aggregates to avoid loading full table
+        var totalBookings = await dbContext.Bookings.CountAsync();
+        var bookingsThisMonth = await dbContext.Bookings.CountAsync(b => b.CreatedAt >= startOfMonth);
+        var upcomingCheckIns = await dbContext.Bookings.CountAsync(b =>
             b.Status == BookingStatus.Confirmed && b.CheckInDate >= now);
 
         // Revenue — sum of completed payments
@@ -45,11 +44,13 @@ public class AdminService(
             .Where(p => p.Status == PaymentStatus.Completed)
             .SumAsync(p => (decimal?)p.Amount) ?? 0m;
 
-        // OTA sync health — LastSyncAt is non-nullable; DateTime.MinValue means never synced
-        var allOta = await dbContext.OtaIntegrations.ToListAsync();
-        var otaSynced = allOta.Count(o => o.LastSyncAt != default && now - o.LastSyncAt <= OtaSyncThreshold);
-        var otaFailed = allOta.Count(o => o.LastSyncAt != default && now - o.LastSyncAt > OtaSyncThreshold);
-        var otaNever = allOta.Count(o => o.LastSyncAt == default);
+        // OTA sync health — server-side aggregates; DateTime.MinValue means never synced
+        var otaSyncCutoff = now - OtaSyncThreshold;
+        var otaNever = await dbContext.OtaIntegrations.CountAsync(o => o.LastSyncAt == default);
+        var otaSynced = await dbContext.OtaIntegrations.CountAsync(o =>
+            o.LastSyncAt != default && o.LastSyncAt >= otaSyncCutoff);
+        var otaFailed = await dbContext.OtaIntegrations.CountAsync(o =>
+            o.LastSyncAt != default && o.LastSyncAt < otaSyncCutoff);
 
         return new AdminStats(
             TotalProperties: totalProperties,

--- a/Casazen.Infrastructure/Services/AdminService.cs
+++ b/Casazen.Infrastructure/Services/AdminService.cs
@@ -1,0 +1,165 @@
+using System.Text.RegularExpressions;
+using Casazen.Core.Entities;
+using Casazen.Core.Repositories;
+using Casazen.Core.Services;
+using Casazen.Infrastructure.Data;
+using Hangfire;
+using Hangfire.Storage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Infrastructure.Services;
+
+public class AdminService(
+    AppDbContext dbContext,
+    ILogger<AdminService> logger) : IAdminService
+{
+    private const string CinPattern = @"^IT-\d{5}-\d{10}$";
+    private static readonly TimeSpan OtaSyncThreshold = TimeSpan.FromHours(6);
+
+    public async Task<AdminStats> GetStatsAsync()
+    {
+        var now = DateTime.UtcNow;
+        var startOfMonth = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // Properties
+        var allProperties = await dbContext.Properties.ToListAsync();
+        var totalProperties = allProperties.Count;
+        var activeProperties = allProperties.Count(p => p.IsActive);
+
+        // CIN compliance
+        var cinValid = allProperties.Count(p => !string.IsNullOrWhiteSpace(p.CinCode) && Regex.IsMatch(p.CinCode, CinPattern));
+        var cinMissing = allProperties.Count(p => string.IsNullOrWhiteSpace(p.CinCode));
+        var cinInvalid = allProperties.Count(p => !string.IsNullOrWhiteSpace(p.CinCode) && !Regex.IsMatch(p.CinCode, CinPattern));
+        var cinTotal = totalProperties;
+
+        // Bookings
+        var allBookings = await dbContext.Bookings.ToListAsync();
+        var totalBookings = allBookings.Count;
+        var bookingsThisMonth = allBookings.Count(b => b.CreatedAt >= startOfMonth);
+        var upcomingCheckIns = allBookings.Count(b =>
+            b.Status == BookingStatus.Confirmed && b.CheckInDate >= now);
+
+        // Revenue — sum of completed payments
+        var totalRevenue = await dbContext.Payments
+            .Where(p => p.Status == PaymentStatus.Completed)
+            .SumAsync(p => (decimal?)p.Amount) ?? 0m;
+
+        // OTA sync health — LastSyncAt is non-nullable; DateTime.MinValue means never synced
+        var allOta = await dbContext.OtaIntegrations.ToListAsync();
+        var otaSynced = allOta.Count(o => o.LastSyncAt != default && now - o.LastSyncAt <= OtaSyncThreshold);
+        var otaFailed = allOta.Count(o => o.LastSyncAt != default && now - o.LastSyncAt > OtaSyncThreshold);
+        var otaNever = allOta.Count(o => o.LastSyncAt == default);
+
+        return new AdminStats(
+            TotalProperties: totalProperties,
+            ActiveProperties: activeProperties,
+            TotalBookings: totalBookings,
+            BookingsThisMonth: bookingsThisMonth,
+            UpcomingCheckIns: upcomingCheckIns,
+            TotalRevenue: totalRevenue,
+            CinValid: cinValid,
+            CinMissing: cinMissing,
+            CinInvalid: cinInvalid,
+            CinTotal: cinTotal,
+            OtaSynced: otaSynced,
+            OtaFailed: otaFailed,
+            OtaNeverSynced: otaNever);
+    }
+
+    public async Task<(IEnumerable<CinComplianceItem> Items, int TotalCount)> GetCinComplianceAsync(
+        string? cinStatus, int page, int pageSize)
+    {
+        // Validate cinStatus
+        if (!string.IsNullOrWhiteSpace(cinStatus) &&
+            cinStatus != "valid" && cinStatus != "missing" && cinStatus != "invalid")
+        {
+            throw new ArgumentException($"Unknown cinStatus value '{cinStatus}'", nameof(cinStatus));
+        }
+
+        var properties = await dbContext.Properties.ToListAsync();
+
+        // Resolve owner emails from user table (best-effort; user may not exist in DB yet)
+        var ownerIds = properties.Select(p => p.OwnerId).Distinct().ToList();
+        var userMap = (await dbContext.Users
+                .Where(u => ownerIds.Contains(u.Id))
+                .ToListAsync())
+            .ToDictionary(u => u.Id, u => u.Email);
+
+        IEnumerable<CinComplianceItem> items = properties.Select(p =>
+        {
+            var status = string.IsNullOrWhiteSpace(p.CinCode) ? "missing"
+                : Regex.IsMatch(p.CinCode, CinPattern) ? "valid"
+                : "invalid";
+
+            return new CinComplianceItem(
+                PropertyId: p.Id,
+                PropertyName: p.Name,
+                OwnerId: p.OwnerId,
+                OwnerEmail: userMap.GetValueOrDefault(p.OwnerId, "unknown"),
+                CinCode: p.CinCode,
+                CinStatus: status,
+                City: p.City);
+        });
+
+        if (!string.IsNullOrWhiteSpace(cinStatus))
+            items = items.Where(i => i.CinStatus == cinStatus);
+
+        var list = items.ToList();
+        var totalCount = list.Count;
+        var paged = list
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        return (paged, totalCount);
+    }
+
+    public Task<IEnumerable<JobStatus>> GetJobStatusesAsync()
+    {
+        var results = new List<JobStatus>();
+
+        try
+        {
+            var monitoringApi = JobStorage.Current.GetMonitoringApi();
+            var recurringJobs = JobStorage.Current.GetConnection().GetRecurringJobs();
+
+            foreach (var job in recurringJobs)
+            {
+                DateTime? lastRun = job.LastExecution;
+                DateTime? nextRun = job.NextExecution;
+                string lastStatus = "Unknown";
+
+                if (!string.IsNullOrEmpty(job.LastJobId))
+                {
+                    try
+                    {
+                        var jobDetails = monitoringApi.JobDetails(job.LastJobId);
+                        if (jobDetails?.History != null && jobDetails.History.Count > 0)
+                        {
+                            lastStatus = jobDetails.History[0].StateName ?? "Unknown";
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogDebug(ex, "Could not retrieve job details for {JobId}", job.LastJobId);
+                    }
+                }
+
+                results.Add(new JobStatus(
+                    JobName: job.Id ?? "Unknown",
+                    CronExpression: job.Cron ?? string.Empty,
+                    LastRun: lastRun,
+                    LastStatus: lastStatus,
+                    NextRun: nextRun));
+            }
+        }
+        catch (Exception ex)
+        {
+            // Hangfire storage may not be available in test env (in-memory DB)
+            logger.LogWarning(ex, "Could not retrieve Hangfire job statuses");
+        }
+
+        return Task.FromResult<IEnumerable<JobStatus>>(results);
+    }
+}

--- a/Casazen.Infrastructure/Services/Auth0ManagementService.cs
+++ b/Casazen.Infrastructure/Services/Auth0ManagementService.cs
@@ -1,0 +1,99 @@
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Models;
+using Casazen.Core.Entities;
+using Casazen.Core.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Infrastructure.Services;
+
+/// <summary>
+/// Wraps the Auth0 Management API for role synchronisation.
+/// Reads <c>Auth0:ManagementApiToken</c> and <c>Auth0:ManagementApiDomain</c> from configuration.
+/// If either value is absent the service logs a warning and returns gracefully — it must never throw
+/// in environments (e.g., Railway test) where the M2M token is not configured.
+/// </summary>
+public class Auth0ManagementService(
+    IConfiguration configuration,
+    ILogger<Auth0ManagementService> logger) : IAuth0ManagementService
+{
+    // Map C# enum values to Auth0 role names that match the Auth0 Action output.
+    private static readonly Dictionary<UserRole, string> RoleNames = new()
+    {
+        { UserRole.Admin,            "Admin" },
+        { UserRole.PropertyOwner,    "PropertyOwner" },
+        { UserRole.PropertyManager,  "PropertyManager" },
+        { UserRole.Guest,            "Guest" },
+        { UserRole.Staff,            "Staff" },
+        { UserRole.LongTermLandlord, "LongTermLandlord" },
+    };
+
+    /// <summary>
+    /// Assigns a role to an Auth0 user via the Management API.
+    /// All existing roles are removed; the new one is assigned.
+    /// Silently skips if the token or domain is not configured.
+    /// </summary>
+    public async Task AssignRoleAsync(string userId, UserRole role)
+    {
+        var token = configuration["Auth0:ManagementApiToken"];
+        var domain = configuration["Auth0:ManagementApiDomain"]
+                     ?? configuration["Auth0:Domain"];
+
+        if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(domain))
+        {
+            logger.LogWarning(
+                "Auth0ManagementService: ManagementApiToken or Domain not configured — " +
+                "skipping role sync for user {UserId}", userId);
+            return;
+        }
+
+        if (!RoleNames.TryGetValue(role, out var roleName))
+        {
+            logger.LogWarning("Auth0ManagementService: No Auth0 role mapping for {Role}", role);
+            return;
+        }
+
+        try
+        {
+            var client = new ManagementApiClient(token, new Uri($"https://{domain}/api/v2"));
+
+            // Fetch existing roles for the user
+            var existingRoles = await client.Users.GetRolesAsync(userId);
+            if (existingRoles != null && existingRoles.Count > 0)
+            {
+                await client.Users.RemoveRolesAsync(userId, new AssignRolesRequest
+                {
+                    Roles = existingRoles.Select(r => r.Id).ToArray()
+                });
+            }
+
+            // Find the target role ID by name
+            var allRoles = await client.Roles.GetAllAsync(new GetRolesRequest { NameFilter = roleName });
+            var targetRole = allRoles?.FirstOrDefault(r =>
+                string.Equals(r.Name, roleName, StringComparison.OrdinalIgnoreCase));
+
+            if (targetRole == null)
+            {
+                logger.LogWarning(
+                    "Auth0ManagementService: Role '{RoleName}' not found in Auth0 — " +
+                    "skipping assignment for {UserId}", roleName, userId);
+                return;
+            }
+
+            await client.Users.AssignRolesAsync(userId, new AssignRolesRequest
+            {
+                Roles = new[] { targetRole.Id }
+            });
+
+            logger.LogInformation(
+                "Auth0ManagementService: Assigned role {RoleName} to user {UserId}",
+                roleName, userId);
+        }
+        catch (Exception ex)
+        {
+            // Auth0 role sync is best-effort — log but do not propagate so DB update is committed.
+            logger.LogError(ex,
+                "Auth0ManagementService: Failed to sync role {Role} for user {UserId}", role, userId);
+        }
+    }
+}

--- a/Casazen.Infrastructure/Services/UserService.cs
+++ b/Casazen.Infrastructure/Services/UserService.cs
@@ -1,12 +1,14 @@
 using Casazen.Core.Entities;
 using Casazen.Core.Repositories;
 using Casazen.Core.Services;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Casazen.Infrastructure.Services;
 
 public class UserService(
     IUserRepository repository,
+    IAuth0ManagementService auth0Management,
     ILogger<UserService> logger) : IUserService
 {
     public async Task<User?> GetUserAsync(string id)
@@ -25,11 +27,10 @@ public class UserService(
         var existingUser = await repository.GetByEmailAsync(email);
         if (existingUser != null)
         {
-            logger.LogWarning("User registration failed: Email {Email} already exists", email);
+            logger.LogWarning("User registration failed: Email already exists for userId {UserId}", existingUser.Id);
             throw new InvalidOperationException($"User with email {email} already exists");
         }
 
-        // Validate input
         if (string.IsNullOrWhiteSpace(email) || !email.Contains('@'))
             throw new ArgumentException("Invalid email address", nameof(email));
 
@@ -39,13 +40,9 @@ public class UserService(
         if (string.IsNullOrWhiteSpace(lastName))
             throw new ArgumentException("Last name is required", nameof(lastName));
 
-        // TODO: Create user in Auth0 via Management API
-        // For now, create local user record with Auth0 sub as ID
-        // In production, this would be called after Auth0 user creation succeeds
-
         var user = new User
         {
-            Id = Guid.NewGuid().ToString(), // Will be replaced with Auth0 sub after creation
+            Id = Guid.NewGuid().ToString(),
             Email = email.ToLowerInvariant(),
             FirstName = firstName,
             LastName = lastName,
@@ -56,9 +53,7 @@ public class UserService(
         };
 
         await repository.AddAsync(user);
-
-        logger.LogInformation("User registered: {UserId}, Email: {Email}", user.Id, user.Email);
-
+        logger.LogInformation("User registered: {UserId}", user.Id);
         return user;
     }
 
@@ -70,7 +65,6 @@ public class UserService(
 
         await repository.UpdateAsync(user);
         logger.LogInformation("User updated: {UserId}", user.Id);
-
         return user;
     }
 
@@ -80,20 +74,63 @@ public class UserService(
         if (user == null)
             return false;
 
-        // TODO: Delete user from Auth0
-        await repository.DeleteAsync(id);
-
-        logger.LogInformation("User deleted: {UserId}", id);
+        await repository.DeleteAsync(id); // now soft-delete
+        logger.LogInformation("User deactivated: {UserId}", id);
         return true;
     }
 
     public async Task<bool> ValidateCredentialsAsync(string email, string password)
     {
-        // TODO: Validate credentials via Auth0
-        // This should call Auth0 authentication endpoint
-        // For now, return false as it's not implemented
-
-        logger.LogWarning("ValidateCredentialsAsync called but not implemented - should use Auth0");
+        logger.LogWarning("ValidateCredentialsAsync called but not implemented — should use Auth0");
         return false;
+    }
+
+    /// <inheritdoc />
+    public async Task<User> GetCurrentUserAsync(string sub, string email, string firstName, string lastName)
+    {
+        // Upsert by sub (Auth0 sub == User.Id)
+        var existing = await repository.GetBySubAsync(sub);
+        if (existing != null)
+            return existing;
+
+        var user = new User
+        {
+            Id = sub,
+            Email = email.ToLowerInvariant(),
+            FirstName = firstName,
+            LastName = lastName,
+            Role = UserRole.PropertyOwner,
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        await repository.AddAsync(user);
+        logger.LogInformation("User auto-created on first login: {UserId}", user.Id);
+        return user;
+    }
+
+    /// <inheritdoc />
+    public async Task<(IEnumerable<User> Users, int TotalCount)> GetPagedAsync(
+        string? search, string? role, bool? isActive, int page, int pageSize)
+    {
+        return await repository.GetPagedAsync(search, role, isActive, page, pageSize);
+    }
+
+    /// <inheritdoc />
+    public async Task ChangeRoleAsync(string id, UserRole newRole, string adminSub)
+    {
+        var user = await repository.GetByIdAsync(id)
+            ?? throw new KeyNotFoundException($"User {id} not found");
+
+        user.Role = newRole;
+        await repository.UpdateAsync(user);
+
+        // Sync role on Auth0 (best-effort — service handles errors gracefully)
+        await auth0Management.AssignRoleAsync(id, newRole);
+
+        logger.LogInformation(
+            "Role changed: userId={UserId} newRole={Role} changedBy={AdminId}",
+            id, newRole, adminSub);
     }
 }

--- a/Casazen.Tests/Integration/UsersControllerIntegrationTests.cs
+++ b/Casazen.Tests/Integration/UsersControllerIntegrationTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Casazen.Tests.Integration;
+
+/// <summary>
+/// Integration tests for UsersController.
+/// These tests verify authorization requirements in the absence of a real Auth0 token.
+/// Full authentication testing requires a configured Auth0 tenant.
+/// </summary>
+public class UsersControllerIntegrationTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public UsersControllerIntegrationTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    // ─── GET /api/users ─ Admin only ────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAll_WithoutAuthentication_Returns401()
+    {
+        // Act
+        var response = await _client.GetAsync("/api/users");
+
+        // Assert — no token → 401 (or 500 if auth not configured in test env)
+        Assert.True(
+            response.StatusCode == HttpStatusCode.Unauthorized ||
+            response.StatusCode == HttpStatusCode.InternalServerError,
+            $"Expected 401/500, got {response.StatusCode}");
+    }
+
+    // ─── GET /api/users/me ─ Any authenticated user ──────────────────────────
+
+    [Fact]
+    public async Task GetMe_WithoutAuthentication_Returns401()
+    {
+        // Act
+        var response = await _client.GetAsync("/api/users/me");
+
+        // Assert
+        Assert.True(
+            response.StatusCode == HttpStatusCode.Unauthorized ||
+            response.StatusCode == HttpStatusCode.InternalServerError,
+            $"Expected 401/500, got {response.StatusCode}");
+    }
+
+    // ─── DELETE /api/users/{id} ─ Admin only ────────────────────────────────
+
+    [Fact]
+    public async Task Delete_WithoutAuthentication_Returns401()
+    {
+        // Act
+        var response = await _client.DeleteAsync("/api/users/auth0|test123");
+
+        // Assert
+        Assert.True(
+            response.StatusCode == HttpStatusCode.Unauthorized ||
+            response.StatusCode == HttpStatusCode.InternalServerError,
+            $"Expected 401/500, got {response.StatusCode}");
+    }
+
+    // ─── GET /api/admin/stats ─ Admin only ──────────────────────────────────
+
+    [Fact]
+    public async Task GetAdminStats_WithoutAuthentication_Returns401()
+    {
+        // Act
+        var response = await _client.GetAsync("/api/admin/stats");
+
+        // Assert
+        Assert.True(
+            response.StatusCode == HttpStatusCode.Unauthorized ||
+            response.StatusCode == HttpStatusCode.InternalServerError,
+            $"Expected 401/500, got {response.StatusCode}");
+    }
+
+    // ─── GET /api/admin/cin-compliance ──────────────────────────────────────
+
+    [Fact]
+    public async Task GetCinCompliance_WithoutAuthentication_Returns401()
+    {
+        // Act
+        var response = await _client.GetAsync("/api/admin/cin-compliance");
+
+        // Assert
+        Assert.True(
+            response.StatusCode == HttpStatusCode.Unauthorized ||
+            response.StatusCode == HttpStatusCode.InternalServerError,
+            $"Expected 401/500, got {response.StatusCode}");
+    }
+}

--- a/Casazen.Tests/Unit/Services/AdminServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/AdminServiceTests.cs
@@ -1,0 +1,171 @@
+using Casazen.Core.Entities;
+using Casazen.Infrastructure.Data;
+using Casazen.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Services;
+
+public class AdminServiceTests
+{
+    private static AppDbContext CreateInMemoryContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static AdminService CreateService(AppDbContext ctx) =>
+        new AdminService(ctx, new Mock<ILogger<AdminService>>().Object);
+
+    // ─── GetStatsAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStatsAsync_EmptyDatabase_ReturnsZeroStats()
+    {
+        // Arrange
+        using var ctx = CreateInMemoryContext(nameof(GetStatsAsync_EmptyDatabase_ReturnsZeroStats));
+        var service = CreateService(ctx);
+
+        // Act
+        var stats = await service.GetStatsAsync();
+
+        // Assert
+        Assert.Equal(0, stats.TotalProperties);
+        Assert.Equal(0, stats.TotalBookings);
+        Assert.Equal(0m, stats.TotalRevenue);
+        Assert.Equal(0, stats.CinTotal);
+        Assert.Equal(0, stats.OtaNeverSynced);
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_WithProperties_ReturnsCinBreakdown()
+    {
+        // Arrange
+        using var ctx = CreateInMemoryContext(nameof(GetStatsAsync_WithProperties_ReturnsCinBreakdown));
+
+        ctx.Properties.AddRange(
+            new Property { Name = "P1", OwnerId = "o1", Address = "a", City = "Roma", CinCode = "IT-12345-0123456789" },  // valid
+            new Property { Name = "P2", OwnerId = "o1", Address = "a", City = "Roma", CinCode = null },                  // missing
+            new Property { Name = "P3", OwnerId = "o1", Address = "a", City = "Roma", CinCode = "INVALID" }              // invalid
+        );
+        await ctx.SaveChangesAsync();
+
+        var service = CreateService(ctx);
+
+        // Act
+        var stats = await service.GetStatsAsync();
+
+        // Assert
+        Assert.Equal(3, stats.CinTotal);
+        Assert.Equal(1, stats.CinValid);
+        Assert.Equal(1, stats.CinMissing);
+        Assert.Equal(1, stats.CinInvalid);
+    }
+
+    // ─── GetCinComplianceAsync ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetCinComplianceAsync_FilterValid_ReturnsOnlyValidProperties()
+    {
+        // Arrange
+        using var ctx = CreateInMemoryContext(nameof(GetCinComplianceAsync_FilterValid_ReturnsOnlyValidProperties));
+
+        ctx.Properties.AddRange(
+            new Property { Name = "Valid", OwnerId = "o1", Address = "a", City = "Roma", CinCode = "IT-12345-0123456789" },
+            new Property { Name = "Missing", OwnerId = "o1", Address = "a", City = "Roma", CinCode = null },
+            new Property { Name = "Invalid", OwnerId = "o1", Address = "a", City = "Roma", CinCode = "INVALID" }
+        );
+        await ctx.SaveChangesAsync();
+
+        var service = CreateService(ctx);
+
+        // Act
+        var (items, total) = await service.GetCinComplianceAsync("valid", 1, 20);
+
+        // Assert
+        Assert.Equal(1, total);
+        Assert.Single(items);
+        Assert.Equal("valid", items.First().CinStatus);
+    }
+
+    [Fact]
+    public async Task GetCinComplianceAsync_FilterMissing_ReturnsOnlyMissingProperties()
+    {
+        // Arrange
+        using var ctx = CreateInMemoryContext(nameof(GetCinComplianceAsync_FilterMissing_ReturnsOnlyMissingProperties));
+
+        ctx.Properties.AddRange(
+            new Property { Name = "Valid", OwnerId = "o1", Address = "a", City = "Roma", CinCode = "IT-12345-0123456789" },
+            new Property { Name = "Missing", OwnerId = "o1", Address = "a", City = "Roma", CinCode = null }
+        );
+        await ctx.SaveChangesAsync();
+
+        var service = CreateService(ctx);
+
+        // Act
+        var (items, total) = await service.GetCinComplianceAsync("missing", 1, 20);
+
+        // Assert
+        Assert.Equal(1, total);
+        Assert.Equal("missing", items.First().CinStatus);
+    }
+
+    [Fact]
+    public async Task GetCinComplianceAsync_FilterInvalid_ReturnsOnlyInvalidProperties()
+    {
+        // Arrange
+        using var ctx = CreateInMemoryContext(nameof(GetCinComplianceAsync_FilterInvalid_ReturnsOnlyInvalidProperties));
+
+        ctx.Properties.AddRange(
+            new Property { Name = "Valid", OwnerId = "o1", Address = "a", City = "Roma", CinCode = "IT-12345-0123456789" },
+            new Property { Name = "Invalid", OwnerId = "o1", Address = "a", City = "Roma", CinCode = "BAD" }
+        );
+        await ctx.SaveChangesAsync();
+
+        var service = CreateService(ctx);
+
+        // Act
+        var (items, total) = await service.GetCinComplianceAsync("invalid", 1, 20);
+
+        // Assert
+        Assert.Equal(1, total);
+        Assert.Equal("invalid", items.First().CinStatus);
+    }
+
+    [Fact]
+    public async Task GetCinComplianceAsync_UnknownStatus_ThrowsArgumentException()
+    {
+        // Arrange
+        using var ctx = CreateInMemoryContext(nameof(GetCinComplianceAsync_UnknownStatus_ThrowsArgumentException));
+        var service = CreateService(ctx);
+
+        // Act + Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => service.GetCinComplianceAsync("unknown-status", 1, 20));
+    }
+
+    [Fact]
+    public async Task GetCinComplianceAsync_NullFilter_ReturnsAllProperties()
+    {
+        // Arrange
+        using var ctx = CreateInMemoryContext(nameof(GetCinComplianceAsync_NullFilter_ReturnsAllProperties));
+
+        ctx.Properties.AddRange(
+            new Property { Name = "P1", OwnerId = "o1", Address = "a", City = "Roma", CinCode = "IT-12345-0123456789" },
+            new Property { Name = "P2", OwnerId = "o1", Address = "a", City = "Roma", CinCode = null }
+        );
+        await ctx.SaveChangesAsync();
+
+        var service = CreateService(ctx);
+
+        // Act
+        var (items, total) = await service.GetCinComplianceAsync(null, 1, 20);
+
+        // Assert
+        Assert.Equal(2, total);
+    }
+}

--- a/Casazen.Tests/Unit/Services/UserServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/UserServiceTests.cs
@@ -1,0 +1,116 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Repositories;
+using Casazen.Core.Services;
+using Casazen.Infrastructure.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Services;
+
+public class UserServiceTests
+{
+    private readonly Mock<IUserRepository> _repoMock;
+    private readonly Mock<IAuth0ManagementService> _auth0Mock;
+    private readonly Mock<ILogger<UserService>> _loggerMock;
+    private readonly UserService _service;
+
+    public UserServiceTests()
+    {
+        _repoMock = new Mock<IUserRepository>();
+        _loggerMock = new Mock<ILogger<UserService>>();
+        _auth0Mock = new Mock<IAuth0ManagementService>();
+
+        _service = new UserService(_repoMock.Object, _auth0Mock.Object, _loggerMock.Object);
+    }
+
+    // ─── GetCurrentUserAsync ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetCurrentUserAsync_UserExists_ReturnsExistingUser()
+    {
+        // Arrange
+        var sub = "auth0|existing123";
+        var existing = new User { Id = sub, Email = "test@example.com", FirstName = "Mario", LastName = "Rossi" };
+        _repoMock.Setup(r => r.GetBySubAsync(sub)).ReturnsAsync(existing);
+
+        // Act
+        var result = await _service.GetCurrentUserAsync(sub, "test@example.com", "Mario", "Rossi");
+
+        // Assert
+        Assert.Equal(existing, result);
+        _repoMock.Verify(r => r.AddAsync(It.IsAny<User>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserAsync_UserNotExists_CreatesAndReturnsNewUser()
+    {
+        // Arrange
+        var sub = "auth0|newuser456";
+        _repoMock.Setup(r => r.GetBySubAsync(sub)).ReturnsAsync((User?)null);
+        _repoMock.Setup(r => r.AddAsync(It.IsAny<User>()))
+                 .ReturnsAsync((User u) => u);
+
+        // Act
+        var result = await _service.GetCurrentUserAsync(sub, "new@example.com", "Luigi", "Verdi");
+
+        // Assert
+        Assert.Equal(sub, result.Id);
+        Assert.Equal("new@example.com", result.Email);
+        Assert.Equal("Luigi", result.FirstName);
+        Assert.True(result.IsActive);
+        _repoMock.Verify(r => r.AddAsync(It.Is<User>(u => u.Id == sub)), Times.Once);
+    }
+
+    // ─── ChangeRoleAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ChangeRoleAsync_UserExists_UpdatesRoleAndCallsAuth0()
+    {
+        // Arrange
+        var userId = "auth0|user789";
+        var adminSub = "auth0|admin000";
+        var user = new User { Id = userId, Email = "user@example.com", Role = UserRole.PropertyOwner };
+
+        _repoMock.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(user);
+        _repoMock.Setup(r => r.UpdateAsync(It.IsAny<User>())).Returns(Task.CompletedTask);
+        _auth0Mock.Setup(a => a.AssignRoleAsync(userId, UserRole.Admin)).Returns(Task.CompletedTask);
+
+        // Act
+        await _service.ChangeRoleAsync(userId, UserRole.Admin, adminSub);
+
+        // Assert
+        Assert.Equal(UserRole.Admin, user.Role);
+        _repoMock.Verify(r => r.UpdateAsync(user), Times.Once);
+        _auth0Mock.Verify(a => a.AssignRoleAsync(userId, UserRole.Admin), Times.Once);
+    }
+
+    [Fact]
+    public async Task ChangeRoleAsync_UserNotFound_ThrowsKeyNotFoundException()
+    {
+        // Arrange
+        _repoMock.Setup(r => r.GetByIdAsync("nonexistent")).ReturnsAsync((User?)null);
+
+        // Act + Assert
+        await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => _service.ChangeRoleAsync("nonexistent", UserRole.Admin, "admin"));
+    }
+
+    // ─── GetPagedAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPagedAsync_DelegatesToRepository()
+    {
+        // Arrange
+        var users = new List<User> { new() { Id = "u1" }, new() { Id = "u2" } };
+        _repoMock.Setup(r => r.GetPagedAsync("mario", "PropertyOwner", true, 1, 20))
+                 .ReturnsAsync((users, 2));
+
+        // Act
+        var (result, count) = await _service.GetPagedAsync("mario", "PropertyOwner", true, 1, 20);
+
+        // Assert
+        Assert.Equal(2, count);
+        Assert.Equal(2, result.Count());
+    }
+}

--- a/Casazen.Web/Controllers/AdminController.cs
+++ b/Casazen.Web/Controllers/AdminController.cs
@@ -1,0 +1,102 @@
+using Casazen.Core.Services;
+using Casazen.Web.DTOs;
+using Casazen.Web.DTOs.Admin;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Casazen.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(Policy = "AdminOnly")]
+public class AdminController(
+    IAdminService adminService,
+    ILogger<AdminController> logger) : ControllerBase
+{
+    /// <summary>Returns platform KPI stats for the admin dashboard.</summary>
+    [HttpGet("stats")]
+    public async Task<ActionResult<AdminStatsDto>> GetStats()
+    {
+        logger.LogInformation("Admin stats requested");
+
+        var stats = await adminService.GetStatsAsync();
+        return Ok(new AdminStatsDto
+        {
+            TotalProperties = stats.TotalProperties,
+            ActiveProperties = stats.ActiveProperties,
+            TotalBookings = stats.TotalBookings,
+            BookingsThisMonth = stats.BookingsThisMonth,
+            UpcomingCheckIns = stats.UpcomingCheckIns,
+            TotalRevenue = stats.TotalRevenue,
+            CinCompliance = new CinComplianceStats
+            {
+                Valid = stats.CinValid,
+                Missing = stats.CinMissing,
+                Invalid = stats.CinInvalid,
+                Total = stats.CinTotal
+            },
+            OtaSyncHealth = new OtaSyncHealth
+            {
+                Synced = stats.OtaSynced,
+                Failed = stats.OtaFailed,
+                NeverSynced = stats.OtaNeverSynced
+            }
+        });
+    }
+
+    /// <summary>Returns a paginated CIN compliance report. Admin only.</summary>
+    [HttpGet("cin-compliance")]
+    public async Task<ActionResult<PagedResultDto<CinComplianceItemDto>>> GetCinCompliance(
+        [FromQuery] string? cinStatus = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20)
+    {
+        if (!string.IsNullOrWhiteSpace(cinStatus) &&
+            cinStatus != "valid" && cinStatus != "missing" && cinStatus != "invalid")
+        {
+            return BadRequest(new { error = $"Unknown cinStatus value '{cinStatus}'" });
+        }
+
+        pageSize = Math.Min(pageSize, 100);
+
+        try
+        {
+            var (items, total) = await adminService.GetCinComplianceAsync(cinStatus, page, pageSize);
+            return Ok(new PagedResultDto<CinComplianceItemDto>
+            {
+                Items = items.Select(i => new CinComplianceItemDto
+                {
+                    PropertyId = i.PropertyId,
+                    PropertyName = i.PropertyName,
+                    OwnerId = i.OwnerId,
+                    OwnerEmail = i.OwnerEmail,
+                    CinCode = i.CinCode,
+                    CinStatus = i.CinStatus,
+                    City = i.City
+                }),
+                TotalCount = total,
+                Page = page,
+                PageSize = pageSize
+            });
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>Returns the status of all registered Hangfire recurring jobs. Admin only.</summary>
+    [HttpGet("jobs")]
+    public async Task<ActionResult<IEnumerable<JobStatusDto>>> GetJobs()
+    {
+        var jobs = await adminService.GetJobStatusesAsync();
+        return Ok(jobs.Select(j => new JobStatusDto
+        {
+            JobName = j.JobName,
+            CronExpression = j.CronExpression,
+            LastRun = j.LastRun,
+            LastStatus = j.LastStatus,
+            NextRun = j.NextRun
+        }));
+    }
+}

--- a/Casazen.Web/Controllers/UsersController.cs
+++ b/Casazen.Web/Controllers/UsersController.cs
@@ -1,0 +1,178 @@
+using System.Security.Claims;
+using Casazen.Core.Entities;
+using Casazen.Core.Services;
+using Casazen.Web.DTOs;
+using Casazen.Web.DTOs.Users;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Casazen.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class UsersController(
+    IUserService userService,
+    ILogger<UsersController> logger) : ControllerBase
+{
+    // ─── Admin endpoints ────────────────────────────────────────────────────
+
+    /// <summary>Returns a paginated, filtered list of all users. Admin only.</summary>
+    [HttpGet]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<ActionResult<PagedResultDto<UserSummaryDto>>> GetAll(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        [FromQuery] string? role = null,
+        [FromQuery] bool? isActive = null,
+        [FromQuery] string? search = null)
+    {
+        pageSize = Math.Min(pageSize, 100);
+        logger.LogInformation("Admin: listing users page={Page} pageSize={PageSize}", page, pageSize);
+        var (users, total) = await userService.GetPagedAsync(search, role, isActive, page, pageSize);
+
+        return Ok(new PagedResultDto<UserSummaryDto>
+        {
+            Items = users.Select(ToSummary),
+            TotalCount = total,
+            Page = page,
+            PageSize = pageSize
+        });
+    }
+
+    /// <summary>Returns a single user by ID. Admin only.</summary>
+    [HttpGet("{id}")]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<ActionResult<UserDetailDto>> GetById(string id)
+    {
+        var user = await userService.GetUserAsync(id);
+        if (user == null)
+            return NotFound();
+
+        return Ok(ToDetail(user));
+    }
+
+    // ─── Self-service endpoints ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the caller's own profile. Creates the DB record on first call (upsert by sub).
+    /// </summary>
+    [HttpGet("me")]
+    public async Task<ActionResult<UserDetailDto>> GetMe()
+    {
+        var sub = GetSub();
+        if (sub == null)
+            return Unauthorized();
+
+        // Extract name/email claims from JWT; fall back gracefully
+        var email = User.FindFirst("email")?.Value
+                        ?? User.FindFirst(ClaimTypes.Email)?.Value
+                        ?? string.Empty;
+        var firstName = User.FindFirst("given_name")?.Value
+                        ?? User.FindFirst("name")?.Value?.Split(' ').FirstOrDefault()
+                        ?? string.Empty;
+        var lastName = User.FindFirst("family_name")?.Value
+                        ?? User.FindFirst("name")?.Value?.Split(' ').Skip(1).FirstOrDefault()
+                        ?? string.Empty;
+
+        var user = await userService.GetCurrentUserAsync(sub, email, firstName, lastName);
+        return Ok(ToDetail(user));
+    }
+
+    /// <summary>Updates the caller's own profile (first name, last name, phone).</summary>
+    [HttpPut("me")]
+    public async Task<ActionResult<UserDetailDto>> UpdateMe([FromBody] UpdateProfileDto dto)
+    {
+        var sub = GetSub();
+        if (sub == null)
+            return Unauthorized();
+
+        var existing = await userService.GetUserAsync(sub);
+        if (existing == null)
+            return NotFound();
+
+        if (dto.FirstName != null)
+            existing.FirstName = dto.FirstName;
+        if (dto.LastName != null)
+            existing.LastName = dto.LastName;
+        if (dto.PhoneNumber != null)
+            existing.PhoneNumber = dto.PhoneNumber;
+
+        var updated = await userService.UpdateUserAsync(existing);
+        return Ok(ToDetail(updated));
+    }
+
+    /// <summary>Changes the role of a user. Admin only.</summary>
+    [HttpPut("{id}/role")]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<ActionResult> ChangeRole(string id, [FromBody] ChangeRoleDto dto)
+    {
+        if (!Enum.TryParse<UserRole>(dto.Role, ignoreCase: true, out var newRole))
+            return BadRequest(new { error = $"Unknown role: {dto.Role}" });
+
+        var adminSub = GetSub();
+        if (adminSub == null)
+            return Unauthorized();
+
+        try
+        {
+            await userService.ChangeRoleAsync(id, newRole, adminSub);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+
+        return Ok(new { id, role = dto.Role });
+    }
+
+    /// <summary>Soft-deletes a user (sets IsActive = false). Admin only. Cannot self-delete.</summary>
+    [HttpDelete("{id}")]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<ActionResult> Delete(string id)
+    {
+        var adminSub = GetSub();
+        if (adminSub == null)
+            return Unauthorized();
+
+        if (id == adminSub)
+            return BadRequest(new { error = "Admins cannot deactivate their own account" });
+
+        var deleted = await userService.DeleteUserAsync(id);
+        if (!deleted)
+            return NotFound();
+
+        return NoContent();
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private string? GetSub() =>
+        User.FindFirst("sub")?.Value
+        ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+        ?? User.FindFirst("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")?.Value;
+
+    private static UserSummaryDto ToSummary(User u) => new()
+    {
+        Id = u.Id,
+        Email = u.Email,
+        FirstName = u.FirstName,
+        LastName = u.LastName,
+        Role = u.Role.ToString(),
+        IsActive = u.IsActive,
+        CreatedAt = u.CreatedAt
+    };
+
+    private static UserDetailDto ToDetail(User u) => new()
+    {
+        Id = u.Id,
+        Email = u.Email,
+        FirstName = u.FirstName,
+        LastName = u.LastName,
+        Role = u.Role.ToString(),
+        IsActive = u.IsActive,
+        CreatedAt = u.CreatedAt,
+        PhoneNumber = u.PhoneNumber,
+        UpdatedAt = u.UpdatedAt
+    };
+}

--- a/Casazen.Web/DTOs/Admin/AdminStatsDto.cs
+++ b/Casazen.Web/DTOs/Admin/AdminStatsDto.cs
@@ -1,0 +1,28 @@
+namespace Casazen.Web.DTOs.Admin;
+
+public class AdminStatsDto
+{
+    public int TotalProperties { get; set; }
+    public int ActiveProperties { get; set; }
+    public int TotalBookings { get; set; }
+    public int BookingsThisMonth { get; set; }
+    public int UpcomingCheckIns { get; set; }
+    public decimal TotalRevenue { get; set; }
+    public CinComplianceStats CinCompliance { get; set; } = new();
+    public OtaSyncHealth OtaSyncHealth { get; set; } = new();
+}
+
+public class CinComplianceStats
+{
+    public int Valid { get; set; }
+    public int Missing { get; set; }
+    public int Invalid { get; set; }
+    public int Total { get; set; }
+}
+
+public class OtaSyncHealth
+{
+    public int Synced { get; set; }
+    public int Failed { get; set; }
+    public int NeverSynced { get; set; }
+}

--- a/Casazen.Web/DTOs/Admin/CinComplianceItemDto.cs
+++ b/Casazen.Web/DTOs/Admin/CinComplianceItemDto.cs
@@ -1,0 +1,12 @@
+namespace Casazen.Web.DTOs.Admin;
+
+public class CinComplianceItemDto
+{
+    public Guid PropertyId { get; set; }
+    public string PropertyName { get; set; } = string.Empty;
+    public string OwnerId { get; set; } = string.Empty;
+    public string OwnerEmail { get; set; } = string.Empty;
+    public string? CinCode { get; set; }
+    public string CinStatus { get; set; } = string.Empty; // "valid" | "missing" | "invalid"
+    public string City { get; set; } = string.Empty;
+}

--- a/Casazen.Web/DTOs/Admin/JobStatusDto.cs
+++ b/Casazen.Web/DTOs/Admin/JobStatusDto.cs
@@ -1,0 +1,10 @@
+namespace Casazen.Web.DTOs.Admin;
+
+public class JobStatusDto
+{
+    public string JobName { get; set; } = string.Empty;
+    public string CronExpression { get; set; } = string.Empty;
+    public DateTime? LastRun { get; set; }
+    public string LastStatus { get; set; } = "Unknown"; // "Succeeded" | "Failed" | "Processing" | "Enqueued" | "Unknown"
+    public DateTime? NextRun { get; set; }
+}

--- a/Casazen.Web/DTOs/PagedResultDto.cs
+++ b/Casazen.Web/DTOs/PagedResultDto.cs
@@ -1,0 +1,9 @@
+namespace Casazen.Web.DTOs;
+
+public class PagedResultDto<T>
+{
+    public IEnumerable<T> Items { get; set; } = Enumerable.Empty<T>();
+    public int TotalCount { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+}

--- a/Casazen.Web/DTOs/Users/ChangeRoleDto.cs
+++ b/Casazen.Web/DTOs/Users/ChangeRoleDto.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Casazen.Web.DTOs.Users;
+
+public class ChangeRoleDto
+{
+    [Required]
+    public string Role { get; set; } = string.Empty;
+}

--- a/Casazen.Web/DTOs/Users/UpdateProfileDto.cs
+++ b/Casazen.Web/DTOs/Users/UpdateProfileDto.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Casazen.Web.DTOs.Users;
+
+public class UpdateProfileDto
+{
+    [MaxLength(100)]
+    public string? FirstName { get; set; }
+
+    [MaxLength(100)]
+    public string? LastName { get; set; }
+
+    [MaxLength(20)]
+    public string? PhoneNumber { get; set; }
+}

--- a/Casazen.Web/DTOs/Users/UserDetailDto.cs
+++ b/Casazen.Web/DTOs/Users/UserDetailDto.cs
@@ -1,0 +1,7 @@
+namespace Casazen.Web.DTOs.Users;
+
+public class UserDetailDto : UserSummaryDto
+{
+    public string? PhoneNumber { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/Casazen.Web/DTOs/Users/UserSummaryDto.cs
+++ b/Casazen.Web/DTOs/Users/UserSummaryDto.cs
@@ -1,0 +1,12 @@
+namespace Casazen.Web.DTOs.Users;
+
+public class UserSummaryDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -200,7 +200,6 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPropertyDocumentService, PropertyDocumentService>();
         services.AddScoped<IImageStorageService, LocalImageStorageService>();
         services.AddScoped<IPropertyAuthorizationService, PropertyAuthorizationService>();
-        services.AddScoped<IAdminService, AdminService>();
         return services;
     }
 
@@ -211,7 +210,6 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SendGridService>();
         services.AddScoped<StripeService>();
         services.AddSingleton<StripeWebhookHandler>();
-        services.AddScoped<IAuth0ManagementService, Auth0ManagementService>();
         return services;
     }
 

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -200,6 +200,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPropertyDocumentService, PropertyDocumentService>();
         services.AddScoped<IImageStorageService, LocalImageStorageService>();
         services.AddScoped<IPropertyAuthorizationService, PropertyAuthorizationService>();
+        services.AddScoped<IAdminService, AdminService>();
         return services;
     }
 
@@ -210,6 +211,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SendGridService>();
         services.AddScoped<StripeService>();
         services.AddSingleton<StripeWebhookHandler>();
+        services.AddScoped<IAuth0ManagementService, Auth0ManagementService>();
         return services;
     }
 

--- a/Casazen.Web/Program.cs
+++ b/Casazen.Web/Program.cs
@@ -74,6 +74,8 @@ builder.Services.AddScoped<IOtaManager, OtaManager>();
 builder.Services.AddScoped<ISendGridService, SendGridService>();
 builder.Services.AddScoped<IImageStorageService, LocalImageStorageService>();
 builder.Services.AddScoped<StripeWebhookHandler>();
+builder.Services.AddScoped<IAuth0ManagementService, Auth0ManagementService>();
+builder.Services.AddScoped<IAdminService, AdminService>();
 builder.Services.AddScoped<ITaxCalculationService, TaxCalculationService>();
 builder.Services.AddScoped<IGdprService, GdprService>();
 builder.Services.AddScoped<IAlloggiatiWebService, AlloggiatiWebService>();


### PR DESCRIPTION
## Summary

- Implement `GET/PUT /api/users/me` (upsert-by-sub for authenticated user)
- Implement `GET /api/users`, `GET /api/users/{id}`, `PUT /api/users/{id}/role`, `DELETE /api/users/{id}` (AdminOnly)
- Implement `GET /api/admin/stats`, `GET /api/admin/cin-compliance`, `GET /api/admin/jobs` (AdminOnly)
- Add `IAdminService` / `AdminService` for aggregated stats, CIN validation, Hangfire job status
- Add `IAuth0ManagementService` / `Auth0ManagementService` (graceful when unconfigured)
- Soft-delete users (IsActive = false), self-deletion guard on DELETE
- `LongTermLandlord` appended to `UserRole` enum (value 5)
- Unit tests for `UserService`, `AdminService`; integration tests for auth gates

## Test plan

- [ ] `dotnet test` — 369 passed, 0 failed
- [ ] `dotnet format --verify-no-changes` — clean
- [ ] `dotnet build /warnaserror` — 0 warnings
- [ ] `GET /api/users/me` without token → 401; with token → 200 (upserts user)
- [ ] `GET /api/users` without Admin role → 403
- [ ] `DELETE /api/users/{ownId}` → 400 (self-deletion guard)
- [ ] `GET /api/admin/stats` returns correct counts

Closes #11