### PR TITLE
feat(properties): aggregate detail endpoint, document validation, RBAC hardening (#152)

### DIFF
--- a/Casazen.Core/DTOs/PropertyDetailResponse.cs
+++ b/Casazen.Core/DTOs/PropertyDetailResponse.cs
@@ -19,6 +19,10 @@ public class PropertyDetailResponse
     public decimal DamageDeposit { get; set; }
     public string? CinCode { get; set; }
     public CinStatus CinStatus { get; set; }
+    public string Timezone { get; set; } = "Europe/Rome";
+    public IReadOnlyList<string> Amenities { get; set; } = [];
+    public IReadOnlyList<string> PhotoUrls { get; set; } = [];
+    public string HouseRules { get; set; } = string.Empty;
     public bool IsActive { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
@@ -26,28 +30,26 @@ public class PropertyDetailResponse
     public IReadOnlyList<PropertyDocumentDto> Documents { get; set; } = [];
     public IReadOnlyList<OtaIntegrationSummaryDto> OtaIntegrations { get; set; } = [];
     public BookingsSummaryDto BookingsSummary { get; set; } = new();
+    public PricingAdapterSummaryDto PricingAdapterSummary { get; set; } = new();
 }
 
 public class PropertyDocumentDto
 {
     public Guid Id { get; set; }
     public string FileName { get; set; } = string.Empty;
-    public string StorageUrl { get; set; } = string.Empty;
-    public DocumentType DocumentType { get; set; }
-    public string UploadedBy { get; set; } = string.Empty;
+    public string FileType { get; set; } = string.Empty;
     public DateTime UploadedAt { get; set; }
+    public string DownloadUrl { get; set; } = string.Empty;
 }
 
 public class OtaIntegrationSummaryDto
 {
     public Guid Id { get; set; }
     public string Platform { get; set; } = string.Empty;
-    public string ExternalPropertyId { get; set; } = string.Empty;
     public bool IsActive { get; set; }
     public bool SyncEnabled { get; set; }
     public DateTime LastSyncAt { get; set; }
     public OtaSyncStatus? SyncStatus { get; set; }
-    public string? LastSyncError { get; set; }
 }
 
 public class BookingsSummaryDto
@@ -57,4 +59,11 @@ public class BookingsSummaryDto
     public int ActiveBookings { get; set; }
     public DateTime? NextCheckIn { get; set; }
     public DateTime? NextCheckOut { get; set; }
+}
+
+public class PricingAdapterSummaryDto
+{
+    public bool IsEnabled { get; set; }
+    public DateTime? LastAdaptedAt { get; set; }
+    public DateTime? NextScheduledRunAt { get; set; }
 }

--- a/Casazen.Core/Services/IAdminAccessAuditService.cs
+++ b/Casazen.Core/Services/IAdminAccessAuditService.cs
@@ -1,0 +1,11 @@
+namespace Casazen.Core.Services;
+
+public interface IAdminAccessAuditService
+{
+    Task LogPrivilegedPropertyAccessAsync(
+        string actorUserId,
+        Guid propertyId,
+        string ownerId,
+        string action,
+        CancellationToken ct = default);
+}

--- a/Casazen.Core/Services/IImageStorageService.cs
+++ b/Casazen.Core/Services/IImageStorageService.cs
@@ -24,4 +24,14 @@ public interface IImageStorageService
     /// <param name="file">File to validate</param>
     /// <returns>True if valid, false otherwise</returns>
     bool ValidateImage(IFormFile file);
+
+    /// <summary>
+    /// Upload a compliance document and return the public URL
+    /// </summary>
+    Task<string> UploadDocumentAsync(IFormFile file, Guid propertyId);
+
+    /// <summary>
+    /// Validate if a file is an accepted compliance document (PDF, DOC, DOCX, JPG, PNG)
+    /// </summary>
+    bool ValidateDocument(IFormFile file);
 }

--- a/Casazen.Infrastructure/Repositories/PropertyRepositories.cs
+++ b/Casazen.Infrastructure/Repositories/PropertyRepositories.cs
@@ -80,6 +80,7 @@ public class PropertyRepository(AppDbContext context) : IPropertyRepository
             .Include(p => p.PropertyDocuments)
             .Include(p => p.OtaIntegrations)
             .Include(p => p.Bookings)
+            .Include(p => p.PricingAdapterConfig)
             .FirstOrDefaultAsync(p => p.Id == id && p.IsActive);
     }
 }

--- a/Casazen.Infrastructure/Services/AdminAccessAuditService.cs
+++ b/Casazen.Infrastructure/Services/AdminAccessAuditService.cs
@@ -1,0 +1,26 @@
+using Casazen.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Infrastructure.Services;
+
+public class AdminAccessAuditService(ILogger<AdminAccessAuditService> logger) : IAdminAccessAuditService
+{
+    public Task LogPrivilegedPropertyAccessAsync(
+        string actorUserId,
+        Guid propertyId,
+        string ownerId,
+        string action,
+        CancellationToken ct = default)
+    {
+        logger.LogWarning(
+            "Privileged property access: {Event} ActorUserId={ActorUserId} PropertyId={PropertyId} OwnerId={OwnerId} Action={Action} Timestamp={Timestamp}",
+            "PrivilegedPropertyAccess",
+            actorUserId,
+            propertyId,
+            ownerId,
+            action,
+            DateTime.UtcNow);
+
+        return Task.CompletedTask;
+    }
+}

--- a/Casazen.Infrastructure/Services/LocalImageStorageService.cs
+++ b/Casazen.Infrastructure/Services/LocalImageStorageService.cs
@@ -13,6 +13,15 @@ public class LocalImageStorageService : IImageStorageService
     private readonly long _maxFileSizeBytes = 10 * 1024 * 1024; // 10MB
     private readonly string[] _allowedExtensions = { ".jpg", ".jpeg", ".png", ".webp" };
     private readonly string[] _allowedMimeTypes = { "image/jpeg", "image/png", "image/webp" };
