### PR TITLE
feat(auth): context workspace switcher (#189)

### DIFF
--- a/Casazen.Core/Authorization/ContextAccessBootstrap.cs
+++ b/Casazen.Core/Authorization/ContextAccessBootstrap.cs
@@ -1,0 +1,94 @@
+using Casazen.Core.Services;
+
+namespace Casazen.Core.Authorization;
+
+public static class ContextAccessBootstrap
+{
+    private static readonly BootstrapContext[] BootstrapContexts =
+    [
+        new(
+            JwtRole: "PropertyOwner",
+            ContextKey: "short-rent",
+            DisplayName: "Affitti brevi",
+            RoleKey: "property_owner",
+            DefaultRoute: "/app/short-rent",
+            Permissions:
+            [
+                "property.read",
+                "property.write",
+                "booking.read",
+                "booking.write",
+                "payment.read",
+                "payment.write",
+                "ota.read",
+                "ota.write",
+                "guest.read",
+                "guest.write",
+            ]),
+        new(
+            JwtRole: "LongTermLandlord",
+            ContextKey: "long-rent",
+            DisplayName: "Affitti lungo termine",
+            RoleKey: "long_term_landlord",
+            DefaultRoute: "/app/long-rent/leases",
+            Permissions:
+            [
+                "lease.read",
+                "lease.create",
+                "lease.sign",
+                "lease.register",
+            ]),
+        new(
+            JwtRole: "Admin",
+            ContextKey: "admin",
+            DisplayName: "Amministrazione",
+            RoleKey: "platform_admin",
+            DefaultRoute: "/app/admin",
+            Permissions:
+            [
+                "admin.stats.read",
+                "admin.users.read",
+                "admin.users.manage",
+                "admin.cin.read",
+                "admin.jobs.read",
+                "admin.tax.manage",
+            ]),
+    ];
+
+    public static IReadOnlyList<BootstrapContextMembership> DeriveContextsFromJwtRoles(IEnumerable<string> jwtRoles)
+    {
+        var rolesSet = jwtRoles
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .Select(r => r.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return BootstrapContexts
+            .Where(c => rolesSet.Contains(c.JwtRole))
+            .Select(c => new BootstrapContextMembership(c.ContextKey, c.RoleKey))
+            .ToList();
+    }
+
+    public static IReadOnlyList<ContextAccess> BuildFallbackAccess(IEnumerable<string> jwtRoles)
+    {
+        var rolesSet = jwtRoles
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .Select(r => r.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return BootstrapContexts
+            .Where(c => rolesSet.Contains(c.JwtRole))
+            .Select(c => new ContextAccess(c.ContextKey, c.DisplayName, c.RoleKey, c.Permissions, c.DefaultRoute))
+            .ToList();
+    }
+
+    private sealed record BootstrapContext(
+        string JwtRole,
+        string ContextKey,
+        string DisplayName,
+        string RoleKey,
+        string DefaultRoute,
+        IReadOnlyList<string> Permissions
+    );
+}
+
+public sealed record BootstrapContextMembership(string ContextKey, string RoleKey);

--- a/Casazen.Core/Entities/AppContext.cs
+++ b/Casazen.Core/Entities/AppContext.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Casazen.Core.Entities;
+
+[Table("AppContexts")]
+public class AppContext
+{
+    [Key, MaxLength(64)]
+    public string Key { get; set; } = string.Empty;
+
+    [Required, MaxLength(128)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    public ICollection<Role> Roles { get; set; } = new List<Role>();
+    public ICollection<UserContextMembership> Memberships { get; set; } = new List<UserContextMembership>();
+}

--- a/Casazen.Core/Entities/Role.cs
+++ b/Casazen.Core/Entities/Role.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Casazen.Core.Entities;
+
+[Table("Roles")]
+public class Role
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required, MaxLength(64)]
+    public string ContextKey { get; set; } = string.Empty;
+
+    [Required, MaxLength(64)]
+    public string RoleKey { get; set; } = string.Empty;
+
+    public AppContext Context { get; set; } = null!;
+    public ICollection<RolePermission> Permissions { get; set; } = new List<RolePermission>();
+    public ICollection<UserContextMembership> Memberships { get; set; } = new List<UserContextMembership>();
+}

--- a/Casazen.Core/Entities/RolePermission.cs
+++ b/Casazen.Core/Entities/RolePermission.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Casazen.Core.Entities;
+
+[Table("RolePermissions")]
+public class RolePermission
+{
+    [Required]
+    public int RoleId { get; set; }
+
+    [Required, MaxLength(128)]
+    public string PermissionKey { get; set; } = string.Empty;
+
+    public Role Role { get; set; } = null!;
+}

--- a/Casazen.Core/Entities/User.cs
+++ b/Casazen.Core/Entities/User.cs
@@ -24,10 +24,15 @@ public class User
     [Required]
     public UserRole Role { get; set; } = UserRole.PropertyOwner;
 
+    [MaxLength(64)]
+    public string? LastUsedContextKey { get; set; }
+
     public bool IsActive { get; set; } = true;
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    public ICollection<UserContextMembership> ContextMemberships { get; set; } = new List<UserContextMembership>();
 }
 
 public enum UserRole

--- a/Casazen.Core/Entities/UserContextMembership.cs
+++ b/Casazen.Core/Entities/UserContextMembership.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Casazen.Core.Entities;
+
+[Table("UserContextMemberships")]
+public class UserContextMembership
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required, MaxLength(255)]
+    public string UserId { get; set; } = string.Empty;
+
+    [Required, MaxLength(64)]
+    public string ContextKey { get; set; } = string.Empty;
+
+    [Required]
+    public int RoleId { get; set; }
+
+    public User User { get; set; } = null!;
+    public AppContext Context { get; set; } = null!;
+    public Role Role { get; set; } = null!;
+}

--- a/Casazen.Core/Services/IContextAuthorizationService.cs
+++ b/Casazen.Core/Services/IContextAuthorizationService.cs
@@ -1,0 +1,15 @@
+namespace Casazen.Core.Services;
+
+public interface IContextAuthorizationService
+{
+    Task<IReadOnlyList<ContextAccess>> GetUserContextsAsync(string userId, CancellationToken cancellationToken = default);
+    Task<bool> HasPermissionAsync(string userId, string contextKey, string permissionKey, CancellationToken cancellationToken = default);
+}
+
+public record ContextAccess(
+    string ContextKey,
+    string DisplayName,
+    string RoleKey,
+    IReadOnlyList<string> Permissions,
+    string DefaultRoute
+);

--- a/Casazen.Infrastructure/Data/AppDbContext.cs
+++ b/Casazen.Infrastructure/Data/AppDbContext.cs
@@ -2,6 +2,7 @@ using Casazen.Core.Entities;
 using Casazen.Core.Entities.Enums;
 using Microsoft.EntityFrameworkCore;
 using Property = Casazen.Core.Entities.Property;
+using AppContextEntity = Casazen.Core.Entities.AppContext;
 
 namespace Casazen.Infrastructure.Data;
 
@@ -27,6 +28,10 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<Party> Parties { get; set; } = null!;
     public DbSet<LeaseRegistration> LeaseRegistrations { get; set; } = null!;
     public DbSet<LeaseEvent> LeaseEvents { get; set; } = null!;
+    public DbSet<AppContextEntity> AppContexts { get; set; } = null!;
+    public DbSet<Role> Roles { get; set; } = null!;
+    public DbSet<RolePermission> RolePermissions { get; set; } = null!;
+    public DbSet<UserContextMembership> UserContextMemberships { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -177,5 +182,81 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
         modelBuilder.Entity<LeaseEvent>()
             .HasIndex(e => new { e.LeaseContractId, e.OccurredAt });
+
+        modelBuilder.Entity<AppContextEntity>()
+            .HasKey(c => c.Key);
+
+        modelBuilder.Entity<Role>()
+            .HasIndex(r => new { r.ContextKey, r.RoleKey })
+            .IsUnique();
+
+        modelBuilder.Entity<Role>()
+            .HasOne(r => r.Context)
+            .WithMany(c => c.Roles)
+            .HasForeignKey(r => r.ContextKey)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<RolePermission>()
+            .HasKey(rp => new { rp.RoleId, rp.PermissionKey });
+
+        modelBuilder.Entity<RolePermission>()
+            .HasOne(rp => rp.Role)
+            .WithMany(r => r.Permissions)
+            .HasForeignKey(rp => rp.RoleId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<UserContextMembership>()
+            .HasIndex(m => new { m.UserId, m.ContextKey })
+            .IsUnique();
+
+        modelBuilder.Entity<UserContextMembership>()
+            .HasOne(m => m.User)
+            .WithMany(u => u.ContextMemberships)
+            .HasForeignKey(m => m.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<UserContextMembership>()
+            .HasOne(m => m.Context)
+            .WithMany(c => c.Memberships)
+            .HasForeignKey(m => m.ContextKey)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<UserContextMembership>()
+            .HasOne(m => m.Role)
+            .WithMany(r => r.Memberships)
+            .HasForeignKey(m => m.RoleId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<AppContextEntity>().HasData(
+            new AppContextEntity { Key = "short-rent", DisplayName = "Affitti brevi" },
+            new AppContextEntity { Key = "long-rent", DisplayName = "Affitti lungo termine" },
+            new AppContextEntity { Key = "admin", DisplayName = "Amministrazione" });
+
+        modelBuilder.Entity<Role>().HasData(
+            new Role { Id = 1, ContextKey = "short-rent", RoleKey = "property_owner" },
+            new Role { Id = 2, ContextKey = "long-rent", RoleKey = "long_term_landlord" },
+            new Role { Id = 3, ContextKey = "admin", RoleKey = "platform_admin" });
+
+        modelBuilder.Entity<RolePermission>().HasData(
+            new RolePermission { RoleId = 1, PermissionKey = "property.read" },
+            new RolePermission { RoleId = 1, PermissionKey = "property.write" },
+            new RolePermission { RoleId = 1, PermissionKey = "booking.read" },
+            new RolePermission { RoleId = 1, PermissionKey = "booking.write" },
+            new RolePermission { RoleId = 1, PermissionKey = "payment.read" },
+            new RolePermission { RoleId = 1, PermissionKey = "payment.write" },
+            new RolePermission { RoleId = 1, PermissionKey = "ota.read" },
+            new RolePermission { RoleId = 1, PermissionKey = "ota.write" },
+            new RolePermission { RoleId = 1, PermissionKey = "guest.read" },
+            new RolePermission { RoleId = 1, PermissionKey = "guest.write" },
+            new RolePermission { RoleId = 2, PermissionKey = "lease.read" },
+            new RolePermission { RoleId = 2, PermissionKey = "lease.create" },
+            new RolePermission { RoleId = 2, PermissionKey = "lease.sign" },
+            new RolePermission { RoleId = 2, PermissionKey = "lease.register" },
+            new RolePermission { RoleId = 3, PermissionKey = "admin.stats.read" },
+            new RolePermission { RoleId = 3, PermissionKey = "admin.users.read" },
+            new RolePermission { RoleId = 3, PermissionKey = "admin.users.manage" },
+            new RolePermission { RoleId = 3, PermissionKey = "admin.cin.read" },
+            new RolePermission { RoleId = 3, PermissionKey = "admin.jobs.read" },
+            new RolePermission { RoleId = 3, PermissionKey = "admin.tax.manage" });
     }
 }

--- a/Casazen.Infrastructure/Migrations/20260604193911_AddContextAuthorization.Designer.cs
+++ b/Casazen.Infrastructure/Migrations/20260604193911_AddContextAuthorization.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Casazen.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604193911_AddContextAuthorization")]
+    partial class AddContextAuthorization
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Casazen.Infrastructure/Migrations/20260604193911_AddContextAuthorization.cs
+++ b/Casazen.Infrastructure/Migrations/20260604193911_AddContextAuthorization.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Casazen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddContextAuthorization : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LastUsedContextKey",
+                table: "Users",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "AppContexts",
+                columns: table => new
+                {
+                    Key = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppContexts", x => x.Key);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Roles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ContextKey = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    RoleKey = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Roles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Roles_AppContexts_ContextKey",
+                        column: x => x.ContextKey,
+                        principalTable: "AppContexts",
+                        principalColumn: "Key",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "RolePermissions",
+                columns: table => new
+                {
+                    RoleId = table.Column<int>(type: "integer", nullable: false),
+                    PermissionKey = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RolePermissions", x => new { x.RoleId, x.PermissionKey });
+                    table.ForeignKey(
+                        name: "FK_RolePermissions_Roles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "Roles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserContextMemberships",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    ContextKey = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    RoleId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserContextMemberships", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserContextMemberships_AppContexts_ContextKey",
+                        column: x => x.ContextKey,
+                        principalTable: "AppContexts",
+                        principalColumn: "Key",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserContextMemberships_Roles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "Roles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserContextMemberships_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.InsertData(
+                table: "AppContexts",
+                columns: new[] { "Key", "DisplayName" },
+                values: new object[,]
+                {
+                    { "admin", "Amministrazione" },
+                    { "long-rent", "Affitti lungo termine" },
+                    { "short-rent", "Affitti brevi" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Roles",
+                columns: new[] { "Id", "ContextKey", "RoleKey" },
+                values: new object[,]
+                {
+                    { 1, "short-rent", "property_owner" },
+                    { 2, "long-rent", "long_term_landlord" },
+                    { 3, "admin", "platform_admin" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "RolePermissions",
+                columns: new[] { "PermissionKey", "RoleId" },
+                values: new object[,]
+                {
+                    { "booking.read", 1 },
+                    { "booking.write", 1 },
+                    { "guest.read", 1 },
+                    { "guest.write", 1 },
+                    { "ota.read", 1 },
+                    { "ota.write", 1 },
+                    { "payment.read", 1 },
+                    { "payment.write", 1 },
+                    { "property.read", 1 },
+                    { "property.write", 1 },
+                    { "lease.create", 2 },
+                    { "lease.read", 2 },
+                    { "lease.register", 2 },
+                    { "lease.sign", 2 },
+                    { "admin.cin.read", 3 },
+                    { "admin.jobs.read", 3 },
+                    { "admin.stats.read", 3 },
+                    { "admin.tax.manage", 3 },
+                    { "admin.users.manage", 3 },
+                    { "admin.users.read", 3 }
+                });
+
+            migrationBuilder.Sql("""
+                INSERT INTO "UserContextMemberships" ("Id", "UserId", "ContextKey", "RoleId")
+                SELECT
+                    ('00000000-0000-0000-0000-' || substring(md5(u."Id" || ':short-rent') from 1 for 12))::uuid,
+                    u."Id",
+                    'short-rent',
+                    1
+                FROM "Users" u
+                WHERE u."Role" = 1
+                ON CONFLICT ("UserId", "ContextKey") DO NOTHING;
+
+                INSERT INTO "UserContextMemberships" ("Id", "UserId", "ContextKey", "RoleId")
+                SELECT
+                    ('00000000-0000-0000-0000-' || substring(md5(u."Id" || ':long-rent') from 1 for 12))::uuid,
+                    u."Id",
+                    'long-rent',
+                    2
+                FROM "Users" u
+                WHERE u."Role" = 5
+                ON CONFLICT ("UserId", "ContextKey") DO NOTHING;
+
+                INSERT INTO "UserContextMemberships" ("Id", "UserId", "ContextKey", "RoleId")
+                SELECT
+                    ('00000000-0000-0000-0000-' || substring(md5(u."Id" || ':admin') from 1 for 12))::uuid,
+                    u."Id",
+                    'admin',
+                    3
+                FROM "Users" u
+                WHERE u."Role" = 0
+                ON CONFLICT ("UserId", "ContextKey") DO NOTHING;
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Roles_ContextKey_RoleKey",
+                table: "Roles",
+                columns: new[] { "ContextKey", "RoleKey" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserContextMemberships_ContextKey",
+                table: "UserContextMemberships",
+                column: "ContextKey");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserContextMemberships_RoleId",
+                table: "UserContextMemberships",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserContextMemberships_UserId_ContextKey",
+                table: "UserContextMemberships",
+                columns: new[] { "UserId", "ContextKey" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RolePermissions");
+
+            migrationBuilder.DropTable(
+                name: "UserContextMemberships");
+
+            migrationBuilder.DropTable(
+                name: "Roles");
+
+            migrationBuilder.DropTable(
+                name: "AppContexts");
+
+            migrationBuilder.DropColumn(
+                name: "LastUsedContextKey",
+                table: "Users");
+        }
+    }
+}

--- a/Casazen.Infrastructure/Migrations/AddContextAuthorization.sql
+++ b/Casazen.Infrastructure/Migrations/AddContextAuthorization.sql
@@ -1,0 +1,512 @@
+﻿CREATE TABLE IF NOT EXISTS "__EFMigrationsHistory" (
+    "MigrationId" character varying(150) NOT NULL,
+    "ProductVersion" character varying(32) NOT NULL,
+    CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY ("MigrationId")
+);
+
+START TRANSACTION;
+CREATE TABLE "CancellationPolicies" (
+    "Id" uuid NOT NULL,
+    "Name" character varying(50) NOT NULL,
+    "Description" character varying(500) NOT NULL,
+    "FullRefundHours" integer NOT NULL,
+    "PartialRefundPercent" numeric(18,2) NOT NULL,
+    "PartialRefundHours" integer NOT NULL,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_CancellationPolicies" PRIMARY KEY ("Id")
+);
+
+CREATE TABLE "Guests" (
+    "Id" uuid NOT NULL,
+    "FirstName" character varying(100) NOT NULL,
+    "LastName" character varying(100) NOT NULL,
+    "Email" character varying(255) NOT NULL,
+    "PhoneNumber" character varying(20) NOT NULL,
+    "Address" character varying(500) NOT NULL,
+    "City" character varying(50) NOT NULL,
+    "PostalCode" character varying(10) NOT NULL,
+    "Country" character varying(100) NOT NULL,
+    "DateOfBirth" timestamp with time zone,
+    "PlaceOfBirth" character varying(100) NOT NULL,
+    "Nationality" character varying(100) NOT NULL,
+    "DocumentType" integer,
+    "DocumentNumber" character varying(50) NOT NULL,
+    "DocumentIssueDate" timestamp with time zone,
+    "DocumentExpiryDate" timestamp with time zone,
+    "DocumentIssuingCountry" character varying(100) NOT NULL,
+    "DataProcessingConsentDate" timestamp with time zone,
+    "ConsentIpAddress" character varying(50) NOT NULL,
+    "DataRetentionExpiryDate" timestamp with time zone,
+    "ErasureRequested" boolean NOT NULL,
+    "ErasureRequestedDate" timestamp with time zone,
+    "DataAnonymizedDate" timestamp with time zone,
+    "Notes" character varying(1000) NOT NULL,
+    "Gender" integer,
+    "ConsentDate" timestamp with time zone,
+    "ConsentVersion" character varying(50) NOT NULL,
+    "MarketingConsent" boolean NOT NULL,
+    "MarketingConsentDate" timestamp with time zone,
+    "DataRetentionUntil" timestamp with time zone NOT NULL,
+    "DataProcessingPurpose" character varying(200) NOT NULL,
+    "IsDeleted" boolean NOT NULL,
+    "DeletedAt" timestamp with time zone,
+    "DeletionReason" character varying(500) NOT NULL,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_Guests" PRIMARY KEY ("Id")
+);
+
+CREATE TABLE "TaxRates" (
+    "Id" uuid NOT NULL,
+    "Region" character varying(100) NOT NULL,
+    "City" character varying(100) NOT NULL,
+    "RatePerNight" numeric(18,2) NOT NULL,
+    "MaxNights" integer,
+    "EffectiveFrom" timestamp with time zone NOT NULL,
+    "EffectiveTo" timestamp with time zone,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_TaxRates" PRIMARY KEY ("Id")
+);
+
+CREATE TABLE "TouristTaxRates" (
+    "Id" uuid NOT NULL,
+    "City" character varying(100) NOT NULL,
+    "RegionCode" character varying(10) NOT NULL,
+    "RatePerPersonPerNight" numeric(18,2) NOT NULL,
+    "MaxNights" integer,
+    "MinimumAge" integer NOT NULL,
+    "IsActive" boolean NOT NULL,
+    "EffectiveFrom" timestamp with time zone NOT NULL,
+    "EffectiveTo" timestamp with time zone,
+    "Notes" character varying(500) NOT NULL,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_TouristTaxRates" PRIMARY KEY ("Id")
+);
+
+CREATE TABLE "Users" (
+    "Id" character varying(255) NOT NULL,
+    "Email" character varying(255) NOT NULL,
+    "FirstName" character varying(100) NOT NULL,
+    "LastName" character varying(100) NOT NULL,
+    "PhoneNumber" character varying(20) NOT NULL,
+    "Role" integer NOT NULL,
+    "IsActive" boolean NOT NULL,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_Users" PRIMARY KEY ("Id")
+);
+
+CREATE TABLE "Properties" (
+    "Id" uuid NOT NULL,
+    "OwnerId" character varying(255) NOT NULL,
+    "Name" character varying(100) NOT NULL,
+    "Description" character varying(2000) NOT NULL,
+    "Address" character varying(500) NOT NULL,
+    "City" character varying(50) NOT NULL,
+    "PostalCode" character varying(10) NOT NULL,
+    "Latitude" numeric(18,2) NOT NULL,
+    "Longitude" numeric(18,2) NOT NULL,
+    "Bedrooms" integer NOT NULL,
+    "Bathrooms" integer NOT NULL,
+    "MaxGuests" integer NOT NULL,
+    "NightlyRate" numeric(18,2) NOT NULL,
+    "CleaningFee" numeric(18,2) NOT NULL,
+    "DamageDeposit" numeric(18,2) NOT NULL,
+    "Amenities" integer[] NOT NULL,
+    "PhotoUrls" text[] NOT NULL,
+    "HouseRules" character varying(1000) NOT NULL,
+    "CinCode" character varying(25),
+    "Timezone" character varying(50) NOT NULL,
+    "CancellationPolicyId" uuid,
+    "IsActive" boolean NOT NULL,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_Properties" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_Properties_CancellationPolicies_CancellationPolicyId" FOREIGN KEY ("CancellationPolicyId") REFERENCES "CancellationPolicies" ("Id")
+);
+
+CREATE TABLE "Bookings" (
+    "Id" uuid NOT NULL,
+    "PropertyId" uuid NOT NULL,
+    "GuestId" uuid NOT NULL,
+    "CheckInDate" timestamp with time zone NOT NULL,
+    "CheckOutDate" timestamp with time zone NOT NULL,
+    "NumberOfGuests" integer NOT NULL,
+    "Status" integer NOT NULL,
+    "Source" integer NOT NULL,
+    "ExternalId" character varying(500) NOT NULL,
+    "BasePrice" numeric(18,2) NOT NULL,
+    "TouristTax" numeric(18,2) NOT NULL,
+    "TotalPrice" numeric(18,2) NOT NULL,
+    "TouristTaxAmount" numeric(18,2) NOT NULL,
+    "NumberOfAdults" integer NOT NULL,
+    "NumberOfChildren" integer NOT NULL,
+    "SpecialRequests" character varying(1000) NOT NULL,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_Bookings" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_Bookings_Guests_GuestId" FOREIGN KEY ("GuestId") REFERENCES "Guests" ("Id") ON DELETE RESTRICT,
+    CONSTRAINT "FK_Bookings_Properties_PropertyId" FOREIGN KEY ("PropertyId") REFERENCES "Properties" ("Id") ON DELETE CASCADE
+);
+
+CREATE TABLE "LeaseContracts" (
+    "Id" uuid NOT NULL,
+    "PropertyId" uuid NOT NULL,
+    "Status" integer NOT NULL,
+    "FiscalRegime" integer NOT NULL,
+    "StartDate" timestamp with time zone NOT NULL,
+    "EndDate" timestamp with time zone NOT NULL,
+    "MonthlyRent" numeric(18,2) NOT NULL,
+    "RegistrationDeadline" timestamp with time zone NOT NULL,
+    "ExternalSigningSessionId" character varying(500),
+    "SignedPdfStoragePath" character varying(1000),
+    "ErasureRequested" boolean NOT NULL,
+    "DataRetentionUntil" timestamp with time zone NOT NULL,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_LeaseContracts" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_LeaseContracts_Properties_PropertyId" FOREIGN KEY ("PropertyId") REFERENCES "Properties" ("Id") ON DELETE RESTRICT
+);
+
+CREATE TABLE "OtaIntegrations" (
+    "Id" uuid NOT NULL,
+    "PropertyId" uuid NOT NULL,
+    "Platform" character varying(50) NOT NULL,
+    "ExternalPropertyId" character varying(500) NOT NULL,
+    "ApiKey" character varying(1000) NOT NULL,
+    "ApiSecret" character varying(1000) NOT NULL,
+    "IsActive" boolean NOT NULL,
+    "SyncEnabled" boolean NOT NULL,
+    "LastSyncAt" timestamp with time zone NOT NULL,
+    "SyncStatus" character varying(50),
+    "LastSyncError" character varying(2000),
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_OtaIntegrations" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_OtaIntegrations_Properties_PropertyId" FOREIGN KEY ("PropertyId") REFERENCES "Properties" ("Id") ON DELETE CASCADE
+);
+
+CREATE TABLE "OtaSyncLogs" (
+    "Id" uuid NOT NULL,
+    "PropertyId" uuid NOT NULL,
+    "Platform" character varying(50) NOT NULL,
+    "SyncStartedAt" timestamp with time zone NOT NULL,
+    "SyncCompletedAt" timestamp with time zone,
+    "Success" boolean NOT NULL,
+    "BookingsCreated" integer NOT NULL,
+    "BookingsUpdated" integer NOT NULL,
+    "BookingsCancelled" integer NOT NULL,
+    "ErrorMessage" character varying(2000) NOT NULL,
+    "Details" character varying(5000) NOT NULL,
+    CONSTRAINT "PK_OtaSyncLogs" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_OtaSyncLogs_Properties_PropertyId" FOREIGN KEY ("PropertyId") REFERENCES "Properties" ("Id") ON DELETE CASCADE
+);
+
+CREATE TABLE "PricingAdapterConfigs" (
+    "Id" uuid NOT NULL,
+    "PropertyId" uuid NOT NULL,
+    "IsEnabled" boolean NOT NULL,
+    "AdaptationFrequency" character varying(50) NOT NULL,
+    "IncludeSeasonality" boolean NOT NULL,
+    "IncludePublicHolidays" boolean NOT NULL,
+    "LastAdaptedAt" timestamp with time zone,
+    "NextScheduledRunAt" timestamp with time zone,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_PricingAdapterConfigs" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_PricingAdapterConfigs_Properties_PropertyId" FOREIGN KEY ("PropertyId") REFERENCES "Properties" ("Id") ON DELETE CASCADE
+);
+
+CREATE TABLE "PricingHistories" (
+    "Id" uuid NOT NULL,
+    "PropertyId" uuid NOT NULL,
+    "AdaptationDate" timestamp with time zone NOT NULL,
+    "PreviousPrice" numeric(18,2) NOT NULL,
+    "NewPrice" numeric(18,2) NOT NULL,
+    "ChangeReason" character varying(500) NOT NULL,
+    "AiConfidence" numeric(5,4) NOT NULL,
+    "OtasSynced" character varying(2000) NOT NULL,
+    "SyncStatus" character varying(50) NOT NULL,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_PricingHistories" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_PricingHistories_Properties_PropertyId" FOREIGN KEY ("PropertyId") REFERENCES "Properties" ("Id") ON DELETE CASCADE
+);
+
+CREATE TABLE "PropertyDocuments" (
+    "Id" uuid NOT NULL,
+    "PropertyId" uuid NOT NULL,
+    "FileName" character varying(500) NOT NULL,
+    "StorageUrl" character varying(2000) NOT NULL,
+    "DocumentType" character varying(100) NOT NULL,
+    "UploadedBy" character varying(255) NOT NULL,
+    "UploadedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_PropertyDocuments" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_PropertyDocuments_Properties_PropertyId" FOREIGN KEY ("PropertyId") REFERENCES "Properties" ("Id") ON DELETE CASCADE
+);
+
+CREATE TABLE "AlloggiatiWebReports" (
+    "Id" uuid NOT NULL,
+    "BookingId" uuid NOT NULL,
+    "GuestId" uuid NOT NULL,
+    "ReportedAt" timestamp with time zone NOT NULL,
+    "Status" integer NOT NULL,
+    "ConfirmationNumber" character varying(100),
+    "ErrorMessage" character varying(2000),
+    "RetryCount" integer NOT NULL,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_AlloggiatiWebReports" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_AlloggiatiWebReports_Bookings_BookingId" FOREIGN KEY ("BookingId") REFERENCES "Bookings" ("Id") ON DELETE RESTRICT,
+    CONSTRAINT "FK_AlloggiatiWebReports_Guests_GuestId" FOREIGN KEY ("GuestId") REFERENCES "Guests" ("Id") ON DELETE RESTRICT
+);
+
+CREATE TABLE "Payments" (
+    "Id" uuid NOT NULL,
+    "BookingId" uuid NOT NULL,
+    "Amount" numeric(18,2) NOT NULL,
+    "RefundedAmount" numeric(18,2) NOT NULL,
+    "Status" integer NOT NULL,
+    "Method" integer NOT NULL,
+    "TransactionId" character varying(500) NOT NULL,
+    "Description" character varying(1000) NOT NULL,
+    "StripePaymentIntentId" character varying(255),
+    "ProcessedAt" timestamp with time zone,
+    "CreatedAt" timestamp with time zone NOT NULL,
+    "UpdatedAt" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_Payments" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_Payments_Bookings_BookingId" FOREIGN KEY ("BookingId") REFERENCES "Bookings" ("Id") ON DELETE CASCADE
+);
+
+CREATE TABLE "LeaseEvents" (
+    "Id" uuid NOT NULL,
+    "LeaseContractId" uuid NOT NULL,
+    "EventType" integer NOT NULL,
+    "OccurredAt" timestamp with time zone NOT NULL,
+    "Payload" text,
+    CONSTRAINT "PK_LeaseEvents" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_LeaseEvents_LeaseContracts_LeaseContractId" FOREIGN KEY ("LeaseContractId") REFERENCES "LeaseContracts" ("Id") ON DELETE CASCADE
+);
+
+CREATE TABLE "LeaseRegistrations" (
+    "Id" uuid NOT NULL,
+    "LeaseContractId" uuid NOT NULL,
+    "Status" integer NOT NULL,
+    "ExternalRegistrationId" character varying(200),
+    "RegistrationCode" character varying(100),
+    "ReceiptStoragePath" character varying(1000),
+    "SubmittedAt" timestamp with time zone,
+    "ConfirmedAt" timestamp with time zone,
+    CONSTRAINT "PK_LeaseRegistrations" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_LeaseRegistrations_LeaseContracts_LeaseContractId" FOREIGN KEY ("LeaseContractId") REFERENCES "LeaseContracts" ("Id") ON DELETE CASCADE
+);
+
+CREATE TABLE "Parties" (
+    "Id" uuid NOT NULL,
+    "LeaseContractId" uuid NOT NULL,
+    "Role" integer NOT NULL,
+    "FirstName" character varying(100) NOT NULL,
+    "LastName" character varying(100) NOT NULL,
+    "FiscalCode" character varying(16) NOT NULL,
+    "Citizenship" character varying(2) NOT NULL,
+    "ContactEmail" character varying(255) NOT NULL,
+    "IsExtraEU" boolean NOT NULL,
+    CONSTRAINT "PK_Parties" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_Parties_LeaseContracts_LeaseContractId" FOREIGN KEY ("LeaseContractId") REFERENCES "LeaseContracts" ("Id") ON DELETE CASCADE
+);
+
+CREATE INDEX "IX_AlloggiatiWebReports_BookingId" ON "AlloggiatiWebReports" ("BookingId");
+
+CREATE INDEX "IX_AlloggiatiWebReports_GuestId" ON "AlloggiatiWebReports" ("GuestId");
+
+CREATE INDEX "IX_Bookings_CheckInDate" ON "Bookings" ("CheckInDate");
+
+CREATE INDEX "IX_Bookings_GuestId" ON "Bookings" ("GuestId");
+
+CREATE INDEX "IX_Bookings_PropertyId" ON "Bookings" ("PropertyId");
+
+CREATE INDEX "IX_Bookings_Status" ON "Bookings" ("Status");
+
+CREATE INDEX "IX_Guests_Email" ON "Guests" ("Email");
+
+CREATE INDEX "IX_LeaseContracts_PropertyId" ON "LeaseContracts" ("PropertyId");
+
+CREATE INDEX "IX_LeaseContracts_Status" ON "LeaseContracts" ("Status");
+
+CREATE INDEX "IX_LeaseEvents_LeaseContractId_OccurredAt" ON "LeaseEvents" ("LeaseContractId", "OccurredAt");
+
+CREATE UNIQUE INDEX "IX_LeaseRegistrations_LeaseContractId" ON "LeaseRegistrations" ("LeaseContractId");
+
+CREATE INDEX "IX_OtaIntegrations_PropertyId" ON "OtaIntegrations" ("PropertyId");
+
+CREATE INDEX "IX_OtaSyncLogs_PropertyId" ON "OtaSyncLogs" ("PropertyId");
+
+CREATE INDEX "IX_Parties_LeaseContractId_Role" ON "Parties" ("LeaseContractId", "Role");
+
+CREATE INDEX "IX_Payments_BookingId" ON "Payments" ("BookingId");
+
+CREATE UNIQUE INDEX "IX_PricingAdapterConfigs_PropertyId" ON "PricingAdapterConfigs" ("PropertyId");
+
+CREATE INDEX "IX_PricingAdapterConfigs_PropertyId_IsEnabled" ON "PricingAdapterConfigs" ("PropertyId", "IsEnabled");
+
+CREATE INDEX "IX_PricingHistories_PropertyId_AdaptationDate" ON "PricingHistories" ("PropertyId", "AdaptationDate");
+
+CREATE UNIQUE INDEX "IX_Properties_Address_City_PostalCode_IsActive" ON "Properties" ("Address", "City", "PostalCode", "IsActive") WHERE "IsActive" = true;
+
+CREATE INDEX "IX_Properties_CancellationPolicyId" ON "Properties" ("CancellationPolicyId");
+
+CREATE INDEX "IX_Properties_OwnerId" ON "Properties" ("OwnerId");
+
+CREATE INDEX "IX_PropertyDocuments_PropertyId" ON "PropertyDocuments" ("PropertyId");
+
+CREATE INDEX "IX_TouristTaxRates_City" ON "TouristTaxRates" ("City");
+
+CREATE INDEX "IX_TouristTaxRates_City_IsActive_EffectiveFrom" ON "TouristTaxRates" ("City", "IsActive", "EffectiveFrom");
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20260603080357_InitialCreate', '10.0.1');
+
+COMMIT;
+
+START TRANSACTION;
+ALTER TABLE "Users" ADD "LastUsedContextKey" character varying(64);
+
+CREATE TABLE "AppContexts" (
+    "Key" character varying(64) NOT NULL,
+    "DisplayName" character varying(128) NOT NULL,
+    CONSTRAINT "PK_AppContexts" PRIMARY KEY ("Key")
+);
+
+CREATE TABLE "Roles" (
+    "Id" integer GENERATED BY DEFAULT AS IDENTITY,
+    "ContextKey" character varying(64) NOT NULL,
+    "RoleKey" character varying(64) NOT NULL,
+    CONSTRAINT "PK_Roles" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_Roles_AppContexts_ContextKey" FOREIGN KEY ("ContextKey") REFERENCES "AppContexts" ("Key") ON DELETE CASCADE
+);
+
+CREATE TABLE "RolePermissions" (
+    "RoleId" integer NOT NULL,
+    "PermissionKey" character varying(128) NOT NULL,
+    CONSTRAINT "PK_RolePermissions" PRIMARY KEY ("RoleId", "PermissionKey"),
+    CONSTRAINT "FK_RolePermissions_Roles_RoleId" FOREIGN KEY ("RoleId") REFERENCES "Roles" ("Id") ON DELETE CASCADE
+);
+
+CREATE TABLE "UserContextMemberships" (
+    "Id" uuid NOT NULL,
+    "UserId" character varying(255) NOT NULL,
+    "ContextKey" character varying(64) NOT NULL,
+    "RoleId" integer NOT NULL,
+    CONSTRAINT "PK_UserContextMemberships" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_UserContextMemberships_AppContexts_ContextKey" FOREIGN KEY ("ContextKey") REFERENCES "AppContexts" ("Key") ON DELETE CASCADE,
+    CONSTRAINT "FK_UserContextMemberships_Roles_RoleId" FOREIGN KEY ("RoleId") REFERENCES "Roles" ("Id") ON DELETE CASCADE,
+    CONSTRAINT "FK_UserContextMemberships_Users_UserId" FOREIGN KEY ("UserId") REFERENCES "Users" ("Id") ON DELETE CASCADE
+);
+
+INSERT INTO "AppContexts" ("Key", "DisplayName")
+VALUES ('admin', 'Amministrazione');
+INSERT INTO "AppContexts" ("Key", "DisplayName")
+VALUES ('long-rent', 'Affitti lungo termine');
+INSERT INTO "AppContexts" ("Key", "DisplayName")
+VALUES ('short-rent', 'Affitti brevi');
+
+INSERT INTO "Roles" ("Id", "ContextKey", "RoleKey")
+VALUES (1, 'short-rent', 'property_owner');
+INSERT INTO "Roles" ("Id", "ContextKey", "RoleKey")
+VALUES (2, 'long-rent', 'long_term_landlord');
+INSERT INTO "Roles" ("Id", "ContextKey", "RoleKey")
+VALUES (3, 'admin', 'platform_admin');
+
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('booking.read', 1);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('booking.write', 1);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('guest.read', 1);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('guest.write', 1);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('ota.read', 1);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('ota.write', 1);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('payment.read', 1);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('payment.write', 1);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('property.read', 1);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('property.write', 1);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('lease.create', 2);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('lease.read', 2);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('lease.register', 2);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('lease.sign', 2);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('admin.cin.read', 3);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('admin.jobs.read', 3);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('admin.stats.read', 3);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('admin.tax.manage', 3);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('admin.users.manage', 3);
+INSERT INTO "RolePermissions" ("PermissionKey", "RoleId")
+VALUES ('admin.users.read', 3);
+
+INSERT INTO "UserContextMemberships" ("Id", "UserId", "ContextKey", "RoleId")
+SELECT
+    ('00000000-0000-0000-0000-' || substring(md5(u."Id" || ':short-rent') from 1 for 12))::uuid,
+    u."Id",
+    'short-rent',
+    1
+FROM "Users" u
+WHERE u."Role" = 1
+ON CONFLICT ("UserId", "ContextKey") DO NOTHING;
+
+INSERT INTO "UserContextMemberships" ("Id", "UserId", "ContextKey", "RoleId")
+SELECT
+    ('00000000-0000-0000-0000-' || substring(md5(u."Id" || ':long-rent') from 1 for 12))::uuid,
+    u."Id",
+    'long-rent',
+    2
+FROM "Users" u
+WHERE u."Role" = 5
+ON CONFLICT ("UserId", "ContextKey") DO NOTHING;
+
+INSERT INTO "UserContextMemberships" ("Id", "UserId", "ContextKey", "RoleId")
+SELECT
+    ('00000000-0000-0000-0000-' || substring(md5(u."Id" || ':admin') from 1 for 12))::uuid,
+    u."Id",
+    'admin',
+    3
+FROM "Users" u
+WHERE u."Role" = 0
+ON CONFLICT ("UserId", "ContextKey") DO NOTHING;
+
+CREATE UNIQUE INDEX "IX_Roles_ContextKey_RoleKey" ON "Roles" ("ContextKey", "RoleKey");
+
+CREATE INDEX "IX_UserContextMemberships_ContextKey" ON "UserContextMemberships" ("ContextKey");
+
+CREATE INDEX "IX_UserContextMemberships_RoleId" ON "UserContextMemberships" ("RoleId");
+
+CREATE UNIQUE INDEX "IX_UserContextMemberships_UserId_ContextKey" ON "UserContextMemberships" ("UserId", "ContextKey");
+
+SELECT setval(
+    pg_get_serial_sequence('"Roles"', 'Id'),
+    GREATEST(
+        (SELECT MAX("Id") FROM "Roles") + 1,
+        nextval(pg_get_serial_sequence('"Roles"', 'Id'))),
+    false);
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20260604193911_AddContextAuthorization', '10.0.1');
+
+COMMIT;
+

--- a/Casazen.Infrastructure/Services/ContextAuthorizationService.cs
+++ b/Casazen.Infrastructure/Services/ContextAuthorizationService.cs
@@ -1,0 +1,112 @@
+using Casazen.Core.Authorization;
+using Casazen.Core.Services;
+using Casazen.Infrastructure.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+
+namespace Casazen.Infrastructure.Services;
+
+public class ContextAuthorizationService(
+    AppDbContext dbContext,
+    IHttpContextAccessor httpContextAccessor) : IContextAuthorizationService
+{
+    public async Task<IReadOnlyList<ContextAccess>> GetUserContextsAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        var memberships = await dbContext.UserContextMemberships
+            .AsNoTracking()
+            .Include(m => m.Context)
+            .Include(m => m.Role)
+            .ThenInclude(r => r.Permissions)
+            .Where(m => m.UserId == userId)
+            .OrderBy(m => m.ContextKey)
+            .ToListAsync(cancellationToken);
+
+        if (memberships.Count > 0)
+        {
+            return memberships.Select(m => new ContextAccess(
+                    m.ContextKey,
+                    m.Context.DisplayName,
+                    m.Role.RoleKey,
+                    m.Role.Permissions.Select(p => p.PermissionKey).OrderBy(p => p).ToList(),
+                    GetDefaultRoute(m.ContextKey)))
+                .ToList();
+        }
+
+        var jwtRoles = ParseRoles(httpContextAccessor.HttpContext?.User.FindAll("https://casazen.app/roles").Select(c => c.Value) ?? []);
+
+        return ContextAccessBootstrap.BuildFallbackAccess(jwtRoles);
+    }
+
+    public async Task<bool> HasPermissionAsync(
+        string userId,
+        string contextKey,
+        string permissionKey,
+        CancellationToken cancellationToken = default)
+    {
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+
+        if (user is null || !user.IsActive)
+        {
+            return false;
+        }
+
+        var contexts = await GetUserContextsAsync(userId, cancellationToken);
+        var context = contexts.FirstOrDefault(c => string.Equals(c.ContextKey, contextKey, StringComparison.OrdinalIgnoreCase));
+        if (context is null)
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(permissionKey))
+        {
+            return true;
+        }
+
+        return context.Permissions.Contains(permissionKey, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string GetDefaultRoute(string contextKey) =>
+        contextKey switch
+        {
+            "short-rent" => "/app/short-rent",
+            "long-rent" => "/app/long-rent/leases",
+            "admin" => "/app/admin",
+            _ => "/app/choose-context",
+        };
+
+    private static IReadOnlyList<string> ParseRoles(IEnumerable<string?> claimValues)
+    {
+        var roles = new List<string>();
+        foreach (var value in claimValues)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            var trimmed = value.Trim();
+            if (trimmed.StartsWith('['))
+            {
+                try
+                {
+                    var parsed = JsonSerializer.Deserialize<string[]>(trimmed);
+                    if (parsed is { Length: > 0 })
+                    {
+                        roles.AddRange(parsed.Where(r => !string.IsNullOrWhiteSpace(r))!);
+                        continue;
+                    }
+                }
+                catch (JsonException)
+                {
+                }
+            }
+
+            roles.Add(trimmed);
+        }
+
+        return roles.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+    }
+}

--- a/Casazen.Tests/Unit/Auth/ContextAccessBootstrapTests.cs
+++ b/Casazen.Tests/Unit/Auth/ContextAccessBootstrapTests.cs
@@ -1,0 +1,34 @@
+using Casazen.Core.Authorization;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Auth;
+
+public class ContextAccessBootstrapTests
+{
+    [Fact]
+    public void DeriveContextsFromJwtRoles_MapsKnownRolesToContexts()
+    {
+        var contexts = ContextAccessBootstrap.DeriveContextsFromJwtRoles([
+            "PropertyOwner",
+            "LongTermLandlord",
+            "Admin"
+        ]);
+
+        Assert.Equal(3, contexts.Count);
+        Assert.Contains(contexts, c => c.ContextKey == "short-rent" && c.RoleKey == "property_owner");
+        Assert.Contains(contexts, c => c.ContextKey == "long-rent" && c.RoleKey == "long_term_landlord");
+        Assert.Contains(contexts, c => c.ContextKey == "admin" && c.RoleKey == "platform_admin");
+    }
+
+    [Fact]
+    public void DeriveContextsFromJwtRoles_IgnoresUnknownRoles()
+    {
+        var contexts = ContextAccessBootstrap.DeriveContextsFromJwtRoles([
+            "UnknownRole",
+            "PropertyOwner"
+        ]);
+
+        Assert.Single(contexts);
+        Assert.Equal("short-rent", contexts[0].ContextKey);
+    }
+}

--- a/Casazen.Tests/Unit/Controllers/MeControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/MeControllerTests.cs
@@ -1,0 +1,75 @@
+using System.Security.Claims;
+using Casazen.Core.Entities;
+using Casazen.Core.Services;
+using Casazen.Web.Controllers;
+using Casazen.Web.DTOs.Auth;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Controllers;
+
+public class MeControllerTests
+{
+    [Fact]
+    public async Task GetContexts_WhenUserInactive_Returns403()
+    {
+        var userService = new Mock<IUserService>();
+        var contextService = new Mock<IContextAuthorizationService>();
+        userService.Setup(x => x.GetCurrentUserAsync("auth0|inactive", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new User { Id = "auth0|inactive", Email = "user@test.com", FirstName = "User", LastName = "Test", IsActive = false });
+
+        var controller = BuildController(userService.Object, contextService.Object, "auth0|inactive");
+
+        var result = await controller.GetContexts(CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status403Forbidden, objectResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetContexts_WhenUserActive_ReturnsBootstrapResponse()
+    {
+        var userService = new Mock<IUserService>();
+        var contextService = new Mock<IContextAuthorizationService>();
+        userService.Setup(x => x.GetCurrentUserAsync("auth0|active", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new User
+            {
+                Id = "auth0|active",
+                Email = "user@test.com",
+                FirstName = "User",
+                LastName = "Test",
+                IsActive = true,
+                LastUsedContextKey = "short-rent",
+            });
+        contextService.Setup(x => x.GetUserContextsAsync("auth0|active", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new ContextAccess("short-rent", "Affitti brevi", "property_owner", ["booking.read"], "/app/short-rent"),
+            ]);
+
+        var controller = BuildController(userService.Object, contextService.Object, "auth0|active");
+
+        var result = await controller.GetContexts(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<UserContextsResponse>(ok.Value);
+        Assert.Equal("auth0|active", payload.UserId);
+        Assert.Single(payload.Contexts);
+        Assert.Equal("short-rent", payload.LastUsedContextKey);
+    }
+
+    private static MeController BuildController(
+        IUserService userService,
+        IContextAuthorizationService contextAuthorizationService,
+        string userId)
+    {
+        var controller = new MeController(userService, contextAuthorizationService);
+        var identity = new ClaimsIdentity(new[] { new Claim("sub", userId) }, "TestAuth");
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) },
+        };
+        return controller;
+    }
+}

--- a/Casazen.Web/Controllers/BookingController.cs
+++ b/Casazen.Web/Controllers/BookingController.cs
@@ -12,6 +12,7 @@ namespace Casazen.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "PropertyOwner")]
+[Authorize(Policy = "RequireContext:short-rent:booking.read")]
 public class BookingsController(
     IBookingService bookingService,
     ITaxCalculationService taxCalculationService,
@@ -40,6 +41,7 @@ public class BookingsController(
     }
 
     [HttpPost]
+    [Authorize(Policy = "RequireContext:short-rent:booking.write")]
     public async Task<ActionResult<Booking>> Create([FromBody] Booking booking)
     {
         logger.LogInformation("Creating booking for property: {PropertyId}", booking.PropertyId);
@@ -66,6 +68,7 @@ public class BookingsController(
     }
 
     [HttpPut("{id}")]
+    [Authorize(Policy = "RequireContext:short-rent:booking.write")]
     public async Task<IActionResult> Update(Guid id, [FromBody] Booking booking)
     {
         var existing = await bookingService.GetBookingAsync(id);
@@ -78,6 +81,7 @@ public class BookingsController(
     }
 
     [HttpDelete("{id}")]
+    [Authorize(Policy = "RequireContext:short-rent:booking.write")]
     public async Task<IActionResult> Cancel(Guid id)
     {
         logger.LogInformation("Cancelling booking: {BookingId}", id);
@@ -140,6 +144,7 @@ public class BookingsController(
     }
 
     [HttpPost("{id}/check-in")]
+    [Authorize(Policy = "RequireContext:short-rent:booking.write")]
     public async Task<IActionResult> CheckIn(Guid id)
     {
         var booking = await bookingService.GetBookingAsync(id);
@@ -178,6 +183,7 @@ public class BookingsController(
     }
 
     [HttpPost("{id}/check-out")]
+    [Authorize(Policy = "RequireContext:short-rent:booking.write")]
     public async Task<IActionResult> CheckOut(Guid id)
     {
         var booking = await bookingService.GetBookingAsync(id);

--- a/Casazen.Web/Controllers/LeasesController.cs
+++ b/Casazen.Web/Controllers/LeasesController.cs
@@ -10,6 +10,7 @@ namespace Casazen.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "LongTermLandlord")]
+[Authorize(Policy = "RequireContext:long-rent:lease.read")]
 public class LeasesController(ILeaseWorkflowService leaseService) : ControllerBase
 {
     private string? GetOwnerId() =>
@@ -35,6 +36,7 @@ public class LeasesController(ILeaseWorkflowService leaseService) : ControllerBa
 
     /// <summary>Create a new lease contract draft.</summary>
     [HttpPost]
+    [Authorize(Policy = "RequireContext:long-rent:lease.create")]
     public async Task<IActionResult> Create([FromBody] CreateLeaseDto dto)
     {
         if (GetOwnerId() is not { } ownerId) return Unauthorized();
@@ -63,6 +65,7 @@ public class LeasesController(ILeaseWorkflowService leaseService) : ControllerBa
 
     /// <summary>Generate PDF/A and initiate digital signing for a lease in Draft status.</summary>
     [HttpPost("{id:guid}/signing")]
+    [Authorize(Policy = "RequireContext:long-rent:lease.sign")]
     public async Task<IActionResult> InitiateSigning(Guid id)
     {
         if (GetOwnerId() is not { } ownerId) return Unauthorized();
@@ -83,6 +86,7 @@ public class LeasesController(ILeaseWorkflowService leaseService) : ControllerBa
 
     /// <summary>Submit a Signed lease to Openapi.it Docuengine for RLI registration (async).</summary>
     [HttpPost("{id:guid}/registration")]
+    [Authorize(Policy = "RequireContext:long-rent:lease.register")]
     public async Task<IActionResult> TriggerRegistration(Guid id)
     {
         if (GetOwnerId() is not { } ownerId) return Unauthorized();

--- a/Casazen.Web/Controllers/MeController.cs
+++ b/Casazen.Web/Controllers/MeController.cs
@@ -1,0 +1,59 @@
+using System.Security.Claims;
+using Casazen.Core.Services;
+using Casazen.Web.DTOs.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Casazen.Web.Controllers;
+
+[ApiController]
+[Route("api/me")]
+[Authorize]
+public class MeController(
+    IUserService userService,
+    IContextAuthorizationService contextAuthorizationService) : ControllerBase
+{
+    [HttpGet("contexts")]
+    public async Task<ActionResult<UserContextsResponse>> GetContexts(CancellationToken cancellationToken)
+    {
+        var sub = GetSub();
+        if (string.IsNullOrWhiteSpace(sub))
+        {
+            return Unauthorized();
+        }
+
+        var email = User.FindFirst("email")?.Value
+                    ?? User.FindFirst(ClaimTypes.Email)?.Value
+                    ?? string.Empty;
+        var firstName = User.FindFirst("given_name")?.Value
+                        ?? User.FindFirst("name")?.Value?.Split(' ').FirstOrDefault()
+                        ?? string.Empty;
+        var lastName = User.FindFirst("family_name")?.Value
+                       ?? User.FindFirst("name")?.Value?.Split(' ').Skip(1).FirstOrDefault()
+                       ?? string.Empty;
+
+        var user = await userService.GetCurrentUserAsync(sub, email, firstName, lastName);
+        if (!user.IsActive)
+        {
+            return StatusCode(StatusCodes.Status403Forbidden, new { error = "User account inactive" });
+        }
+
+        var contexts = await contextAuthorizationService.GetUserContextsAsync(sub, cancellationToken);
+        var response = new UserContextsResponse(
+            sub,
+            contexts.Select(c => new ContextBootstrapDto(
+                c.ContextKey,
+                c.DisplayName,
+                c.RoleKey,
+                c.Permissions,
+                c.DefaultRoute)).ToList(),
+            user.LastUsedContextKey);
+
+        return Ok(response);
+    }
+
+    private string? GetSub() =>
+        User.FindFirst("sub")?.Value
+        ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+        ?? User.FindFirst("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")?.Value;
+}

--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -12,6 +12,7 @@ namespace Casazen.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "PropertyOwner")]
+[Authorize(Policy = "RequireContext:short-rent:property.read")]
 public class PropertiesController(
     IPropertyService propertyService,
     IImageStorageService imageStorageService,
@@ -74,6 +75,7 @@ public class PropertiesController(
     /// <response code="201">Property created successfully.</response>
     /// <response code="401">The caller is not authenticated.</response>
     [HttpPost]
+    [Authorize(Policy = "RequireContext:short-rent:property.write")]
     public async Task<ActionResult<Property>> Create([FromBody] CreatePropertyRequest request)
     {
         var userId = GetAuthenticatedUserId();
@@ -103,6 +105,7 @@ public class PropertiesController(
     /// <response code="403">The caller is not the owner of this property.</response>
     /// <response code="404">No property found with the given <paramref name="id"/>.</response>
     [HttpPut("{id}")]
+    [Authorize(Policy = "RequireContext:short-rent:property.write")]
     public async Task<IActionResult> Update(Guid id, [FromBody] UpdatePropertyRequest request)
     {
         var userId = GetAuthenticatedUserId();
@@ -126,6 +129,7 @@ public class PropertiesController(
     }
 
     [HttpDelete("{id}")]
+    [Authorize(Policy = "RequireContext:short-rent:property.write")]
     public async Task<IActionResult> Delete(Guid id)
     {
         var userId = GetAuthenticatedUserId();
@@ -164,6 +168,7 @@ public class PropertiesController(
 
     [HttpPost("{id}/images")]
     [Consumes("multipart/form-data")]
+    [Authorize(Policy = "RequireContext:short-rent:property.write")]
     public async Task<ActionResult<Property>> UploadImages(Guid id, [FromForm] List<IFormFile> images)
     {
         var userId = GetAuthenticatedUserId();
@@ -228,6 +233,7 @@ public class PropertiesController(
     }
 
     [HttpDelete("{id}/images/{imageIndex}")]
+    [Authorize(Policy = "RequireContext:short-rent:property.write")]
     public async Task<ActionResult<Property>> DeleteImage(Guid id, int imageIndex)
     {
         var userId = GetAuthenticatedUserId();
@@ -277,6 +283,7 @@ public class PropertiesController(
     }
 
     [HttpPut("{id}/images/order")]
+    [Authorize(Policy = "RequireContext:short-rent:property.write")]
     public async Task<ActionResult<Property>> ReorderImages(Guid id, [FromBody] List<string> orderedImageUrls)
     {
         var userId = GetAuthenticatedUserId();
@@ -386,6 +393,7 @@ public class PropertiesController(
     /// <response code="404">No property found with the given <paramref name="id"/>.</response>
     [HttpPost("{id}/documents")]
     [Consumes("multipart/form-data")]
+    [Authorize(Policy = "RequireContext:short-rent:property.write")]
     public async Task<ActionResult<PropertyDocumentDto>> UploadDocument(
         Guid id,
         IFormFile file,
@@ -420,6 +428,7 @@ public class PropertiesController(
     /// <response code="403">The caller does not own this property.</response>
     /// <response code="404">Property or document not found.</response>
     [HttpDelete("{id}/documents/{docId}")]
+    [Authorize(Policy = "RequireContext:short-rent:property.write")]
     public async Task<IActionResult> DeleteDocument(Guid id, Guid docId)
     {
         var userId = GetAuthenticatedUserId();

--- a/Casazen.Web/DTOs/Auth/ContextBootstrapDto.cs
+++ b/Casazen.Web/DTOs/Auth/ContextBootstrapDto.cs
@@ -1,0 +1,9 @@
+namespace Casazen.Web.DTOs.Auth;
+
+public record ContextBootstrapDto(
+    string ContextKey,
+    string DisplayName,
+    string RoleKey,
+    IReadOnlyList<string> Permissions,
+    string DefaultRoute
+);

--- a/Casazen.Web/DTOs/Auth/UserContextsResponse.cs
+++ b/Casazen.Web/DTOs/Auth/UserContextsResponse.cs
@@ -1,0 +1,7 @@
+namespace Casazen.Web.DTOs.Auth;
+
+public record UserContextsResponse(
+    string UserId,
+    IReadOnlyList<ContextBootstrapDto> Contexts,
+    string? LastUsedContextKey
+);

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Casazen.Infrastructure.OTA.Resilience;
 using Casazen.Infrastructure.Repositories;
 using Casazen.Infrastructure.Services;
 using Casazen.Web.Infrastructure;
+using Microsoft.AspNetCore.Authorization;
 using Casazen.Web.Middleware;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -110,12 +111,52 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddCasazenAuthorization(this IServiceCollection services)
     {
-        services.AddAuthorizationBuilder()
+        services.AddHttpContextAccessor();
+        services.AddScoped<IContextAuthorizationService, ContextAuthorizationService>();
+        services.AddScoped<IAuthorizationHandler, ContextAuthorizationHandler>();
+
+        var builder = services.AddAuthorizationBuilder()
             .AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"))
             .AddPolicy("PropertyOwner", policy => policy.RequireAuthenticatedUser())
             .AddPolicy("LongTermLandlord", policy => policy.RequireRole("LongTermLandlord"));
 
+        RegisterContextPolicies(builder);
+
         return services;
+    }
+
+    private static void RegisterContextPolicies(AuthorizationBuilder builder)
+    {
+        var contextPermissions = new Dictionary<string, string[]>
+        {
+            ["short-rent"] =
+            [
+                "property.read", "property.write",
+                "booking.read", "booking.write",
+                "payment.read", "payment.write",
+                "ota.read", "ota.write",
+                "guest.read", "guest.write",
+            ],
+            ["long-rent"] =
+            [
+                "lease.read", "lease.create", "lease.sign", "lease.register",
+            ],
+            ["admin"] =
+            [
+                "admin.stats.read", "admin.users.read", "admin.users.manage",
+                "admin.cin.read", "admin.jobs.read", "admin.tax.manage",
+            ],
+        };
+
+        foreach (var pair in contextPermissions)
+        {
+            foreach (var permission in pair.Value)
+            {
+                var policyName = $"RequireContext:{pair.Key}:{permission}";
+                builder.AddPolicy(policyName, policy =>
+                    policy.Requirements.Add(new ContextPermissionRequirement(pair.Key, permission)));
+            }
+        }
     }
 
     public static IServiceCollection AddCasazenCors(this IServiceCollection services, IConfiguration configuration)

--- a/Casazen.Web/Infrastructure/ContextAuthorizationHandler.cs
+++ b/Casazen.Web/Infrastructure/ContextAuthorizationHandler.cs
@@ -1,0 +1,35 @@
+using System.Security.Claims;
+using Casazen.Core.Services;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Casazen.Web.Infrastructure;
+
+public sealed record ContextPermissionRequirement(string ContextKey, string PermissionKey) : IAuthorizationRequirement;
+
+public class ContextAuthorizationHandler(
+    IContextAuthorizationService contextAuthorizationService) : AuthorizationHandler<ContextPermissionRequirement>
+{
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        ContextPermissionRequirement requirement)
+    {
+        var userId = context.User.FindFirstValue("sub")
+            ?? context.User.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? context.User.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier");
+
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return;
+        }
+
+        var authorized = await contextAuthorizationService.HasPermissionAsync(
+            userId,
+            requirement.ContextKey,
+            requirement.PermissionKey);
+
+        if (authorized)
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/Sessions/design-189.md
+++ b/Sessions/design-189.md
@@ -1,0 +1,677 @@
+# Design Spec — Issue #189
+# feat: context workspace switcher (short-rent, long-rent, admin)
+
+**Stage**: 02 Design  
+**Date**: 2026-06-04  
+**Issue**: https://github.com/casazen/backend/issues/189  
+**Planning ref**: `Sessions/pipeline-context-workspace-switch/`  
+**Analysis ref**: `Sessions/specs/spec-split-layer.md`, `Sessions/pipeline-context-workspace-switch/external-analysis.md`  
+**Prior work**: `Sessions/design-182.md` (#182 — layer shells; **extend, do not duplicate**)  
+**Branch target (Stage 03)**: `feature/189-context-workspace-switch` (frontend + backend)  
+**Status**: COMPLETE — all gates passed
+
+---
+
+## Scope
+
+Generalize the #182 **layer** model into three first-class **application contexts** (`short-rent`, `long-rent`, `admin`) with:
+
+- Canonical URLs under `/app/:context/*`
+- Central **route manifest** (nav, guards, default landings)
+- **Workspace switcher** (Italian UI labels) for multi-context users
+- Backend **contextual authorization** (membership + permissions), with a phased JWT stub during migration
+
+**Out of scope**: Re-implementing lease UI (#177), admin feature pages beyond routing/shell, new regulated data flows, OTA/Stripe/Hangfire logic changes.
+
+**Extends #182**: Keeps lease pages, three shells, and existing API contracts; migrates paths and auth model. Does not re-open closed #182 deliverables.
+
+---
+
+## Phased delivery
+
+| Phase | Repo | Deliverable | Membership source |
+|---|---|---|---|
+| **A** | Frontend | Context-prefixed routes, route manifest, workspace switcher, legacy redirects, post-login context resolution | JWT roles → synthetic contexts (client-side mapper; same mapping server will use in B) |
+| **B** | Backend | EF tables, seed, `GET /api/me/contexts`, contextual policy handler on critical controllers | DB `UserContextMembership` (+ JWT fallback until C) |
+| **C** | Backend + Auth0 | Optional: Auth0 Action / Management API alignment; reduce duplicate global operational roles | DB authoritative; JWT roles for identity/bootstrap only |
+
+Stages 03–05 may ship **A then B** in one PR pair or sequential PRs; **C** is a follow-up slice in the same issue if feasible, otherwise a child issue.
+
+---
+
+## Council specialist outputs (summary)
+
+| Specialist | Verdict |
+|---|---|
+| **api-designer** | One new bootstrap endpoint; existing REST paths unchanged; Phase B adds `RequireContext` policy without breaking request/response schemas |
+| **frontend-designer** | Manifest-driven router; unify shell chrome; deprecate `AppLayer` / `ShortStayLayerGuard` in favor of `WorkspaceContext` + `ContextRouteGuard` |
+| **security-by-design** | FE guards are UX only; BE evaluates membership per context; bootstrap returns least privilege; no PII in `localStorage` |
+
+---
+
+## API Contract
+
+### Summary
+
+| Change type | Phase | Count |
+|---|---|---|
+| New endpoints | B | 1 (`GET /api/me/contexts`) |
+| Modified auth (policy handler) | B | Critical controllers (see below) — no schema change |
+| Unchanged endpoints | A–C | All existing REST paths and DTOs |
+
+### New — `GET /api/me/contexts` (Phase B)
+
+Bootstrap for workspace switcher, post-login routing, and FE permission checks.
+
+| | |
+|---|---|
+| **Method / Path** | `GET /api/me/contexts` |
+| **Auth** | `[Authorize]` — caller must be authenticated; upserts `User` on first call (same as `GET /api/users/me`) |
+| **Request** | None |
+| **Response 200** | `UserContextsResponse` |
+
+```json
+{
+  "userId": "auth0|abc123",
+  "contexts": [
+    {
+      "contextKey": "short-rent",
+      "displayName": "Affitti brevi",
+      "roleKey": "property_owner",
+      "permissions": ["booking.read", "property.read", "payment.read", "ota.read"],
+      "defaultRoute": "/app/short-rent"
+    },
+    {
+      "contextKey": "long-rent",
+      "displayName": "Affitti lungo termine",
+      "roleKey": "long_term_landlord",
+      "permissions": ["lease.read", "lease.create"],
+      "defaultRoute": "/app/long-rent/leases"
+    }
+  ],
+  "lastUsedContextKey": "short-rent"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `contexts[].contextKey` | `"short-rent" \| "long-rent" \| "admin"` | Stable enum string |
+| `contexts[].displayName` | `string` | Italian label for switcher (server may return; FE manifest is fallback) |
+| `contexts[].roleKey` | `string` | Per-context role slug |
+| `contexts[].permissions` | `string[]` | Capability keys used by manifest `requiredPermissions` |
+| `contexts[].defaultRoute` | `string` | Canonical FE path (manifest `isDefault` route) |
+| `lastUsedContextKey` | `string?` | Optional server preference (Phase B+); FE still persists `casazen:active-context` in Phase A |
+
+| Status | Body |
+|---|---|
+| 401 | Standard unauthorized |
+| 403 | `{ "error": "User account inactive" }` when `User.IsActive == false` |
+| 200 empty contexts | `{ "contexts": [] }` — FE shows managed “no access” page (not redirect to `/`) |
+
+**C# DTOs** (new in `Casazen.Web/DTOs/Auth/`):
+
+```csharp
+public record UserContextsResponse(string UserId, IReadOnlyList<ContextBootstrapDto> Contexts, string? LastUsedContextKey);
+public record ContextBootstrapDto(string ContextKey, string DisplayName, string RoleKey, IReadOnlyList<string> Permissions, string DefaultRoute);
+```
+
+**Implementation notes**:
+
+- Resolve `sub` from JWT; load memberships from `UserContextMembership` joined to `Role` / `RolePermission`.
+- If no rows exist (migration window), **synthesize** from JWT `https://casazen.app/roles` using the same map as Phase A FE stub (see Migration Plan).
+- `GET /api/users/me` remains unchanged; clients may call both; bootstrap is the single source for **navigation authorization**.
+
+---
+
+### Optional — `PUT /api/me/contexts/active` (Phase B, nice-to-have)
+
+| | |
+|---|---|
+| **Method / Path** | `PUT /api/me/contexts/active` |
+| **Auth** | `[Authorize]` |
+| **Request** | `{ "contextKey": "short-rent" }` |
+| **Response 204** | No body |
+| **Errors** | 400 invalid key; 403 not a member of context |
+
+Persists `User.LastUsedContextKey` (new nullable column on `User`). FE may continue using `localStorage` only if this endpoint is deferred.
+
+---
+
+### Unchanged endpoints (reference — Phase A–C)
+
+No path or DTO changes. Phase B adds **contextual policy evaluation** behind existing `[Authorize(Policy = "...")]` attributes; clients keep calling the same URLs.
+
+#### Public / webhooks
+
+| Method / Path | Auth | Notes |
+|---|---|---|
+| `POST /api/auth/register` | `[AllowAnonymous]` | Dev-oriented registration |
+| `GET /api/health` | Public | Health check |
+| `GET /api/health/auth-test` | Public | Auth probe |
+| `POST /webhooks/stripe` | Signature validation (not JWT) | Stripe |
+| `POST /webhooks/ota/{platform}` | Platform secret | OTA |
+| `POST /webhooks/esign` | Provider validation | E-sign |
+
+#### Authenticated — general
+
+| Method / Path | Auth (today) | Context (Phase B) | Change |
+|---|---|---|---|
+| `GET /api/auth/profile` | `[Authorize]` | N/A | Unchanged |
+| `POST /api/auth/logout` | `[Authorize]` | N/A | Unchanged |
+| `GET /api/users/me` | `[Authorize]` | N/A | Unchanged |
+| `PUT /api/users/me` | `[Authorize]` | N/A | Unchanged |
+| `GET /api/pricing-adapter/*` | `[Authorize]` | `short-rent` | Policy handler added |
+| `GET /api/gdpr/guests/*` | `[Authorize]` | `short-rent` | Policy handler added |
+
+#### Short-rent (`PropertyOwner` policy today)
+
+| Method / Path | Auth | Context | `requiredPermissions` (manifest alignment) |
+|---|---|---|---|
+| `GET/POST/PUT/DELETE /api/properties*` | `PropertyOwner` | `short-rent` | `property.read` / `property.write` |
+| `GET/POST/PUT/DELETE /api/bookings*` | `PropertyOwner` | `short-rent` | `booking.read` / `booking.write` |
+| `GET/POST/PUT/DELETE /api/guests*` | `PropertyOwner` | `short-rent` | `guest.read` / `guest.write` |
+| `GET/POST /api/payments*` | `PropertyOwner` | `short-rent` | `payment.read` / `payment.write` |
+| `GET/POST /api/ota*` | `PropertyOwner` | `short-rent` | `ota.read` / `ota.write` |
+| `GET/POST/PUT/DELETE /api/properties/{id}/ota-integrations*` | `PropertyOwner` | `short-rent` | `ota.read` / `ota.write` |
+| `GET/POST /api/tourist-tax-rates*` (non-admin) | `[Authorize]` | `short-rent` | `booking.read` |
+
+#### Long-rent
+
+| Method / Path | Auth | Context | Permissions |
+|---|---|---|---|
+| `GET/POST /api/leases*` | `LongTermLandlord` | `long-rent` | `lease.read`, `lease.create`, `lease.sign`, `lease.register` |
+
+#### Admin
+
+| Method / Path | Auth | Context | Permissions |
+|---|---|---|---|
+| `GET/PUT/DELETE /api/users*` | `AdminOnly` | `admin` | `admin.users.read`, `admin.users.manage` |
+| `GET /api/admin/stats` | `AdminOnly` | `admin` | `admin.stats.read` |
+| `GET /api/admin/cin-compliance` | `AdminOnly` | `admin` | `admin.cin.read` |
+| `GET /api/admin/jobs` | `AdminOnly` | `admin` | `admin.jobs.read` |
+| `POST/PUT/DELETE /api/tourist-tax-rates` (mutations) | `AdminOnly` | `admin` | `admin.tax.manage` |
+
+### Phase B — contextual authorization mechanism
+
+| Component | Responsibility |
+|---|---|
+| `IContextAuthorizationService` | Given `userId`, `contextKey`, `permissionKey` → bool |
+| `ContextAuthorizationHandler` | ASP.NET authorization handler for policy `RequireContext` |
+| Policy registration | `.AddPolicy("RequireContext:short-rent:booking.read", ...)` or single policy with `ContextRequirement` |
+| Request context | Optional header `X-Casazen-Context: short-rent` for ambiguous endpoints; **leases/bookings/admin controllers infer fixed context** from route namespace |
+
+**Enforcement order**: JWT valid → user active → membership in context → permission in context → existing resource-level checks (owner IDOR on leases/properties).
+
+**Phase A**: No backend change; FE uses JWT stub identical to synthesis map below.
+
+---
+
+## Frontend Flow
+
+### Architecture
+
+```mermaid
+flowchart TD
+    Login[Auth0 callback / LoginPage] --> Bootstrap{Phase A: JWT stub\nPhase B: GET /api/me/contexts}
+    Bootstrap -->|0 contexts| NoAccess[NoAccessPage 403]
+    Bootstrap -->|1 context| Auto[Redirect to defaultRoute]
+    Bootstrap -->|2+ contexts| Picker[Restore last-used or ContextPicker]
+    Picker --> Shell[Unified shell + WorkspaceSwitcher]
+    Auto --> Shell
+    Shell --> Manifest[route-manifest.ts]
+    Manifest --> Nav[Sidebar items]
+    Manifest --> Guard[ContextRouteGuard]
+    Guard --> Page[Feature page Outlet]
+```
+
+### Context model
+
+| `contextKey` | Italian label (UI) | Default landing (`isDefault`) | Shell (Phase A) |
+|---|---|---|---|
+| `short-rent` | Affitti brevi | `/app/short-rent` | `AppShell` + short-stay sidebar (manifest-driven) |
+| `long-rent` | Affitti lungo termine | `/app/long-rent/leases` | `LongTermAppShell` |
+| `admin` | Amministrazione | `/app/admin` | `AdminAppShell` |
+
+**State**: Replace `AppLayer` (`short-stay` \| `long-term`) with `AppContextKey` (`short-rent` \| `long-rent` \| `admin`).
+
+**Storage key**: `casazen:active-context` (rename from `casazen:active-layer`; migration reads old key once).
+
+---
+
+### Route manifest (`src/config/route-manifest.ts`)
+
+Single source for router registration, sidebar, default redirects, and guards.
+
+```typescript
+export type AppContextKey = 'short-rent' | 'long-rent' | 'admin';
+
+export interface RouteManifestEntry {
+  /** Canonical path, e.g. /app/short-rent/bookings */
+  path: string;
+  context: AppContextKey;
+  /** Empty = auth only within context */
+  requiredPermissions: string[];
+  navLabel?: string; // Italian
+  icon?: string; // lucide icon name
+  isDefault?: boolean; // one per context
+  /** Lazy component import */
+  component: () => Promise<{ default: React.ComponentType }>;
+  /** Legacy paths that redirect here (Phase A) */
+  legacyPaths?: string[];
+}
+```
+
+**Manifest rules**:
+
+1. Every protected operational route appears exactly once with `path` under `/app/{context}/...`.
+2. `isDefault: true` exactly one entry per context the user can access.
+3. Sidebar = `entries.filter(e => e.context === activeContext && e.navLabel)`.
+4. `WorkspaceSwitcher` = distinct `contextKey` from bootstrap (not global JWT role names).
+
+---
+
+### Canonical route map (target)
+
+All paths below are **authenticated** unless noted.
+
+#### Public (unchanged)
+
+| Path | Guard |
+|---|---|
+| `/login` | None |
+| `/search` | None |
+
+#### Short-rent — `/app/short-rent/*`
+
+| Canonical path | navLabel (IT) | requiredPermissions | Legacy redirects |
+|---|---|---|---|
+| `/app/short-rent` | Dashboard | `[]` | `/`, `/app/short-rent/` |
+| `/app/short-rent/properties` | Proprietà | `property.read` | `/properties` |
+| `/app/short-rent/properties/create` | — | `property.write` | `/properties/create` |
+| `/app/short-rent/properties/:id` | — | `property.read` | `/properties/:id` |
+| `/app/short-rent/properties/:id/edit` | — | `property.write` | `/properties/:id/edit` |
+| `/app/short-rent/properties/:id/pricing` | — | `property.read` | `/properties/:id/pricing` |
+| `/app/short-rent/properties/:id/pricing/history` | — | `property.read` | `/properties/:id/pricing/history` |
+| `/app/short-rent/bookings` | Prenotazioni | `booking.read` | `/bookings` |
+| `/app/short-rent/bookings/create` | — | `booking.write` | `/bookings/create` |
+| `/app/short-rent/bookings/calendar` | Calendario | `booking.read` | `/bookings/calendar` |
+| `/app/short-rent/bookings/:id` | — | `booking.read` | `/bookings/:id` |
+| `/app/short-rent/bookings/:id/edit` | — | `booking.write` | `/bookings/:id/edit` |
+| `/app/short-rent/payments` | Pagamenti | `payment.read` | `/payments` |
+| `/app/short-rent/payments/create` | — | `payment.write` | `/payments/create` |
+| `/app/short-rent/payments/revenue` | Ricavi | `payment.read` | `/payments/revenue` |
+| `/app/short-rent/payments/:id` | — | `payment.read` | `/payments/:id` |
+| `/app/short-rent/ota` | OTA | `ota.read` | `/ota` |
+| `/app/short-rent/ota/create` | — | `ota.write` | `/ota/create` |
+| `/app/short-rent/profile` | Profilo | `[]` | `/profile` (when active context is short-rent) |
+
+#### Long-rent — `/app/long-rent/*`
+
+| Canonical path | navLabel (IT) | requiredPermissions | Legacy redirects |
+|---|---|---|---|
+| `/app/long-rent/leases` | Contratti | `lease.read` | `/leases` |
+| `/app/long-rent/leases/new` | — | `lease.create` | `/leases/new` |
+| `/app/long-rent/leases/:id` | — | `lease.read` | `/leases/:id` |
+| `/app/long-rent/profile` | Profilo | `[]` | `/profile` (when active context is long-rent) |
+
+#### Admin — `/app/admin/*`
+
+| Canonical path | navLabel (IT) | requiredPermissions | Legacy redirects |
+|---|---|---|---|
+| `/app/admin` | Dashboard | `admin.stats.read` | `/admin` |
+| `/app/admin/users` | Utenti | `admin.users.read` | `/admin/users` |
+| `/app/admin/cin` | CIN | `admin.cin.read` | `/admin/cin` |
+| `/app/admin/jobs` | Job | `admin.jobs.read` | `/admin/jobs` |
+
+**Profile route**: Context-scoped `/app/{context}/profile` replaces `LayerAwareProfilePage` shell selection; same `ProfilePage` content, shell from parent layout route.
+
+---
+
+### Router structure (`src/routes/index.tsx`)
+
+```typescript
+// Pseudocode — Phase A target
+createBrowserRouter([
+  { path: '/login', element: <LoginPage /> },
+  { path: '/search', element: <SearchPage /> },
+
+  // Legacy redirect layer (Phase A) — <LegacyRedirect />
+  { path: '/', element: <LegacyRedirect /> },
+  { path: '/properties/*', element: <LegacyRedirect /> },
+  // ... all legacyPaths from manifest
+
+  {
+    path: '/app',
+    element: (
+      <ProtectedRoute>
+        <WorkspaceProvider>
+          <Outlet />
+        </WorkspaceProvider>
+      </ProtectedRoute>
+    ),
+    children: [
+      { path: ':context', element: <ContextLayout />, children: [
+        // Generated from manifest: ContextRouteGuard per route
+      ]},
+      { path: 'choose-context', element: <ContextPickerPage /> },
+      { path: 'no-access', element: <NoAccessPage /> },
+    ],
+  },
+
+  { path: '*', element: <Navigate to="/app/choose-context" replace /> },
+]);
+```
+
+`ContextLayout` selects shell by `:context` param and renders `<WorkspaceSwitcher />` when `contexts.length > 1`.
+
+---
+
+### Post-login flow
+
+| Condition | Behaviour |
+|---|---|
+| 0 contexts | `/app/no-access` with Italian copy |
+| 1 context | `navigate(contexts[0].defaultRoute, { replace: true })` |
+| 2+ contexts, valid `casazen:active-context` in storage | Restore if still in `contexts`; else picker |
+| 2+ contexts, no storage | `/app/choose-context` or auto short-rent if product prefers (default: **picker**) |
+| Deep link to wrong context | `ContextRouteGuard` → redirect to first allowed context default or `/app/no-access` |
+
+**LoginPage** (Phase A): call `resolveContexts(user)` stub; Phase B: `GET /api/me/contexts` then same branching.
+
+---
+
+### Workspace switcher (`workspace-switcher.tsx`)
+
+Replaces `layer-switcher.tsx` (deprecate after Phase A).
+
+| Property | Value |
+|---|---|
+| Visibility | `availableContexts.length > 1` |
+| Placement | Header `slotStart` in all shells |
+| Labels | Italian: *Affitti brevi*, *Affitti lungo termine*, *Amministrazione* |
+| On change | Set `activeContext`, persist storage, `navigate(defaultRoute for context)` |
+| a11y | `role="tablist"`, keyboard navigation (same as #182) |
+
+Admin-only users see only admin in switcher; dual/triple membership sees all granted contexts.
+
+---
+
+### ProtectedRoute / context guard matrix
+
+Every authenticated route uses **two layers**: auth wrapper + context guard.
+
+| Route pattern | `<ProtectedRoute>` | Context guard | Deny behaviour |
+|---|---|---|---|
+| `/login`, `/search` | None | — | — |
+| `/app/choose-context`, `/app/no-access` | Auth only | Membership check on choose-context | — |
+| `/app/short-rent/*` | Auth | `ContextRouteGuard context="short-rent"` + permission | Redirect to first allowed context default; toast IT |
+| `/app/long-rent/*` | Auth | `ContextRouteGuard context="long-rent"` + permission | Same |
+| `/app/admin/*` | Auth | `ContextRouteGuard context="admin"` + permission | Same |
+| Legacy `/*` redirects | Auth if target is protected | Resolved by redirect target | 302 to canonical |
+
+**`ContextRouteGuard`** (`src/components/auth/context-route-guard.tsx`):
+
+```typescript
+// 1. If :context not in availableContexts → Navigate to first allowed defaultRoute
+// 2. If requiredPermissions not subset of context.permissions → NoAccessPage or redirect
+// 3. If URL context !== activeContext and user can access both → set activeContext from URL (deep link sync, #182 pattern)
+// 4. Else <Outlet />
+```
+
+**JWT stub permissions (Phase A)** — map roles to full permission sets per context:
+
+| JWT role | Context | Stub permissions |
+|---|---|---|
+| `PropertyOwner` | `short-rent` | All short-rent manifest permissions for owner |
+| `LongTermLandlord` | `long-rent` | All `lease.*` |
+| `Admin` | `admin` | All `admin.*` |
+
+**Deprecate** (remove in Phase A PR):
+
+- `ShortStayLayerGuard` — replaced by context prefix + guard
+- `useAppLayer` / `AppLayerProvider` — replaced by `useWorkspace` / `WorkspaceProvider`
+- Role-only `ProtectedRoute role="LongTermLandlord"` on layout — replaced by manifest permissions; keep auth-only `ProtectedRoute` at `/app` root
+
+---
+
+### Component plan
+
+| Component | Status | Location |
+|---|---|---|
+| `route-manifest.ts` | **new** | `src/config/route-manifest.ts` |
+| `WorkspaceProvider` | **new** | `src/contexts/workspace-provider.tsx` |
+| `useWorkspace` | **new** | `src/hooks/use-workspace.ts` |
+| `WorkspaceSwitcher` | **new** | `src/components/layout/workspace-switcher.tsx` |
+| `ContextRouteGuard` | **new** | `src/components/auth/context-route-guard.tsx` |
+| `ContextLayout` | **new** | `src/components/layout/context-layout.tsx` |
+| `LegacyRedirect` | **new** | `src/routes/legacy-redirect.tsx` |
+| `ContextPickerPage` | **new** | `src/pages/context-picker-page.tsx` |
+| `NoAccessPage` | **new** | `src/pages/no-access-page.tsx` |
+| `contextsApi.getContexts` | **new** | `src/api/contexts.ts` (Phase B wire-up; stub Phase A) |
+| `auth-roles.ts` | **modified** | Add `deriveContextsFromRoles()` for Phase A stub |
+| `routes/index.tsx` | **modified** | Manifest-driven tree + legacy routes |
+| `LoginPage` | **modified** | Context-aware post-login |
+| `AppShell`, `LongTermAppShell`, `AdminAppShell` | **modified** | Nav from manifest; `WorkspaceSwitcher` in header |
+| `layer-switcher.tsx`, `app-layer-*` | **deprecated** | Remove after migration |
+| Feature `*Page` components | **unchanged** | No business logic rewrite; paths only |
+
+---
+
+### Internal links and API client (Phase A checklist)
+
+- Replace hardcoded `href`/`navigate('/bookings')` with manifest helpers: `pathFor('bookings.list')` or imported constants.
+- Axios: no header required Phase A; Phase B optional `X-Casazen-Context` from `activeContext`.
+
+---
+
+## Security Notes
+
+### Auth gates
+
+| Surface | Requirement |
+|---|---|
+| Bootstrap API | `[Authorize]` only; returns contexts for **authenticated sub**; never leak other users' memberships |
+| FE `ContextRouteGuard` | UX boundary; must not be sole enforcement |
+| BE Phase B | `IContextAuthorizationService` on all critical controllers; 403 if membership/permission missing |
+| Admin routes | Still require `Admin` membership in `admin` context; global JWT `Admin` until Phase C |
+| Webhooks | Unchanged — no JWT; signature/secret validation |
+| `localStorage` | Only `casazen:active-context` enum — no roles, tokens, or PII |
+
+### JWT stub transition risk (Phase A)
+
+| Risk | Mitigation |
+|---|---|
+| Client-side role mapping bypassed | Phase B makes bootstrap authoritative; API policies enforced server-side |
+| Stale dual source (JWT vs DB) | Document: FE reads bootstrap when available; stub only when `GET /api/me/contexts` 404 or Phase A flag |
+| User with JWT role but no DB row | Synthesis on bootstrap; admin UI to assign memberships later |
+
+### Threat model (STRIDE)
+
+| Threat | Surface | Mitigation |
+|---|---|---|
+| Spoofing | Context header tampering | Server validates membership for claimed context; infer context from controller on resource APIs |
+| Tampering | Deep link to `/app/admin/users` | Context guard + `AdminOnly` policy + membership |
+| Tampering | Legacy URL bypass | Legacy redirect routes still run guards on destination |
+| Elevation | PropertyOwner opens leases via URL | `long-rent` membership check + `LongTermLandlord` policy |
+| Information disclosure | Bootstrap over-fetch | Return only caller's contexts and permission keys |
+| Repudiation | Context switch | Optional server log `ContextSwitched` (Phase C); not blocking |
+
+### PII
+
+| Data | Handling |
+|---|---|
+| Bootstrap response | No email/name required; `userId` is Auth0 sub |
+| Profile pages | Unchanged GDPR rules from existing flows |
+| Guest / lease party PII | Unchanged — not introduced by this issue |
+
+### Secrets / integrations
+
+| Integration | Impact |
+|---|---|
+| Auth0 | Phase C only — optional Action to stop duplicating operational roles |
+| OTA keys | Remain server-side; admin/long-rent manifests exclude OTA nav |
+| Stripe webhooks | N/A |
+
+---
+
+## Migration Plan
+
+### Database — EF Core (Phase B)
+
+**Migration name**: `AddContextAuthorization`
+
+#### Entities
+
+**`AppContext`** (lookup)
+
+| Column | Type | Notes |
+|---|---|---|
+| `Key` | `string` PK | `short-rent`, `long-rent`, `admin` |
+| `DisplayName` | `string` | Italian display |
+
+**`Role`** (per-context role definition)
+
+| Column | Type | Notes |
+|---|---|---|
+| `Id` | `int` PK | |
+| `ContextKey` | `string` FK → `AppContext` | |
+| `RoleKey` | `string` | e.g. `property_owner`, `long_term_landlord`, `platform_admin` |
+| Unique | `(ContextKey, RoleKey)` | |
+
+**`RolePermission`**
+
+| Column | Type | Notes |
+|---|---|---|
+| `RoleId` | `int` FK → `Role` | |
+| `PermissionKey` | `string` | e.g. `booking.read` |
+| Unique | `(RoleId, PermissionKey)` | |
+
+**`UserContextMembership`**
+
+| Column | Type | Notes |
+|---|---|---|
+| `Id` | `Guid` PK | |
+| `UserId` | `string` FK → `User.Id` | Auth0 sub |
+| `ContextKey` | `string` FK → `AppContext` | |
+| `RoleId` | `int` FK → `Role` | |
+| Unique | `(UserId, ContextKey)` | One role per context per user |
+
+**`User`** (optional column)
+
+| Column | Type | Notes |
+|---|---|---|
+| `LastUsedContextKey` | `string?` | For `PUT /api/me/contexts/active` |
+
+Existing `User.Role` enum **retained** for admin user management and Auth0 sync until Phase C; bootstrap prefers `UserContextMembership` when present.
+
+#### Seed data (dev)
+
+| Context | Role | Permissions |
+|---|---|---|
+| `short-rent` | `property_owner` | `property.read`, `property.write`, `booking.read`, `booking.write`, `payment.read`, `payment.write`, `ota.read`, `ota.write`, `guest.read`, `guest.write` |
+| `long-rent` | `long_term_landlord` | `lease.read`, `lease.create`, `lease.sign`, `lease.register` |
+| `admin` | `platform_admin` | `admin.stats.read`, `admin.users.read`, `admin.users.manage`, `admin.cin.read`, `admin.jobs.read`, `admin.tax.manage` |
+
+**Seed script**: For each existing `User` with `User.Role`, insert membership row(s) using JWT alignment map:
+
+| `UserRole` / JWT | Context memberships |
+|---|---|
+| `PropertyOwner` | `short-rent` → `property_owner` |
+| `LongTermLandlord` | `long-rent` → `long_term_landlord` |
+| `Admin` | `admin` → `platform_admin` |
+| Combined JWT roles (dual) | Multiple rows |
+
+#### JWT → context synthesis (Phase A stub & Phase B fallback)
+
+```text
+PropertyOwner      → short-rent / property_owner
+LongTermLandlord   → long-rent / long_term_landlord
+Admin              → admin / platform_admin
+```
+
+### Backend rollout (Phase B)
+
+| Step | Action |
+|---|---|
+| 1 | Add entities + migration + seed |
+| 2 | `IContextAuthorizationService` + handler |
+| 3 | `GET /api/me/contexts` |
+| 4 | Apply handler to `LeasesController`, `BookingController`, `PropertiesController`, `AdminController`, `UsersController` (admin actions) |
+| 5 | Integration tests: bootstrap + 403 without membership |
+
+### Frontend rollout (Phase A)
+
+| Step | Action |
+|---|---|
+| 1 | Add `route-manifest.ts` with full route table |
+| 2 | `WorkspaceProvider` + JWT stub |
+| 3 | Refactor `routes/index.tsx` + `LegacyRedirect` |
+| 4 | `WorkspaceSwitcher` in shells; remove layer switcher |
+| 5 | Update `LoginPage` post-login |
+| 6 | grep internal links → canonical paths |
+| 7 | E2E: legacy redirects, single/multi context, 403 deep link |
+
+### Legacy redirect removal
+
+Temporary redirects live **Phase A–B**; remove in follow-up issue after analytics show near-zero legacy hits (design documents mapping; do not delete in #189 initial merge).
+
+---
+
+## GDPR Scope
+
+**Guest entity (`Guest`)**: N/A — no new guest data fields; short-rent guest flows unchanged.
+
+**Lease party PII**: Unchanged from #177/#182 — context routing does not alter form or API payloads.
+
+**User profile PII** (`FirstName`, `LastName`, `Email`, `PhoneNumber`): Unchanged; `GET /api/me/contexts` does not expose extra PII beyond `userId`.
+
+**Storage**: `casazen:active-context` is not personal data.
+
+**Regulatory modules** (CIN, Alloggiati, tourist tax): Remain in `short-rent` / `admin` contexts per manifest; no new processing purposes.
+
+---
+
+## Acceptance criteria traceability
+
+| AC | Design element |
+|---|---|
+| Canonical context prefixes | Route manifest; all operational routes under `/app/{context}/*` |
+| Centralized manifest | `route-manifest.ts` drives nav, defaults, guards |
+| Workspace switcher | `WorkspaceSwitcher` + Italian labels; updates `activeContext`, nav, URL |
+| Post-login context resolution | Bootstrap stub/API + single/multi/picker flows |
+| No access to forbidden context | `ContextRouteGuard` + `NoAccessPage` |
+| API contextual auth | Phase B membership + policy handler; Phase A documented gap |
+| Legacy URL redirects | `legacyPaths` on manifest entries + `LegacyRedirect` |
+
+---
+
+## Open Questions
+
+All resolved for Stage 02.
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | URL prefix `/app/:context` vs `/` only? | **`/app/:context/*`** per issue AC and external analysis |
+| 2 | Keep three shells or one unified shell? | **Keep three shells** in Phase A; shared header/workspace chrome; nav from manifest (#182 investment preserved) |
+| 3 | Phase A membership source? | **JWT stub** identical to BE synthesis map |
+| 4 | Profile route placement? | **`/app/{context}/profile`** — drops `LayerAwareProfilePage` |
+| 5 | `PUT /api/me/contexts/active` in scope? | **Nice-to-have Phase B**; `localStorage` sufficient for #189 MVP |
+| 6 | Phase C in #189 or child issue? | **Same issue if feasible**; otherwise child issue — not blocking A/B |
+| 7 | Permission granularity for Phase B? | **Coarse keys** per manifest column; expand later without route renames |
+
+---
+
+## Harness gate status
+
+| Gate | Status | Notes |
+|---|---|---|
+| G1: Spec file exists | ✅ | `Sessions/design-189.md` |
+| G2: API contract complete | ✅ | New bootstrap endpoint + unchanged endpoint tables with schemas |
+| G3: Auth on every endpoint | ✅ | Each endpoint has `[Authorize]` / `[AllowAnonymous]` / webhook justification |
+| G4: Frontend flow defined | ✅ | Manifest, router, post-login, switcher, diagrams |
+| G5: ProtectedRoute specified | ✅ | Full matrix + `ContextRouteGuard` for every authenticated route |
+| G6: Security notes | ✅ | Auth gates, STRIDE, PII, JWT transition |
+| G7: Migration plan | ✅ | EF entities, seed, phased FE/BE steps |
+| G8: GDPR scope | ✅ | Guest N/A; lease/profile unchanged |
+
+**Handoff → Stage 03**: Issue `#189`, spec `Sessions/design-189.md`, branches `feature/189-context-workspace-switch` (frontend and backend repos).

--- a/Sessions/pipeline-context-workspace-switch/external-analysis.md
+++ b/Sessions/pipeline-context-workspace-switch/external-analysis.md
@@ -1,0 +1,48 @@
+# External analysis: context / workspace switcher (split layer)
+
+Source: `Sessions/specs/spec-split-layer.md` (user-provided, 2026-06-04)
+
+## Summary (English — pipeline working language)
+
+CasaZen should treat **short-rent**, **long-rent**, and **admin** as distinct **application contexts / workspaces**, not as flat pages gated by global roles.
+
+### Recommended model
+
+| Concept | Purpose |
+|---|---|
+| User | Global identity |
+| Context / Workspace | `short-rent`, `long-rent`, `admin` |
+| Membership | User ↔ context |
+| Role | Per-context role (not necessarily global) |
+| Permission | Fine-grained capabilities (`booking.read`, etc.) |
+
+### Frontend
+
+- Canonical URLs: `/app/short-rent/*`, `/app/long-rent/*`, `/app/admin/*`
+- Central **route manifest** (`path`, `context`, `requiredPermissions`, `navLabel`, `isDefault`)
+- `activeContext` in app state
+- **Workspace switcher** always visible in shell (not exception UX)
+- Post-login: fetch contexts → single context auto-redirect → multi: picker or last-used → derive menu/routes from active context
+- Invalid context/route → redirect to valid home or managed 403
+
+### Backend
+
+- Avoid global roles that encode operational areas (`Admin`, `AffittiBrevi`, …)
+- Authoritative access in backend; frontend reflects decisions
+- Minimum data model: `User`, `UserContextMembership`, `Role`, `RolePermission` (or Workspace/Membership/PermissionGrant variant)
+
+### Anti-patterns to avoid
+
+- Flat routes without context namespace
+- Fixed post-login redirect ignoring available contexts
+- Menu from global roles vs active context
+- Frontend-only permission checks
+- Switcher as rare exception
+
+### Relation to prior work
+
+Pipeline `long-term-ui-layer` (#182) introduced long-term UI separation; this feature **generalizes** that into a unified context architecture across all three areas.
+
+---
+
+Full Italian source document: see `Sessions/specs/spec-split-layer.md`.

--- a/Sessions/pipeline-context-workspace-switch/issue-body.md
+++ b/Sessions/pipeline-context-workspace-switch/issue-body.md
@@ -1,0 +1,90 @@
+## User Story
+
+As a CasaZen user who may operate in one or more operational areas (short-stay rentals, long-term leases, platform administration), I want the application to treat each area as a distinct **workspace/context** with canonical URLs, a persistent workspace switcher, and navigation derived from my active context—so I never need to guess or manually type the correct route after login.
+
+## Acceptance Criteria
+
+- [ ] GIVEN an authenticated user, WHEN they navigate the app, THEN all protected app routes live under canonical context prefixes: `/app/short-rent/*`, `/app/long-rent/*`, and `/app/admin/*` (no new flat operational routes at root such as `/bookings` or `/leases` without context prefix)
+- [ ] GIVEN a centralized **route manifest** (single source for `path`, `context`, `requiredPermissions`, `navLabel`, `isDefault`), WHEN the app builds the sidebar and default redirects, THEN menu items and landing routes for each context are derived from the manifest—not from duplicated per-shell nav config or global Auth0 role names alone
+- [ ] GIVEN a user with membership in more than one context, WHEN they use the application shell, THEN a **workspace switcher** (e.g. Italian labels *Affitti brevi*, *Affitti lungo termine*, *Amministrazione*) is always visible in the header or sidebar and switching context updates `activeContext`, the nav tree, and the URL to the target context’s default landing
+- [ ] GIVEN a user who has just completed login, WHEN the app loads available contexts from the backend (or bootstrap API), THEN: (a) a single available context triggers automatic redirect to that context’s default route; (b) multiple contexts show a context picker or restore last-used context from persisted preference; (c) post-login redirect never sends the user to a context they cannot access
+- [ ] GIVEN a user without membership or required permissions for a context or route, WHEN they open a deep link (e.g. `/app/long-rent/contracts`) or switch workspace, THEN the app redirects to a valid home for an allowed context or shows a managed 403—not silent access or a broken shell
+- [ ] GIVEN any API call for a context-scoped resource, WHEN the backend authorizes the request, THEN access is evaluated using **contextual** membership/permissions (not only global JWT roles such as `PropertyOwner` / `LongTermLandlord` / `Admin`); the frontend guards reflect but do not replace backend decisions
+- [ ] GIVEN legacy URLs from prior navigation (e.g. `/`, `/leases`, `/admin/users` from #182), WHEN users or bookmarks hit old paths, THEN temporary redirects preserve usability until redirects are removed in a follow-up (design stage defines mapping table)
+
+## Technical Notes
+
+**Design reference**: [Sessions/specs/spec-split-layer.md](https://github.com/casazen/backend/blob/main/Sessions/specs/spec-split-layer.md) (structured analysis; pipeline copy in `Sessions/pipeline-context-workspace-switch/external-analysis.md`).
+
+**Relation to prior work**: Closed issue #182 (`long-term-ui-layer`) introduced separate short-stay / long-term / admin shells with role-based `ProtectedRoute`, `AppLayerProvider`, and a dual-role **layer switcher**. This issue **generalizes** that pattern into a unified multi-context architecture (context-prefixed routing, manifest-driven nav, backend contextual auth). Do not re-scope closed #182 deliverables (lease pages, shell split); extend and migrate them.
+
+### Current state (baseline)
+
+| Area | Today |
+|---|---|
+| FE routing | Flat paths (`/`, `/leases`, `/admin/*`); `ProtectedRoute` + `AppLayerProvider` + per-role shells (#182) |
+| FE switcher | `layer-switcher.tsx` — dual-role short-stay ↔ long-term; not a full three-context workspace model |
+| BE auth | Auth0 JWT global roles in claim `https://casazen.app/roles`; no `UserContextMembership` entity yet |
+
+### Frontend impact (`casazen/frontend`)
+
+| Concern | Approach |
+|---|---|
+| Route tree | Nest under `/app/:context/...`; introduce route manifest module consumed by router, sidebar, and guards |
+| State | `activeContext` (`short-rent` \| `long-rent` \| `admin`) in app state + persistence (last-used) |
+| Shell | Unify/refactor `AppShell`, `LongTermAppShell`, `AdminAppShell` to share manifest-driven nav; workspace switcher always on for multi-context users |
+| Guards | Context-aware route guard (membership + permissions from bootstrap API); deprecate role-only `ProtectedRoute` over time |
+| Post-login | Replace fixed `/` redirect with context resolution flow |
+| i18n | Nav/switcher labels remain Italian in UI; route keys English |
+
+**Expected touch areas**: `src/routes/index.tsx`, `src/contexts/app-layer-*`, `src/components/layout/*`, `src/components/auth/protected-route.tsx`, new `src/config/route-manifest.ts` (or equivalent), API client for contexts/bootstrap.
+
+### Backend impact (`casazen/backend`)
+
+| Concern | Approach |
+|---|---|
+| Data model | Introduce contextual authorization primitives (minimum: `UserContextMembership` linking user ↔ `ContextKey` ↔ role; `Role` / `RolePermission` or equivalent grant table)—exact schema in Stage 02 |
+| API | Endpoint(s) for current user’s available contexts, roles, and permissions; enforce on existing controllers via policy/handler evaluated per request context |
+| Auth0 | Phase 1 may map existing JWT roles to synthetic context membership for migration; Phase 2 aligns claims or uses server-side membership as source of truth |
+| Migrations | **EF Core migration expected** for membership/permission tables; no breaking change to lease/booking entities in this epic slice |
+
+### Infrastructure / OTA / jobs
+
+| Area | Impact |
+|---|---|
+| **EF Core migrations** | Yes — new authorization/membership tables (and seed data for dev) |
+| **OTA platforms** | None — short-rent context continues to own OTA surfaces; ensure admin/long-rent manifests do not expose OTA nav |
+| **Background jobs** | None expected; Hangfire admin UI remains under `admin` context routes |
+| **Stripe / webhooks** | None |
+
+### Phased delivery (recommended)
+
+1. **Phase A — FE routing & manifest**: Context-prefixed routes, manifest, redirects from legacy paths, switcher UX wired to `activeContext` (membership stubbed from JWT roles if needed).
+2. **Phase B — BE contextual auth**: Persistence, bootstrap API, policy enforcement on critical endpoints.
+3. **Phase C — JWT/Auth0 alignment**: Reduce reliance on global operational roles where they duplicate context membership.
+
+**Complexity**: effort **L (3–5 days)** cross-repo — routing migration + authorization model + API contract.
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| Bookmark/deep-link breakage | Redirect table; e2e tests for legacy paths |
+| Dual source of truth (JWT roles vs DB membership) | Document transition; single bootstrap API for FE |
+| Role explosion on backend | Capability-style permissions per context (#182 used coarse roles) |
+
+## Compliance Assessment
+
+**Regulations in scope**: None new. Navigation and authorization restructuring does not introduce new regulated data flows beyond existing short-stay (CIN/Alloggiati) and long-term lease flows.
+
+**Label**: `none-required`
+
+## Dependencies
+
+- Builds on / generalizes: #182 (closed — long-term UI layer separation)
+- Spec: `Sessions/specs/spec-split-layer.md`
+- Stage 02 design spec: `Sessions/design-<N>.md` (to be created after planning gate)
+
+## Planning artifact
+
+Pipeline: `Sessions/pipeline-context-workspace-switch` — Stage 01 planning handoff → Stage 02 design.

--- a/Sessions/pipeline-context-workspace-switch/state.md
+++ b/Sessions/pipeline-context-workspace-switch/state.md
@@ -1,0 +1,39 @@
+# Pipeline: Context / workspace switcher (split layer)
+
+## Status
+- status: running
+- current_stage: 03-development
+- started: 2026-06-04T00:00:00Z
+- last_updated: 2026-06-04T12:00:00Z
+
+## Input
+- description: Introduce application contexts (short-rent, long-rent, admin) with canonical context-prefixed routing, centralized route manifest, workspace switcher in app shell, and backend-contextual authorization — per external analysis in Sessions/specs/spec-split-layer.md
+- external_analysis: Sessions/specs/spec-split-layer.md
+- pipeline_copy: Sessions/pipeline-context-workspace-switch/external-analysis.md
+- related_pipeline: Sessions/pipeline-long-term-ui-layer (issue #182 — long-term UI layer; this work generalizes and structures the multi-area model)
+- type: feat
+- priority: medium
+
+## Artifacts
+- issue: #189 — https://github.com/casazen/backend/issues/189
+- branch: feature/189-context-workspace-switch
+- design_spec: Sessions/design-189.md
+- pr_backend: (pending)
+- pr_backend_url: (pending)
+- pr_frontend: (pending)
+- pr_frontend_url: (pending)
+- release_report: (pending)
+- tag: (pending)
+- release_url: (pending)
+- ops_report: (pending)
+
+## Stage History
+
+| Stage | Status | Iterations | Gates | Artifact |
+|---|---|---|---|---|
+| 01-planning | complete | 1 | G1–G5 pass | #189 |
+| 02-design | complete | 1 | G1–G8 pass | design-189.md |
+| 03-development | in_progress | 0 | - | - |
+| 04-review | (pending) | - | - | - |
+| 05-release | (pending) | - | - | - |
+| 06-operations | (pending) | - | - | - |

--- a/Sessions/specs/spec-split-layer.md
+++ b/Sessions/specs/spec-split-layer.md
@@ -1,0 +1,115 @@
+﻿# Analisi strutturata del layer switch per ruoli e contesti in una web application
+
+## Panoramica
+
+Per una web application con aree distinte come **affitti brevi**, **affitti lungo termine** e **pannello admin**, l'approccio più solido non è trattare queste sezioni come semplici pagine abilitate da ruoli globali, ma come **contesti applicativi** o **workspace** separati.[1][2] Questo modello è coerente con le architetture multi-tenant moderne, dove l'accesso viene valutato nel contesto attivo e non solo sul ruolo astratto dell'utente.[1][2]
+
+Il problema per cui l'utente deve inserire manualmente la route giusta nasce di solito da una combinazione di routing piatto, redirect post-login poco strutturato e controllo accessi distribuito in modo incoerente tra menu, frontend e backend.[2][3] Un approccio strutturato risolve questo problema introducendo un livello esplicito di contesto, una route architecture coerente e una sorgente unica di verità per navigazione e autorizzazioni.[1][3]
+
+## Problema architetturale
+
+Quando l'applicazione usa solo RBAC classico, il modello implicito diventa `utente -> ruolo -> pagina`.[2][3] Questo schema funziona in applicazioni semplici, ma tende a rompersi quando uno stesso utente può operare in più aree con privilegi diversi, perché il ruolo non basta più a rappresentare il perimetro funzionale corretto.[1][2]
+
+Nel caso descritto, “affitti brevi”, “affitti lungo termine” e “admin” non sono semplicemente tre viste, ma tre **aree operative** con obiettivi, menu, flussi e permessi distinti.[1][4] Se queste aree non hanno un'identità architetturale propria, l'app tende a delegare all'utente la responsabilità di conoscere la route corretta, che è esattamente il comportamento da evitare in una UX solida.[4][3]
+
+## Modello consigliato
+
+Il modello raccomandato separa chiaramente identità, contesto e permessi.[1][2] In pratica, l'utente ha una identità globale, ma i suoi ruoli e permessi vengono valutati all'interno di un contesto attivo come `short-rent`, `long-rent` o `admin`.[1][2]
+
+Una struttura concettuale efficace è la seguente:
+
+- **User**: identità globale dell'utente.[1]
+- **Context / Workspace**: area operativa selezionabile, per esempio `short-rent`, `long-rent`, `admin`.[1][4]
+- **Membership**: relazione tra utente e contesto.[1][2]
+- **Role**: ruolo assegnato nel contesto specifico, non necessariamente globale.[1][2]
+- **Permission**: capability fine-grained, come `booking.read`, `contract.create`, `admin.users.manage`.[2][3]
+
+Questo approccio evita la cosiddetta **role explosion**, cioè la proliferazione di ruoli globali che cercano di codificare tutte le combinazioni possibili di responsabilità e moduli.[2] Inoltre rende più semplice evolvere il sistema nel tempo, perché i permessi possono crescere per capability invece che per profili monolitici.[2][3]
+
+## Routing e navigazione
+
+L'applicazione dovrebbe adottare URL canonici basati sul contesto, ad esempio `/app/short-rent/*`, `/app/long-rent/*` e `/app/admin/*`.[4][3] In questo modo il contesto corrente diventa parte esplicita della navigazione e tutte le route figlie ereditano in modo naturale il perimetro funzionale corretto.[4][3]
+
+È utile introdurre una route manifest centralizzata, dove ogni route dichiara almeno questi metadati:
+
+| Campo | Significato |
+|---|---|
+| `path` | Path canonico della route |
+| `context` | Contesto di appartenenza, ad esempio `short-rent` |
+| `requiredPermissions` | Permessi richiesti per accedere |
+| `navLabel` | Etichetta da mostrare nel menu |
+| `isDefault` | Indica se è la landing predefinita del contesto |
+
+Una configurazione di questo tipo permette di derivare da un unico punto sia il menu laterale sia i redirect di default sia le guardie di accesso.[3][2] La centralizzazione riduce il rischio di incoerenza tra ciò che l'utente vede nel menu e ciò che può realmente aprire via URL.[2][3]
+
+## Context switcher
+
+Lo switcher non dovrebbe essere pensato come un semplice “role switcher” visibile solo quando un utente ha due o più ruoli, ma come un vero **context switcher** o **workspace switcher** integrato nell'application shell.[4] Questo pattern viene usato nelle app modulari perché rende esplicito il fatto che l'utente sta cambiando area operativa, non semplicemente privilegi astratti.[4][2]
+
+Il comportamento consigliato è il seguente:
+
+1. Dopo il login, l'app recupera i contesti disponibili e i permessi associati.[1][2]
+2. Se esiste un solo contesto disponibile, esegue redirect automatico verso la landing di quel contesto.[1]
+3. Se esistono più contesti, apre una schermata di selezione iniziale oppure riattiva l'ultimo contesto usato.[1][4]
+4. Una volta scelto il contesto, menu, breadcrumb, dashboard e route tree vengono derivati da quel contesto.[4][3]
+5. Se l'utente prova ad aprire una route non compatibile con il contesto o senza permessi, l'app effettua redirect verso la home del contesto valido oppure mostra un 403 gestito.[2][3]
+
+Questo elimina la necessità di digitare manualmente la route e trasforma il cambio area in un flusso intenzionale, comprensibile e consistente.[4][3]
+
+## Backend e autorizzazione
+
+Dal lato backend è preferibile evitare ruoli globali come `Admin`, `AffittiBrevi`, `AffittiLunghi` se questi rappresentano in realtà aree operative.[2] Le architetture di autorizzazione scalabili suggeriscono di modellare i permessi in modo contestuale, così da poter valutare policy e capability nel perimetro corretto.[2]
+
+Un modello dati minimo può essere:
+
+```text
+User
+UserContextMembership
+- UserId
+- ContextKey
+- RoleKey
+
+Role
+- RoleKey
+
+RolePermission
+- RoleKey
+- PermissionKey
+```
+
+In alternativa, una variante ancora più flessibile è basata su `User`, `Workspace`, `Membership` e `PermissionGrant`, soprattutto se il sistema deve crescere con feature flag, tenant o regole più articolate.[1][2] In entrambi i casi, il backend dovrebbe essere la fonte autorevole per la decisione finale di accesso, mentre il frontend dovrebbe limitarsi a riflettere tali decisioni nella navigazione e nell'interfaccia.[2][3]
+
+## Anti-pattern da evitare
+
+Gli anti-pattern principali in questo scenario sono i seguenti:
+
+- Route piatte senza namespace di contesto, ad esempio `/prenotazioni`, `/contratti`, `/users`.[3]
+- Redirect post-login fisso, scollegato dai contesti realmente disponibili.[1]
+- Menu generato da ruoli globali invece che dal contesto attivo.[2][4]
+- Verifica permessi solo nel frontend, con backend permissivo o incoerente.[2][3]
+- Switcher concepito come eccezione UX invece che come elemento strutturale dell'application shell.[4]
+
+Questi problemi tendono a produrre inconsistenza tra esperienza utente, struttura delle route e logica autorizzativa.[2][3] Nel tempo diventano particolarmente costosi da mantenere perché ogni nuova area o variante di accesso obbliga ad aggiungere condizioni sparse nel codice invece di estendere un modello coerente.[2]
+
+## Raccomandazione operativa
+
+Per il caso in esame, la soluzione più ordinata è trasformare i tre layer in tre **app context ufficiali**: `short-rent`, `long-rent` e `admin`.[1][4] Da qui discendono alcune scelte implementative molto concrete.[2][3]
+
+- Introdurre route canoniche con prefisso di contesto, ad esempio `/app/:context/...`.[3]
+- Mantenere uno `activeContext` nello stato dell'applicazione.[4]
+- Usare una route manifest centralizzata come sorgente per route, menu e redirect.[3]
+- Mostrare sempre uno switcher di area nell'header o nella sidebar, non solo in casi eccezionali.[4]
+- Calcolare la landing page in funzione del contesto attivo e dei permessi effettivi.[1][2]
+- Demandare il controllo finale dei permessi al backend o a un authorization layer dedicato.[2]
+
+Dal punto di vista del naming, espressioni come **workspace switcher**, **area switcher** o **context switcher** sono più precise di “role switcher”, perché descrivono meglio ciò che accade dal punto di vista del dominio applicativo.[4][2]
+
+## Esempio di comportamento atteso
+
+Si consideri un utente che ha accesso a `short-rent` e `admin`, ma non a `long-rent`.[1][2] Dopo il login, l'app può riaprire `short-rent` come ultimo contesto usato e portare l'utente a `/app/short-rent/dashboard`.[1][3]
+
+A quel punto la sidebar mostra soltanto le voci rilevanti per `short-rent`, mentre il context switcher permette il passaggio intenzionale a `admin`.[4][3] Se l'utente prova a navigare manualmente verso `/app/long-rent/contracts`, il sistema dovrebbe riconoscere l'assenza di membership o permessi e reindirizzare verso una route valida o rispondere con un 403 gestito.[2][3]
+
+## Conclusione
+
+L'approccio più strutturato consiste nel trattare i tre layer come contesti applicativi distinti, con routing contestuale, navigazione derivata da configurazione centralizzata e autorizzazione valutata nel perimetro corretto.[1][2][3] In questo modo l'utente smette di dover conoscere la route corretta e l'applicazione acquisisce una base molto più robusta per crescere senza accumulare logica fragile e duplicata.[2][4][3]


### PR DESCRIPTION
## Summary
- Backend Phase B: contextual authorization entities, EF migration `AddContextAuthorization`, `GET /api/me/contexts` bootstrap API, JWT synthesis fallback, policies on leases/properties/bookings.
- Design spec and pipeline artifacts for Issue #189.

## Frontend PR
https://github.com/casazen/frontend/pull/new/feature/189-context-workspace-switch

## Test Plan
- [x] `dotnet test` (381 passed)
- [x] `dotnet format --verify-no-changes`
- [x] Migration compiles

## AC to E2E Coverage
| AC | E2E | Status |
|---|---|---|
| BE contextual auth | N/A (no UI) | N/A |
| Bootstrap API | N/A (no UI) | N/A |
| FE routing/switcher | frontend e2e/context-workspace-switch.spec.ts | covered in FE PR |

Closes #189