+    private readonly string[] _allowedDocumentExtensions = { ".pdf", ".doc", ".docx", ".jpg", ".jpeg", ".png" };
+    private readonly string[] _allowedDocumentMimeTypes =
+    {
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "image/jpeg",
+        "image/png"
+    };
 
     public LocalImageStorageService(
         IConfiguration configuration,
@@ -122,6 +131,70 @@ public class LocalImageStorageService : IImageStorageService
         if (!_allowedMimeTypes.Contains(file.ContentType.ToLowerInvariant()))
         {
             _logger.LogWarning("Image validation failed: invalid MIME type {MimeType}", file.ContentType);
+            return false;
+        }
+
+        return true;
+    }
+
+    public async Task<string> UploadDocumentAsync(IFormFile file, Guid propertyId)
+    {
+        if (!ValidateDocument(file))
+        {
+            throw new InvalidOperationException("Invalid document file");
+        }
+
+        var propertyDir = Path.Combine(_storagePath, propertyId.ToString(), "documents");
+        if (!Directory.Exists(propertyDir))
+        {
+            Directory.CreateDirectory(propertyDir);
+        }
+
+        var extension = Path.GetExtension(file.FileName).ToLowerInvariant();
+        var fileName = $"{Guid.NewGuid()}{extension}";
+        var filePath = Path.Combine(propertyDir, fileName);
+
+        try
+        {
+            await using var stream = new FileStream(filePath, FileMode.Create);
+            await file.CopyToAsync(stream);
+            _logger.LogInformation("Document uploaded: {FileName} for property {PropertyId}", fileName, propertyId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to upload document for property {PropertyId}", propertyId);
+            throw;
+        }
+
+        return $"{_baseUrl}/{propertyId}/documents/{fileName}";
+    }
+
+    public bool ValidateDocument(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+        {
+            _logger.LogWarning("Document validation failed: file is null or empty");
+            return false;
+        }
+
+        if (file.Length > _maxFileSizeBytes)
+        {
+            _logger.LogWarning("Document validation failed: file size {Size} exceeds limit {Limit}",
+                file.Length, _maxFileSizeBytes);
+            return false;
+        }
+
+        var extension = Path.GetExtension(file.FileName).ToLowerInvariant();
+        if (!_allowedDocumentExtensions.Contains(extension))
+        {
+            _logger.LogWarning("Document validation failed: invalid extension {Extension}", extension);
+            return false;
+        }
+
+        var mimeType = file.ContentType.ToLowerInvariant();
+        if (!_allowedDocumentMimeTypes.Contains(mimeType))
+        {
+            _logger.LogWarning("Document validation failed: invalid MIME type {MimeType}", file.ContentType);
             return false;
         }
 

--- a/Casazen.Infrastructure/Services/PropertyDocumentService.cs
+++ b/Casazen.Infrastructure/Services/PropertyDocumentService.cs
@@ -21,7 +21,12 @@ public class PropertyDocumentService(
             throw new InvalidOperationException($"Property {propertyId} not found");
         }
 
-        var storageUrl = await storageService.UploadImageAsync(file, propertyId);
+        if (!storageService.ValidateDocument(file))
+        {
+            throw new InvalidOperationException("Invalid document file type or size");
+        }
+
+        var storageUrl = await storageService.UploadDocumentAsync(file, propertyId);
 
         try
         {

--- a/Casazen.Infrastructure/Services/PropertyService.cs
+++ b/Casazen.Infrastructure/Services/PropertyService.cs
@@ -134,28 +134,22 @@ public class PropertyService(IPropertyRepository repository, ILogger<PropertySer
             DamageDeposit = property.DamageDeposit,
             CinCode = property.CinCode,
             CinStatus = ResolveCinStatus(property.CinCode),
+            Timezone = property.Timezone,
+            Amenities = property.Amenities.Select(a => a.ToString()).ToList(),
+            PhotoUrls = property.PhotoUrls,
+            HouseRules = property.HouseRules,
             IsActive = property.IsActive,
             CreatedAt = property.CreatedAt,
             UpdatedAt = property.UpdatedAt,
-            Documents = property.PropertyDocuments.Select(d => new PropertyDocumentDto
-            {
-                Id = d.Id,
-                FileName = d.FileName,
-                StorageUrl = d.StorageUrl,
-                DocumentType = d.DocumentType,
-                UploadedBy = d.UploadedBy,
-                UploadedAt = d.UploadedAt
-            }).ToList(),
+            Documents = property.PropertyDocuments.Select(MapDocument).ToList(),
             OtaIntegrations = property.OtaIntegrations.Select(o => new OtaIntegrationSummaryDto
             {
                 Id = o.Id,
                 Platform = o.Platform,
-                ExternalPropertyId = o.ExternalPropertyId,
                 IsActive = o.IsActive,
                 SyncEnabled = o.SyncEnabled,
                 LastSyncAt = o.LastSyncAt,
-                SyncStatus = o.SyncStatus != null && Enum.TryParse<OtaSyncStatus>(o.SyncStatus, out var status) ? status : null,
-                LastSyncError = o.LastSyncError
+                SyncStatus = o.SyncStatus != null && Enum.TryParse<OtaSyncStatus>(o.SyncStatus, out var status) ? status : null
             }).ToList(),
             BookingsSummary = new BookingsSummaryDto
             {
@@ -170,8 +164,36 @@ public class PropertyService(IPropertyRepository repository, ILogger<PropertySer
                 NextCheckOut = property.Bookings
                     .Where(b => b.CheckOutDate > now)
                     .MinBy(b => b.CheckOutDate)?.CheckOutDate
-            }
+            },
+            PricingAdapterSummary = property.PricingAdapterConfig == null
+                ? new PricingAdapterSummaryDto()
+                : new PricingAdapterSummaryDto
+                {
+                    IsEnabled = property.PricingAdapterConfig.IsEnabled,
+                    LastAdaptedAt = property.PricingAdapterConfig.LastAdaptedAt,
+                    NextScheduledRunAt = property.PricingAdapterConfig.NextScheduledRunAt
+                }
         };
+    }
+
+    public static PropertyDocumentDto MapDocument(PropertyDocument d) => new()
+    {
+        Id = d.Id,
+        FileName = d.FileName,
+        FileType = ResolveFileType(d),
+        UploadedAt = d.UploadedAt,
+        DownloadUrl = d.StorageUrl
+    };
+
+    private static string ResolveFileType(PropertyDocument document)
+    {
+        var extension = Path.GetExtension(document.FileName);
+        if (!string.IsNullOrWhiteSpace(extension))
+        {
+            return extension.TrimStart('.').ToLowerInvariant();
+        }
+
+        return document.DocumentType.ToString();
     }
 
     private static readonly Regex CinRegex = new(@"^IT-\d{5}-\d{10}$", RegexOptions.Compiled);

--- a/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
@@ -19,6 +19,7 @@ public class PropertiesControllerTests
     private readonly Mock<IImageStorageService> _mockImageStorage;
     private readonly Mock<IPropertyAuthorizationService> _mockAuthz;
     private readonly Mock<IPropertyDocumentService> _mockDocumentService;
+    private readonly Mock<IAdminAccessAuditService> _mockAuditService;
     private readonly Mock<ILogger<PropertiesController>> _mockLogger;
     private readonly PropertiesController _controller;
 
@@ -28,12 +29,14 @@ public class PropertiesControllerTests
         _mockImageStorage = new Mock<IImageStorageService>();
         _mockAuthz = new Mock<IPropertyAuthorizationService>();
         _mockDocumentService = new Mock<IPropertyDocumentService>();
+        _mockAuditService = new Mock<IAdminAccessAuditService>();
         _mockLogger = new Mock<ILogger<PropertiesController>>();
         _controller = new PropertiesController(
             _mockService.Object,
             _mockImageStorage.Object,
             _mockAuthz.Object,
             _mockDocumentService.Object,
+            _mockAuditService.Object,
             _mockLogger.Object);
     }
 
@@ -1196,12 +1199,79 @@ public class PropertiesControllerTests
         Assert.IsType<NotFoundResult>(result);
     }
 
-    private void SetupUserClaims(string userId)
+    [Fact]
+    public async Task GetDetail_AsAdminCrossOwner_LogsPrivilegedAccess()
+    {
+        var adminId = "auth0|admin_user";
+        SetupUserClaims(adminId, ["Admin"]);
+        AllowAuthorization();
+
+        var propertyId = Guid.NewGuid();
+        var ownerId = "auth0|owner";
+        _mockService.Setup(x => x.GetPropertyDetailAsync(propertyId))
+            .ReturnsAsync(new PropertyDetailResponse { Id = propertyId, OwnerId = ownerId });
+
+        var result = await _controller.GetDetail(propertyId);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        _mockAuditService.Verify(
+            x => x.LogPrivilegedPropertyAccessAsync(adminId, propertyId, ownerId, "PropertyDetail.Read", default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetDetail_AsOwner_DoesNotLogPrivilegedAccess()
+    {
+        var userId = "auth0|owner_user_123";
+        SetupUserClaims(userId, ["PropertyOwner"]);
+        AllowAuthorization();
+
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyDetailAsync(propertyId))
+            .ReturnsAsync(new PropertyDetailResponse { Id = propertyId, OwnerId = userId });
+
+        await _controller.GetDetail(propertyId);
+
+        _mockAuditService.Verify(
+            x => x.LogPrivilegedPropertyAccessAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), default),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadDocument_InvalidFile_ReturnsBadRequest()
+    {
+        var userId = "auth0|owner_user_123";
+        SetupUserClaims(userId);
+        AllowAuthorization();
+
+        var propertyId = Guid.NewGuid();
+        _mockService.Setup(x => x.GetPropertyAsync(propertyId))
+            .ReturnsAsync(new Property { Id = propertyId, OwnerId = userId });
+
+        var mockFile = CreateMockFormFile("virus.exe", "application/octet-stream", 1024);
+        _mockDocumentService.Setup(x => x.UploadDocumentAsync(propertyId, mockFile, DocumentType.Other, userId))
+            .ThrowsAsync(new InvalidOperationException("Invalid document file type or size"));
+
+        var result = await _controller.UploadDocument(propertyId, mockFile, "Other");
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    private void SetupUserClaims(string userId, IEnumerable<string>? roles = null)
     {
         var claims = new List<Claim>
         {
             new Claim("sub", userId)
         };
+
+        if (roles != null)
+        {
+            foreach (var role in roles)
+            {
+                claims.Add(new Claim("https://casazen.app/roles", role));
+            }
+        }
+
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var claimsPrincipal = new ClaimsPrincipal(identity);
 

--- a/Casazen.Tests/Unit/Services/PropertyDocumentServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/PropertyDocumentServiceTests.cs
@@ -48,7 +48,8 @@ public class PropertyDocumentServiceTests
         };
 
         _mockPropertyRepository.Setup(x => x.ExistsAsync(propertyId)).ReturnsAsync(true);
-        _mockStorageService.Setup(x => x.UploadImageAsync(mockFile.Object, propertyId)).ReturnsAsync(storageUrl);
+        _mockStorageService.Setup(x => x.ValidateDocument(mockFile.Object)).Returns(true);
+        _mockStorageService.Setup(x => x.UploadDocumentAsync(mockFile.Object, propertyId)).ReturnsAsync(storageUrl);
         _mockDocumentRepository.Setup(x => x.AddAsync(It.IsAny<PropertyDocument>())).ReturnsAsync(expectedDocument);
 
         // Act
@@ -74,7 +75,7 @@ public class PropertyDocumentServiceTests
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             _service.UploadDocumentAsync(propertyId, mockFile.Object, DocumentType.CinCertificate, "user@example.com"));
 
-        _mockStorageService.Verify(x => x.UploadImageAsync(It.IsAny<IFormFile>(), It.IsAny<Guid>()), Times.Never);
+        _mockStorageService.Verify(x => x.UploadDocumentAsync(It.IsAny<IFormFile>(), It.IsAny<Guid>()), Times.Never);
         _mockDocumentRepository.Verify(x => x.AddAsync(It.IsAny<PropertyDocument>()), Times.Never);
     }
 
@@ -88,14 +89,15 @@ public class PropertyDocumentServiceTests
         var savedDocument = new PropertyDocument { Id = Guid.NewGuid(), PropertyId = propertyId };
 
         _mockPropertyRepository.Setup(x => x.ExistsAsync(propertyId)).ReturnsAsync(true);
-        _mockStorageService.Setup(x => x.UploadImageAsync(mockFile.Object, propertyId)).ReturnsAsync(storageUrl);
+        _mockStorageService.Setup(x => x.ValidateDocument(mockFile.Object)).Returns(true);
+        _mockStorageService.Setup(x => x.UploadDocumentAsync(mockFile.Object, propertyId)).ReturnsAsync(storageUrl);
         _mockDocumentRepository.Setup(x => x.AddAsync(It.IsAny<PropertyDocument>())).ReturnsAsync(savedDocument);
 
         // Act
         await _service.UploadDocumentAsync(propertyId, mockFile.Object, DocumentType.FloorPlan, "owner@example.com");
 
         // Assert
-        _mockStorageService.Verify(x => x.UploadImageAsync(mockFile.Object, propertyId), Times.Once);
+        _mockStorageService.Verify(x => x.UploadDocumentAsync(mockFile.Object, propertyId), Times.Once);
     }
 
     [Fact]

--- a/Casazen.Tests/Unit/Services/PropertyServiceGetDetailTests.cs
+++ b/Casazen.Tests/Unit/Services/PropertyServiceGetDetailTests.cs
@@ -93,7 +93,76 @@ public class PropertyServiceGetDetailTests
         Assert.Single(result.OtaIntegrations);
         Assert.Equal(1, result.BookingsSummary.TotalBookings);
         Assert.Equal(1, result.BookingsSummary.UpcomingBookings);
+        Assert.False(result.PricingAdapterSummary.IsEnabled);
         _mockRepository.Verify(x => x.GetPropertyDetailAsync(propertyId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetPropertyDetailAsync_WithPricingAdapterConfig_ReturnsPricingAdapterSummary()
+    {
+        var propertyId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var property = new Property
+        {
+            Id = propertyId,
+            OwnerId = "auth0|owner123",
+            Name = "Test Property",
+            Address = "Via Test 1",
+            City = "Rome",
+            IsActive = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+            PricingAdapterConfig = new PricingAdapterConfig
+            {
+                PropertyId = propertyId,
+                IsEnabled = true,
+                LastAdaptedAt = now.AddHours(-2),
+                NextScheduledRunAt = now.AddHours(22)
+            }
+        };
+
+        _mockRepository.Setup(x => x.GetPropertyDetailAsync(propertyId)).ReturnsAsync(property);
+
+        var result = await _service.GetPropertyDetailAsync(propertyId);
+
+        Assert.True(result.PricingAdapterSummary.IsEnabled);
+        Assert.Equal(now.AddHours(-2), result.PricingAdapterSummary.LastAdaptedAt);
+        Assert.Equal(now.AddHours(22), result.PricingAdapterSummary.NextScheduledRunAt);
+    }
+
+    [Fact]
+    public async Task GetPropertyDetailAsync_MapsDocumentsWithDownloadUrlAndFileType()
+    {
+        var propertyId = Guid.NewGuid();
+        var property = new Property
+        {
+            Id = propertyId,
+            OwnerId = "auth0|owner123",
+            Name = "Test Property",
+            Address = "Via Test 1",
+            City = "Rome",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        property.PropertyDocuments.Add(new PropertyDocument
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId,
+            FileName = "cin-cert.pdf",
+            StorageUrl = "/uploads/properties/cin-cert.pdf",
+            DocumentType = DocumentType.CinCertificate,
+            UploadedAt = DateTime.UtcNow
+        });
+
+        _mockRepository.Setup(x => x.GetPropertyDetailAsync(propertyId)).ReturnsAsync(property);
+
+        var result = await _service.GetPropertyDetailAsync(propertyId);
+
+        var doc = Assert.Single(result.Documents);
+        Assert.Equal("pdf", doc.FileType);
+        Assert.Equal("/uploads/properties/cin-cert.pdf", doc.DownloadUrl);
     }
 
     [Fact]

--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -4,6 +4,7 @@ using Casazen.Core.Entities;
 using Casazen.Core.Enums;
 using Casazen.Core.Services;
 using Casazen.Web.DTOs;
+using Casazen.Web.Infrastructure;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,6 +19,7 @@ public class PropertiesController(
     IImageStorageService imageStorageService,
     IPropertyAuthorizationService authorizationService,
     IPropertyDocumentService documentService,
+    IAdminAccessAuditService adminAccessAuditService,
     ILogger<PropertiesController> logger) : ControllerBase
 {
     [HttpGet("health")]
@@ -116,12 +118,15 @@ public class PropertiesController(
         if (existing == null)
             return NotFound();
 
-        if (!authorizationService.CanAccess(userId, existing.OwnerId, GetUserRoles()))
+        var roles = GetUserRoles();
+        if (!authorizationService.CanAccess(userId, existing.OwnerId, roles))
         {
             logger.LogWarning("User {UserId} attempted to update property {PropertyId} owned by {OwnerId}",
                 userId, id, existing.OwnerId);
             return Forbid();
         }
+
+        await AuditPrivilegedAccessIfNeededAsync(userId, id, existing.OwnerId, roles, "Property.Update");
 
         request.ApplyTo(existing);
         await propertyService.UpdatePropertyAsync(existing);
@@ -346,8 +351,11 @@ public class PropertiesController(
             return NotFound();
         }
 
-        if (!authorizationService.CanAccess(userId, detail.OwnerId, GetUserRoles()))
+        var roles = GetUserRoles();
+        if (!authorizationService.CanAccess(userId, detail.OwnerId, roles))
             return Forbid();
+
+        await AuditPrivilegedAccessIfNeededAsync(userId, id, detail.OwnerId, roles, "PropertyDetail.Read");
 
         return Ok(detail);
     }
@@ -372,8 +380,11 @@ public class PropertiesController(
         if (property == null)
             return NotFound();
 
-        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
+        var roles = GetUserRoles();
+        if (!authorizationService.CanAccess(userId, property.OwnerId, roles))
             return Forbid();
+
+        await AuditPrivilegedAccessIfNeededAsync(userId, id, property.OwnerId, roles, "PropertyDocument.List");
 
         var documents = await documentService.GetByPropertyIdAsync(id);
         return Ok(documents.Select(ToDocumentDto));
@@ -407,14 +418,24 @@ public class PropertiesController(
         if (property == null)
             return NotFound();
 
-        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
+        var roles = GetUserRoles();
+        if (!authorizationService.CanAccess(userId, property.OwnerId, roles))
             return Forbid();
 
         if (!Enum.TryParse<DocumentType>(documentType, ignoreCase: true, out var docType))
             return BadRequest(new { error = $"Invalid document type: {documentType}" });
 
-        var document = await documentService.UploadDocumentAsync(id, file, docType, userId);
-        return CreatedAtAction(nameof(GetDocuments), new { id }, ToDocumentDto(document));
+        await AuditPrivilegedAccessIfNeededAsync(userId, id, property.OwnerId, roles, "PropertyDocument.Upload");
+
+        try
+        {
+            var document = await documentService.UploadDocumentAsync(id, file, docType, userId);
+            return CreatedAtAction(nameof(GetDocuments), new { id }, ToDocumentDto(document));
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Invalid document", StringComparison.OrdinalIgnoreCase))
+        {
+            return BadRequest(new { error = ex.Message });
+        }
     }
 
     /// <summary>
@@ -439,32 +460,51 @@ public class PropertiesController(
         if (property == null)
             return NotFound();
 
-        if (!authorizationService.CanAccess(userId, property.OwnerId, GetUserRoles()))
+        var roles = GetUserRoles();
+        if (!authorizationService.CanAccess(userId, property.OwnerId, roles))
             return Forbid();
 
         var document = await documentService.GetDocumentAsync(docId);
         if (document == null || document.PropertyId != id)
             return NotFound();
 
+        await AuditPrivilegedAccessIfNeededAsync(userId, id, property.OwnerId, roles, "PropertyDocument.Delete");
+
         await documentService.DeleteDocumentAsync(docId);
         return NoContent();
     }
 
-    private static PropertyDocumentDto ToDocumentDto(PropertyDocument d) => new()
-    {
-        Id = d.Id,
-        FileName = d.FileName,
-        StorageUrl = d.StorageUrl,
-        DocumentType = d.DocumentType,
-        UploadedBy = d.UploadedBy,
-        UploadedAt = d.UploadedAt
-    };
+    private static PropertyDocumentDto ToDocumentDto(PropertyDocument d) =>
+        Casazen.Infrastructure.Services.PropertyService.MapDocument(d);
 
     private string? GetAuthenticatedUserId() =>
         User.FindFirst("sub")?.Value
         ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value
         ?? User.FindFirst("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")?.Value;
 
-    private IEnumerable<string> GetUserRoles() =>
-        User.FindAll(ClaimTypes.Role).Select(c => c.Value);
+    private IReadOnlyList<string> GetUserRoles()
+    {
+        var auth0Roles = Auth0RolesClaimParser.Parse(
+            User.FindAll("https://casazen.app/roles").Select(c => c.Value));
+        if (auth0Roles.Count > 0)
+            return auth0Roles;
+
+        return User.FindAll(ClaimTypes.Role).Select(c => c.Value).ToArray();
+    }
+
+    private async Task AuditPrivilegedAccessIfNeededAsync(
+        string userId,
+        Guid propertyId,
+        string ownerId,
+        IReadOnlyList<string> roles,
+        string action)
+    {
+        if (userId == ownerId)
+            return;
+
+        if (!roles.Any(r => r is "PropertyManager" or "Admin"))
+            return;
+
+        await adminAccessAuditService.LogPrivilegedPropertyAccessAsync(userId, propertyId, ownerId, action);
+    }
 }

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -10,10 +10,7 @@ using Casazen.Infrastructure.OTA.Resilience;
 using Casazen.Infrastructure.Repositories;
 using Casazen.Infrastructure.Services;
 using Casazen.Web.Infrastructure;
-<<<<<<< HEAD
-=======
 using Microsoft.AspNetCore.Authorization;
->>>>>>> origin/develop
 using Casazen.Web.Middleware;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -121,6 +118,7 @@ public static class ServiceCollectionExtensions
         var builder = services.AddAuthorizationBuilder()
             .AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"))
             .AddPolicy("PropertyOwner", policy => policy.RequireAuthenticatedUser())
+            .AddPolicy("PropertyManagerOrAdmin", policy => policy.RequireRole("PropertyManager", "Admin"))
             .AddPolicy("LongTermLandlord", policy => policy.RequireRole("LongTermLandlord"));
 
         RegisterContextPolicies(builder);
@@ -240,6 +238,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPropertyDocumentService, PropertyDocumentService>();
         services.AddScoped<IImageStorageService, LocalImageStorageService>();
         services.AddScoped<IPropertyAuthorizationService, PropertyAuthorizationService>();
+        services.AddScoped<IAdminAccessAuditService, AdminAccessAuditService>();
         return services;
     }
 

--- a/Sessions/design-152.md
+++ b/Sessions/design-152.md
@@ -1,0 +1,637 @@
+# Design Spec — Issue #152
+# feat: Property detail — aggregate endpoint, documents storage, RBAC hardening, CIN compliance
+
+**Stage**: 02 Design  
+**Date**: 2026-06-05  
+**Issue**: https://github.com/casazen/backend/issues/152  
+**Input spec**: `Sessions/specs/spec-property-detail.md`  
+**Branch target (Stage 03)**: `feature/152-property-detail` (backend + frontend)  
+**Status**: COMPLETE — all gates passed
+
+---
+
+## Scope
+
+Fullstack feature delivering a single aggregate property detail view for short-stay owners, property managers, and platform admins. The page surfaces anagrafica, CIN compliance, amenities, tariffs, documents, OTA sync status, bookings KPIs, and an entry point to AI pricing — all from `GET /api/properties/{id}/detail`.
+
+### Codebase state at design time
+
+| Area | State | Gap for #152 |
+|---|---|---|
+| `GET /api/properties/{id}/detail` | **Partial** — endpoint exists | Missing `amenities`, `timezone`, `photoUrls`, `PricingAdapterSummary`; `GetPropertyDetailAsync` does not `.Include(PricingAdapterConfig)` |
+| Document CRUD endpoints | **Implemented** | Upload reuses `IImageStorageService` (image-only validation); needs document MIME/extension gate (PDF, DOC, DOCX, JPG, PNG) |
+| `PropertyDocument` entity + table | **Implemented** (in PostgreSQL `InitialCreate`) | No schema change required on greenfield; verify on `casazen_test` before deploy |
+| `PropertyAuthorizationService` | **Implemented** | `PropertyManager` + `Admin` bypass present; role claim source bug: controllers read `ClaimTypes.Role` but Auth0 emits `https://casazen.app/roles` |
+| `PropertyManagerOrAdmin` policy | **Missing** | Add to `ServiceCollectionExtensions.cs` |
+| `PUT /api/properties/{id}` RBAC | **Partial** — uses `authorizationService.CanAccess` | Works once role-claim fix applied |
+| Admin cross-owner audit log | **Missing** | New `IAdminAccessAuditService` + structured log/DB row on privileged access |
+| `property-detail-page.tsx` | **Stub** — uses `useProperty` → `GET /{id}` | Full refactor to aggregate DTO + section components |
+| Frontend routes | **Implemented** — context manifest | `/app/short-rent/properties/:id` + legacy `/properties/:id` redirect |
+
+### In scope
+
+- Extend aggregate detail DTO and service layer
+- Harden document upload validation
+- Add `PropertyManagerOrAdmin` authorization policy
+- Fix JWT role claim resolution in property controllers
+- Admin/property-manager cross-owner audit logging
+- Frontend detail page refactor with 7 section components
+- TanStack Query hooks for detail + document mutations
+
+### Out of scope
+
+- OTA adapter implementation (read-only summary in detail)
+- AI pricing engine logic changes (summary card links to existing `/pricing` routes)
+- Layer separation (#182) — detail page stays in short-rent context
+- Guest PII in detail response (aggregates only)
+
+---
+
+## Council Specialist Outputs
+
+### api-designer
+
+**Verdict**: Five endpoints — one extended aggregate GET, three document endpoints (already scaffolded), one RBAC-extended PUT. `PropertyDocuments` table exists in consolidated `InitialCreate`; Stage 03 runs `dotnet ef database update` on `casazen_test` — new migration only if schema drift detected.
+
+**Key contract decisions**:
+
+| Decision | Resolution |
+|---|---|
+| `downloadUrl` vs `storageUrl` | Response field **`downloadUrl`** (maps from entity `StorageUrl`; relative path served by static files middleware) |
+| `fileType` vs `documentType` | Response field **`fileType`** — string MIME or extension derived from `DocumentType` enum + filename |
+| OTA DTO shape | **`platform`, `syncStatus`, `lastSyncAt`** per AC1; retain `id`, `isActive` for UI; never `apiKey`/`apiSecret` |
+| `PricingAdapterSummary` | New nested DTO; defaults `{ isEnabled: false }` when no config row |
+
+### frontend-designer
+
+**Verdict**: Refactor `property-detail-page.tsx` to consume `usePropertyDetail(id)`. Route unchanged in manifest (`/app/short-rent/properties/:id`, legacy `/properties/:id`). Seven new presentational components under `src/features/properties/components/`. Upload via shadcn `Dialog` + drag-and-drop zone.
+
+**CIN badge**: Clickable `PropertyCinBadge` with `Tooltip` explaining D.L. 145/2023 obligation (Italian end-user text).
+
+**Pricing link**: `→ Gestisci prezzi AI` navigates to `/app/short-rent/properties/:id/pricing` (legacy `/properties/:id/pricing`).
+
+### security-by-design
+
+**Verdict**: All endpoints authenticated. Owner-scoped IDOR via `IPropertyAuthorizationService`; privileged roles bypass with audit trail. OTA `apiKey`/`apiSecret` excluded at DTO mapping layer (AC7 regression test exists). `BookingsSummary` exposes counts/dates only — no guest names or contact data.
+
+**Threat priority**: IDOR on `{id}` path params, OTA secret leakage in JSON serialization, PII in booking aggregates, missing audit on admin cross-owner reads.
+
+---
+
+## API Contract
+
+### Summary
+
+| Change type | Count |
+|---|---|
+| New endpoints | 0 (scaffolded — extend contracts) |
+| Modified endpoints | 2 (`GET /detail` response schema, `PUT /{id}` RBAC documentation) |
+| Document endpoints | 3 (validate + align response fields) |
+| New auth policy | 1 (`PropertyManagerOrAdmin`) |
+
+### Controller-level authentication
+
+`PropertiesController` carries:
+
+```csharp
+[Authorize(Policy = "PropertyOwner")]
+[Authorize(Policy = "RequireContext:short-rent:property.read")]
+```
+
+Per-action write gate: `[Authorize(Policy = "RequireContext:short-rent:property.write")]`.
+
+**Stage 03 fix (required)**: `GetUserRoles()` must read `https://casazen.app/roles` claims (same as `ContextAuthorizationService`), not `ClaimTypes.Role` alone.
+
+### New authorization policy
+
+**File**: `Casazen.Web/Extensions/ServiceCollectionExtensions.cs`
+
+```csharp
+.AddPolicy("PropertyManagerOrAdmin", policy =>
+    policy.RequireRole("PropertyManager", "Admin"))
+```
+
+Used for documentation and optional action-level attributes; runtime property access continues through `IPropertyAuthorizationService.CanAccess` which already treats `PropertyManager` and `Admin` as privileged.
+
+---
+
+### GET /api/properties/{id}/detail
+
+| | |
+|---|---|
+| **Method / Path** | `GET /api/properties/{id}/detail` |
+| **Auth** | `[Authorize(Policy = "PropertyOwner")]` + `[Authorize(Policy = "RequireContext:short-rent:property.read")]` + `authorizationService.CanAccess(userId, ownerId, roles)` |
+| **Path params** | `id: Guid` |
+| **Query params** | none |
+| **Response 200** | `PropertyDetailResponse` (see schema below) |
+| **Errors** | 401 (no JWT), 403 (not owner/manager/admin), 404 (property not found or inactive) |
+
+**Response schema** (`PropertyDetailResponse`):
+
+```typescript
+interface PropertyDetailResponse {
+  // Property core fields
+  id: string;
+  ownerId: string;
+  name: string;
+  description: string;
+  address: string;
+  city: string;
+  postalCode: string;
+  bedrooms: number;
+  bathrooms: number;
+  maxGuests: number;
+  nightlyRate: number;
+  cleaningFee: number;
+  damageDeposit: number;
+  cinCode: string | null;
+  cinStatus: 'Valid' | 'Missing' | 'Invalid';  // computed: ^IT-\d{5}-\d{10}$
+  timezone: string;                               // IANA, default Europe/Rome
+  amenities: string[];                            // PropertyAmenity enum names
+  photoUrls: string[];
+  houseRules: string;
+  isActive: boolean;
+  createdAt: string;                              // ISO 8601 UTC
+  updatedAt: string;
+
+  // Nested aggregates
+  documents: PropertyDocumentDto[];
+  otaIntegrations: OtaIntegrationSummaryDto[];
+  bookingsSummary: BookingsSummaryDto;
+  pricingAdapterSummary: PricingAdapterSummaryDto;
+}
+
+interface PropertyDocumentDto {
+  id: string;
+  fileName: string;
+  fileType: string;        // MIME or extension label (e.g. "application/pdf")
+  uploadedAt: string;
+  downloadUrl: string;     // maps from StorageUrl — NEVER expose raw filesystem path
+}
+
+interface OtaIntegrationSummaryDto {
+  id: string;
+  platform: string;
+  syncStatus: 'Pending' | 'InProgress' | 'Success' | 'Failed' | null;
+  lastSyncAt: string;
+  isActive: boolean;
+  syncEnabled: boolean;
+  // EXCLUDED: apiKey, apiSecret, externalPropertyId in minimal AC1 view;
+  // retain id/isActive/syncEnabled for UI cards — no secrets
+}
+
+interface BookingsSummaryDto {
+  totalBookings: number;
+  upcomingBookings: number;
+  activeBookings: number;
+  nextCheckIn: string | null;
+  nextCheckOut: string | null;
+}
+
+interface PricingAdapterSummaryDto {
+  isEnabled: boolean;
+  lastAdaptedAt: string | null;
+  nextScheduledRunAt: string | null;
+}
+```
+
+**CIN status computation** (server-side, `PropertyService.ResolveCinStatus`):
+
+| Condition | `cinStatus` |
+|---|---|
+| `cinCode` null/empty | `Missing` |
+| Matches `^IT-\d{5}-\d{10}$` | `Valid` |
+| Otherwise | `Invalid` |
+
+**AC7 regression**: Serialized JSON body must not contain `apiKey` or `apiSecret` (case-insensitive). Enforced by `OtaIntegrationSummaryDto` shape + unit test `GetPropertyDetailAsync_OtaIntegrations_DoNotExposeApiKey`.
+
+**Privileged access audit**: When caller has `Admin` or `PropertyManager` role AND `userId != ownerId`, call `IAdminAccessAuditService.LogAsync(userId, propertyId, "PropertyDetail.Read", ownerId)` before returning 200.
+
+**Frontend usage**: `propertiesApi.getDetail(id)` → `usePropertyDetail(id)`
+
+---
+
+### GET /api/properties/{id}/documents
+
+| | |
+|---|---|
+| **Method / Path** | `GET /api/properties/{id}/documents` |
+| **Auth** | `[Authorize(Policy = "PropertyOwner")]` + `[Authorize(Policy = "RequireContext:short-rent:property.read")]` + `CanAccess` |
+| **Path params** | `id: Guid` |
+| **Response 200** | `PropertyDocumentDto[]` (same shape as detail nested documents) |
+| **Errors** | 401, 403, 404 |
+
+**Frontend usage**: `propertiesApi.getDocuments(id)` — used for document section refresh after upload/delete; detail page primarily uses embedded `documents` from `/detail`.
+
+---
+
+### POST /api/properties/{id}/documents
+
+| | |
+|---|---|
+| **Method / Path** | `POST /api/properties/{id}/documents` |
+| **Auth** | `[Authorize(Policy = "PropertyOwner")]` + `[Authorize(Policy = "RequireContext:short-rent:property.write")]` + `CanAccess` (owner, PropertyManager, Admin) |
+| **Content-Type** | `multipart/form-data` |
+| **Form fields** | `file: IFormFile` (required), `documentType: string` (required — enum name) |
+| **Accepted formats** | PDF (`.pdf`), DOC (`.doc`), DOCX (`.docx`), JPG/JPEG (`.jpg`, `.jpeg`), PNG (`.png`) |
+| **Max size** | 10 MB |
+| **Response 201** | `PropertyDocumentDto` |
+| **Errors** | 400 (invalid type/size/MIME), 401, 403, 404, 500 (storage failure) |
+
+**`documentType` enum values**: `CinCertificate`, `FloorPlan`, `InsurancePolicy`, `PropertyLicense`, `SafetyCompliance`, `Ape`, `Other`
+
+**Stage 03**: Add `IDocumentStorageService` (or extend `IImageStorageService` with `ValidateDocument`) — do not accept WebP-only image validation for compliance documents.
+
+**Frontend usage**: `propertiesApi.uploadDocument(id, formData)` → `useUploadPropertyDocument()`
+
+---
+
+### DELETE /api/properties/{id}/documents/{docId}
+
+| | |
+|---|---|
+| **Method / Path** | `DELETE /api/properties/{id}/documents/{docId}` |
+| **Auth** | `[Authorize(Policy = "PropertyOwner")]` + `[Authorize(Policy = "RequireContext:short-rent:property.write")]` + `CanAccess` |
+| **Path params** | `id: Guid`, `docId: Guid` |
+| **Response 204** | No content |
+| **Errors** | 401, 403, 404 (property or document not found / wrong property) |
+
+**Privileged access audit**: Log `PropertyDocument.Delete` on cross-owner privileged delete.
+
+**Frontend usage**: `propertiesApi.deleteDocument(id, docId)` → `useDeletePropertyDocument()`
+
+---
+
+### PUT /api/properties/{id}
+
+| | |
+|---|---|
+| **Method / Path** | `PUT /api/properties/{id}` |
+| **Auth** | `[Authorize(Policy = "PropertyOwner")]` + `[Authorize(Policy = "RequireContext:short-rent:property.write")]` + `CanAccess` |
+| **Request body** | `UpdatePropertyRequest` (existing — no schema change) |
+| **RBAC extension (AC5)** | `PropertyManager` and `Admin` may update without `OwnerId` match via `IPropertyAuthorizationService.CanAccess` |
+| **Response 204** | No content |
+| **Errors** | 401, 403, 404 |
+
+**Privileged access audit**: Log `Property.Update` on cross-owner privileged update.
+
+**Frontend usage**: unchanged — `useUpdateProperty()` on edit page
+
+---
+
+### Public endpoints (unchanged — reference)
+
+| Method / Path | Auth | Notes |
+|---|---|---|
+| `GET /api/properties/health` | `[AllowAnonymous]` | Liveness only |
+| `GET /api/properties/search` | `[AllowAnonymous]` | Public search — not used by detail page |
+
+---
+
+## Frontend Flow
+
+### Architecture diagram
+
+```mermaid
+flowchart TD
+    Auth[ProtectedRoute on /app/*] --> Ctx[ContextRouteGuard short-rent property.read]
+    Ctx --> Detail[PropertyDetailPage]
+    Detail --> Hook[usePropertyDetail id]
+    Hook --> API[GET /api/properties/id/detail]
+
+    Detail --> Header[PropertyHeader carousel + CIN badge]
+    Detail --> Info[PropertyInfoCard]
+    Detail --> Amenities[AmenitiesGrid]
+    Detail --> Docs[PropertyDocumentsSection]
+    Detail --> OTA[PropertyOtaSummary]
+    Detail --> KPI[PropertyBookingsKpi]
+    Detail --> Pricing[PropertyPricingSummaryCard]
+
+    Docs --> UploadDlg[DocumentUploadDialog drag-drop]
+    UploadDlg --> PostDoc[POST /documents]
+    Docs --> DelDoc[DELETE /documents/docId]
+
+    Pricing --> NavPricing[Navigate to /properties/id/pricing]
+```
+
+### Route map
+
+Routes defined in `src/config/route-manifest.ts`. All property routes inherit app-level `<ProtectedRoute>` from `src/routes/index.tsx` and `ContextRouteGuard` with `property.read` / `property.write`.
+
+| Path (canonical) | Legacy redirect | Guard | Component |
+|---|---|---|---|
+| `/app/short-rent/properties` | `/properties` | `ProtectedRoute` + `property.read` | `PropertiesPage` |
+| `/app/short-rent/properties/create` | `/properties/create` | `ProtectedRoute` + `property.write` | `PropertyCreatePage` |
+| `/app/short-rent/properties/:id` | `/properties/:id` | `ProtectedRoute` + `property.read` | **`PropertyDetailPage`** (refactor) |
+| `/app/short-rent/properties/:id/edit` | `/properties/:id/edit` | `ProtectedRoute` + `property.write` | `PropertyEditPage` |
+| `/app/short-rent/properties/:id/pricing` | `/properties/:id/pricing` | `ProtectedRoute` + `property.read` | `PricingDashboardPage` |
+| `/app/short-rent/properties/:id/pricing/history` | `/properties/:id/pricing/history` | `ProtectedRoute` + `property.read` | `PricingHistoryPage` |
+
+**AC11**: Every `/properties/*` legacy path redirects into guarded `/app/short-rent/properties/*` — `<ProtectedRoute>` is never removed.
+
+### ProtectedRoute matrix
+
+| Path pattern | ProtectedRoute | Additional guard | Redirect on deny |
+|---|---|---|---|
+| `/login` | None (public) | — | — |
+| `/search` | None (public) | — | — |
+| `/app/*` | Auth only (layout) | `WorkspaceProvider` | `/login` |
+| `/app/short-rent/properties` | Inherited | `ContextRouteGuard` + `property.read` | context default |
+| `/app/short-rent/properties/:id` | Inherited | `ContextRouteGuard` + `property.read` | context default |
+| `/app/short-rent/properties/:id/edit` | Inherited | `ContextRouteGuard` + `property.write` | context default |
+| `/app/short-rent/properties/:id/pricing` | Inherited | `ContextRouteGuard` + `property.read` | context default |
+| `/app/short-rent/properties/:id/pricing/history` | Inherited | `ContextRouteGuard` + `property.read` | context default |
+| `/properties/*` (legacy) | Inherited via redirect | Same as canonical target | — |
+
+### User journey (AC8–AC12)
+
+1. Owner navigates to `/properties/{id}` (or `/app/short-rent/properties/{id}`)
+2. `ProtectedRoute` validates JWT; `ContextRouteGuard` checks `property.read` permission
+3. `usePropertyDetail(id)` fetches aggregate DTO
+4. Page renders sections:
+   - **Header**: photo carousel (`photoUrls`), name, city, `PropertyCinBadge` (green/yellow/red by `cinStatus`)
+   - **Info card**: bedrooms, bathrooms, maxGuests, nightlyRate, cleaningFee, damageDeposit, timezone
+   - **Amenities grid**: icon + Italian label per amenity (empty state hidden)
+   - **Documents**: file list with download link (`downloadUrl`) + "Carica documento" button
+   - **OTA Integrations**: platform card with sync status icon + `lastSyncAt` — no apiKey field (AC12)
+   - **Bookings KPI**: 4 cards — totale, upcoming, active, prossimo check-in
+   - **AI Pricing card**: ON/OFF badge, `lastAdaptedAt`, `nextScheduledRunAt`, link "→ Gestisci prezzi AI"
+5. CIN badge click (AC9) → tooltip with D.L. 145/2023 explanation (Italian)
+6. Upload (AC10) → modal dialog, drag-and-drop or file picker, `documentType` select, POST multipart
+7. On upload/delete success → invalidate `['properties', id, 'detail']` query
+
+### Component plan
+
+| Component | Status | Location | Responsibility |
+|---|---|---|---|
+| `PropertyDetailPage` | **refactor** | `src/features/properties/property-detail-page.tsx` | Orchestrates sections; uses `usePropertyDetail` |
+| `PropertyCinBadge` | **new** | `src/features/properties/components/property-cin-badge.tsx` | Color-coded badge + regulatory tooltip (AC9) |
+| `PropertyDocumentsSection` | **new** | `src/features/properties/components/property-documents-section.tsx` | List, download links, upload trigger |
+| `DocumentUploadDialog` | **new** | `src/features/properties/components/document-upload-dialog.tsx` | Modal drag-drop + file picker (AC10) |
+| `PropertyOtaSummary` | **new** | `src/features/properties/components/property-ota-summary.tsx` | Platform cards, sync status — no apiKey (AC12) |
+| `PropertyBookingsKpi` | **new** | `src/features/properties/components/property-bookings-kpi.tsx` | 4 KPI cards from `bookingsSummary` |
+| `PropertyPricingSummaryCard` | **new** | `src/features/properties/components/property-pricing-summary-card.tsx` | AI pricing summary + nav link |
+| `PropertyPhotoCarousel` | **new** | `src/features/properties/components/property-photo-carousel.tsx` | Header image carousel |
+| `PropertyInfoCard` | **new** | `src/features/properties/components/property-info-card.tsx` | Capacity + tariff sidebar card |
+| `PropertyAmenitiesGrid` | **new** | `src/features/properties/components/property-amenities-grid.tsx` | Amenity icons + labels |
+
+### State / API hooks
+
+**File**: `src/queries/use-properties.ts`
+
+```typescript
+// New query
+export function usePropertyDetail(id: string) {
+  return useQuery({
+    queryKey: [PROPERTIES_KEY, id, 'detail'],
+    queryFn: () => propertiesApi.getDetail(id),
+    enabled: !!id,
+  });
+}
+
+// New mutations
+export function useUploadPropertyDocument() { /* POST multipart; invalidate detail */ }
+export function useDeletePropertyDocument() { /* DELETE; invalidate detail */ }
+```
+
+**File**: `src/api/properties.api.ts` — add `getDetail`, `uploadDocument`, `deleteDocument`
+
+**File**: `src/types/property.types.ts` — add `PropertyDetailDto`, `PropertyDocumentDto`, `OtaIntegrationSummaryDto`, `PricingAdapterSummaryDto`, `BookingsSummaryDto`, `CinStatus`
+
+### CIN badge UX (AC9)
+
+| `cinStatus` | Badge color | Italian label | Tooltip (on click) |
+|---|---|---|---|
+| `Valid` | green (`success`) | CIN valido | Spiega obbligo D.L. 145/2023 — codice conforme al formato IT-XXXXX-XXXXXXXXXX |
+| `Missing` | yellow (`warning`) | CIN mancante | Obbligo di registrazione BDSR; sanzioni per mancata comunicazione |
+| `Invalid` | red (`destructive`) | CIN non valido | Formato richiesto: IT-XXXXX-XXXXXXXXXX (5 cifre struttura + 10 cifre unità) |
+
+### Loading / error states
+
+| State | UI |
+|---|---|
+| Loading | `<LoadingScreen message="Caricamento proprietà..." />` |
+| 404 / null | Centered "Proprietà non trovata" inside `AppShell` |
+| 403 | Toast "Accesso negato" + redirect to `/app/short-rent/properties` |
+| Upload error | Toast with server `error` message; dialog stays open |
+
+---
+
+## Security Notes
+
+### Auth gates
+
+| Surface | Requirement |
+|---|---|
+| All `/api/properties/{id}/*` | JWT Bearer + `RequireContext:short-rent:property.read/write` |
+| Owner IDOR | `IPropertyAuthorizationService.CanAccess` on every `{id}` operation |
+| PropertyManager / Admin bypass | Privileged roles in `CanAccess`; cross-owner actions audited |
+| `PropertyManagerOrAdmin` policy | Registered for reuse; documents write requires `CanAccess` not policy alone |
+| Frontend `/properties/*` | `<ProtectedRoute>` at `/app` layout + `ContextRouteGuard` |
+| OTA secrets | Excluded from `OtaIntegrationSummaryDto`; never rendered in UI (AC12) |
+| Document download URLs | Relative `downloadUrl` only; no storage root path leakage |
+
+### IDOR threat model
+
+| Endpoint | Attack | Mitigation |
+|---|---|---|
+| `GET /detail` | User A requests User B's `{id}` | `CanAccess(userId, ownerId, roles)` → 403 |
+| `POST /documents` | Upload to another owner's property | Property existence check + `CanAccess` → 403 |
+| `DELETE /documents/{docId}` | Delete doc from another property | Verify `document.PropertyId == id` + `CanAccess` → 404/403 |
+| `PUT /{id}` | Modify another owner's property | `CanAccess` with manager/admin bypass + audit |
+
+### OTA key handling
+
+| Layer | Rule |
+|---|---|
+| Entity | `OtaIntegration.ApiKey`, `ApiSecret` stored encrypted/at rest in DB |
+| DTO mapping | `PropertyService.GetPropertyDetailAsync` maps to `OtaIntegrationSummaryDto` — no key fields |
+| Serialization | AC7 integration test: case-insensitive body must not contain `apikey` |
+| Frontend | `PropertyOtaSummary` types omit `apiKey`; TypeScript compile-time guard |
+
+### PII and logging
+
+| Data | Rule |
+|---|---|
+| `BookingsSummary` | Counts and dates only — no guest name, email, document number |
+| Document `uploadedBy` | Auth0 `sub` — acceptable operator ID, not guest PII |
+| Error responses | No stack traces with connection strings in production |
+| Structured logs | Do not log file contents, OTA keys, or guest fields in detail flow |
+
+### Threat summary (STRIDE)
+
+| Threat | Surface | Mitigation |
+|---|---|---|
+| Spoofing | Document upload | JWT required; `uploadedBy` from token `sub` |
+| Tampering | Cross-owner property edit | `CanAccess` + audit on privileged write |
+| Repudiation | Admin reads owner data | `IAdminAccessAuditService` log entry |
+| Information disclosure | OTA apiKey in JSON | DTO whitelist + regression test |
+| Information disclosure | IDOR on detail | Owner-scoped authorization |
+| Elevation of privilege | PropertyOwner → admin | JWT role from Auth0; no client-side role injection |
+| Denial of service | 10 MB upload bomb | Size validation server-side |
+
+### Admin access audit (new — Stage 03)
+
+**Interface**: `IAdminAccessAuditService`
+
+```csharp
+Task LogPrivilegedPropertyAccessAsync(
+    string actorUserId,
+    Guid propertyId,
+    string ownerId,
+    string action,          // e.g. "PropertyDetail.Read"
+    CancellationToken ct = default);
+```
+
+**Implementation**: Structured `ILogger` entry at `Warning` level with fixed schema `{ Event: "PrivilegedPropertyAccess", ActorUserId, PropertyId, OwnerId, Action, Timestamp }`. Optional follow-up: persist to `AdminAccessAuditLogs` table (out of scope unless PO requests persistence in #152).
+
+**Trigger points**: `GetDetail`, `GetDocuments`, `UploadDocument`, `DeleteDocument`, `Update` when `CanAccess` returns true via privileged role (not owner match).
+
+---
+
+## Migration Plan
+
+### Database — PropertyDocuments
+
+The `PropertyDocuments` table is **already present** in PostgreSQL `InitialCreate` (`20260603080357_InitialCreate.cs`):
+
+| Column | Type | Notes |
+|---|---|---|
+| `Id` | `uuid` PK | |
+| `PropertyId` | `uuid` FK → `Properties` | CASCADE delete |
+| `FileName` | `varchar(500)` | |
+| `StorageUrl` | `varchar(2000)` | Served as `downloadUrl` in API |
+| `DocumentType` | `varchar` (enum string) | |
+| `UploadedBy` | `varchar(255)` | Auth0 `sub` |
+| `UploadedAt` | `timestamp` | UTC |
+
+**Index**: `IX_PropertyDocuments_PropertyId`
+
+### Stage 03 migration steps
+
+| Step | Action | Rollback |
+|---|---|---|
+| 1 | Run `dotnet ef database update` on `casazen_test` | N/A |
+| 2 | Verify `PropertyDocuments` table + index exist | — |
+| 3 | Extend `PropertyDetailResponse` + `PropertyService.GetPropertyDetailAsync` (include `PricingAdapterConfig`, amenities, timezone, photos) | Revert service/DTO |
+| 4 | Add `PricingAdapterSummaryDto` mapping | Revert DTO |
+| 5 | Add `PropertyManagerOrAdmin` policy | Remove policy line |
+| 6 | Fix `GetUserRoles()` claim source in property controllers | Revert claim read |
+| 7 | Add document MIME validation service | Revert validation |
+| 8 | Add `IAdminAccessAuditService` + wire in controller | Remove service registration |
+| 9 | Frontend refactor + hooks | Revert FE files |
+| 10 | Unit + integration tests (AC7, RBAC, CIN status) | — |
+
+**New EF migration**: Only required if Stage 03 introduces schema drift (e.g., audit log table). For #152 core scope: **no new migration** — table exists in `InitialCreate`.
+
+### Repository change
+
+`PropertyRepository.GetPropertyDetailAsync` — add `.Include(p => p.PricingAdapterConfig)`:
+
+```csharp
+return await context.Properties
+    .Include(p => p.PropertyDocuments)
+    .Include(p => p.OtaIntegrations)
+    .Include(p => p.Bookings)
+    .Include(p => p.PricingAdapterConfig)
+    .FirstOrDefaultAsync(p => p.Id == id && p.IsActive);
+```
+
+### Deploy dependency
+
+Migration (or `database update`) must be applied to `casazen_test` before Stage 05 test deploy. Blocks Compliance Epic CIN display and OTA Integration Epic.
+
+---
+
+## GDPR Scope
+
+### Guest entity
+
+**No guest PII in property detail.** `BookingsSummary` returns aggregate counts and next check-in/out dates only — no `GuestId`, name, email, `DocumentNumber`, or nationality.
+
+| Field | Exposed in detail? | Legal basis |
+|---|---|---|
+| `totalBookings` | Yes (count) | Legitimate interest — owner property management |
+| `upcomingBookings` | Yes (count) | Same |
+| `activeBookings` | Yes (count) | Same |
+| `nextCheckIn` / `nextCheckOut` | Yes (dates only) | Same — no guest identity |
+| Guest name/email/document | **No** | N/A |
+
+### Property documents
+
+Documents may contain owner-uploaded compliance files (CIN certificate, APE). Access restricted by `CanAccess`. Download URLs are authenticated-context only (same JWT session). No document content in logs.
+
+### Admin / PropertyManager cross-owner access (Art. 32)
+
+When platform admin or property manager accesses another owner's property data:
+
+| Requirement | Implementation |
+|---|---|
+| Accountability | `IAdminAccessAuditService` logs actor, property, owner, action, timestamp |
+| Data minimization | Detail DTO excludes guest PII |
+| Legal basis | Accepted as operational risk by PO (2026-05-12) — Art. 28 DPA for PropertyManager deferred |
+
+### Data not stored client-side
+
+- No property detail payload in `localStorage`
+- No OTA keys in React state beyond API response (which omits them)
+- Upload dialog clears selected file on close
+
+### Regulatory modules
+
+| Regulation | #152 touchpoint |
+|---|---|
+| CIN (D.L. 145/2023) | `cinStatus` indicator + tooltip; format validation server-side |
+| GDPR Art. 17 | N/A — no guest erasure flow in this feature |
+| OTA Reg. EU 2024/1028 | Read-only sync status display; no new OTA write surface |
+
+---
+
+## Acceptance Criteria Traceability
+
+| AC | Design element |
+|---|---|
+| AC1 | `PropertyDetailResponse` full schema with all nested DTOs including `PricingAdapterSummary` |
+| AC2 | `GET /documents` contract |
+| AC3 | `POST /documents` multipart + role gating + format/size limits |
+| AC4 | `DELETE /documents/{docId}` → 204 |
+| AC5 | `PUT /{id}` + `CanAccess` with PropertyManager/Admin bypass |
+| AC6 | `PropertyManagerOrAdmin` policy in `ServiceCollectionExtensions.cs` |
+| AC7 | OTA DTO excludes keys + regression test reference |
+| AC8 | Section component breakdown + `usePropertyDetail` |
+| AC9 | `PropertyCinBadge` + tooltip |
+| AC10 | `DocumentUploadDialog` drag-drop |
+| AC11 | ProtectedRoute matrix — all `/properties/*` guarded |
+| AC12 | `PropertyOtaSummary` — no apiKey in types or render |
+
+---
+
+## Open Questions
+
+All resolved for Stage 02.
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | `downloadUrl` vs `storageUrl` in API? | **`downloadUrl`** in response — maps from `StorageUrl` |
+| 2 | Separate `AddPropertyDocuments` migration? | **Not needed** — table in PostgreSQL `InitialCreate`; verify on deploy |
+| 3 | Audit log persistence: DB table or structured log? | **Structured log** (`ILogger` Warning) for #152; DB table deferred |
+| 4 | JWT role claim source in controllers? | **Fix to `https://casazen.app/roles`** in Stage 03 |
+| 5 | Frontend route prefix after #182 context work? | **Use `/app/short-rent/properties/:id`** with legacy `/properties/:id` redirect |
+| 6 | PropertyManager GDPR Art. 28 DPA? | **Accepted as risk by PO** (2026-05-12) — documented, not blocking |
+
+---
+
+## Harness Gate Status
+
+| Gate | Status | Owner | Notes |
+|---|---|---|---|
+| G1: Spec file exists | ✅ | coordinator | `Sessions/design-152.md` |
+| G2: API contract complete | ✅ | api-designer | All 5 endpoints: method, path, auth, request/response, errors |
+| G3: Auth decisions | ✅ | security-by-design | Every endpoint has `[Authorize]` or `[AllowAnonymous]` justification |
+| G4: Frontend flow defined | ✅ | frontend-designer | Route map, journey, component plan, hooks |
+| G5: ProtectedRoute specified | ✅ | frontend-designer | Matrix for all `/properties/*` and canonical paths |
+| G6: Security notes | ✅ | security-by-design | OTA keys, PII, IDOR, audit, STRIDE |
+| G7: Migration plan | ✅ | api-designer | PropertyDocuments schema + deploy steps |
+| G8: GDPR scope | ✅ | security-by-design | BookingsSummary aggregates only; admin audit |
+
+**Handoff → Stage 03**: Issue `#152`, spec `Sessions/design-152.md`, branch `feature/152-property-detail` (backend + frontend).


### PR DESCRIPTION
## Summary
- Extend `GET /api/properties/{id}/detail` with `amenities`, `timezone`, `photoUrls`, `PricingAdapterSummary`, and hardened document validation (PDF/DOC/DOCX/JPG/PNG, 10 MB max)
- Add `PropertyManagerOrAdmin` policy, fix JWT role claim source (`https://casazen.app/roles`), and admin cross-owner audit logging via `IAdminAccessAuditService`
- AC7 regression: OTA `apiKey`/`apiSecret` excluded from detail response (unit test enforced)

## Frontend PR
https://github.com/casazen/frontend/pull/96

## Test Plan
- [ ] `dotnet test` — all 386+ unit tests pass
- [ ] `GET /api/properties/{id}/detail` returns full aggregate DTO for owner
- [ ] PropertyManager/Admin can access cross-owner properties with audit log entry
- [ ] Document upload rejects invalid MIME types; accepts PDF/DOC/DOCX/JPG/PNG
- [ ] Serialized detail JSON contains no `apiKey` (case-insensitive)

## Acceptance criteria coverage

| AC | Test file |
|---|---|
| AC1 | `PropertyServiceGetDetailTests.cs` |
| AC2-AC4 | `PropertyDocumentServiceTests.cs`, `PropertiesControllerTests.cs` |
| AC5-AC6 | `PropertiesControllerTests.cs` |
| AC7 | `PropertyServiceGetDetailTests.GetPropertyDetailAsync_OtaIntegrations_DoNotExposeApiKey` |

## Gate status

| Gate | Status |
|---|---|
| G1 dotnet test | pass |
| G2 format | pass |
| G3 build /warnaserror | pass |
| G4 migrations | N/A (no schema change) |
| G10 CIN | pass |
| G11 secrets | pass |
| G12 GDPR | N/A |
| G13 tourist tax | pass |

Closes #152