### PR TITLE
test: pricing adapter verification (integration + CI smoke)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -97,6 +97,25 @@ jobs:
           fi
           echo "✅ Bookings auth gate OK"
 
+      - name: Verify pricing adapter endpoint (auth gate — never 500)
+        env:
+          RAILWAY_TEST_URL: ${{ vars.RAILWAY_TEST_URL }}
+          TEST_PROPERTY_ID: ${{ vars.TEST_PROPERTY_ID }}
+        run: |
+          if [ -z "$RAILWAY_TEST_URL" ]; then exit 0; fi
+          PROPERTY_ID="${TEST_PROPERTY_ID:-00000000-0000-0000-0000-000000000001}"
+          STATUS=$(curl -o /dev/null -sw "%{http_code}" \
+            "${RAILWAY_TEST_URL}/api/pricing-adapter/config/${PROPERTY_ID}")
+          if [ "$STATUS" = "500" ]; then
+            echo "❌ /api/pricing-adapter/config returned 500"
+            exit 1
+          fi
+          if [ "$STATUS" != "401" ] && [ "$STATUS" != "404" ] && [ "$STATUS" != "200" ]; then
+            echo "❌ Unexpected status on pricing-adapter config: $STATUS"
+            exit 1
+          fi
+          echo "✅ Pricing adapter auth gate OK (status $STATUS)"
+
   # Railway deploys production via GitHub integration (push to main → production environment).
   verify-prod:
     name: Verify Railway Production (native deploy)

--- a/Casazen.Tests/Casazen.Tests.csproj
+++ b/Casazen.Tests/Casazen.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />

--- a/Casazen.Tests/Integration/CasazenWebApplicationFactory.cs
+++ b/Casazen.Tests/Integration/CasazenWebApplicationFactory.cs
@@ -1,0 +1,141 @@
+using System.Net.Http.Headers;
+using Casazen.Core.Entities;
+using Casazen.Core.Services;
+using Casazen.Infrastructure.Data;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Casazen.Tests.Integration;
+
+/// <summary>
+/// WebApplicationFactory for integration tests — in-memory EF, test auth, mocked Hangfire.
+/// </summary>
+public class CasazenWebApplicationFactory : WebApplicationFactory<Program>
+{
+    public Mock<IBackgroundJobClient> BackgroundJobClientMock { get; } = new();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", string.Empty);
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:DefaultConnection", string.Empty);
+
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = string.Empty,
+                ["Auth0:Domain"] = "test.auth0.com",
+                ["Auth0:Audience"] = "https://test-api.casazen.app",
+            });
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            RemoveService<IPublicHolidayService>(services);
+            var holidayMock = new Mock<IPublicHolidayService>();
+            holidayMock.Setup(h => h.IsPublicHolidayAsync(It.IsAny<DateTime>())).ReturnsAsync(false);
+            services.AddScoped(_ => holidayMock.Object);
+
+            RemoveService<IBackgroundJobClient>(services);
+            BackgroundJobClientMock
+                .Setup(c => c.Create(It.IsAny<Job>(), It.IsAny<IState>()))
+                .Returns("job-integration-test-001");
+            services.AddSingleton(BackgroundJobClientMock.Object);
+
+            services.PostConfigure<AuthenticationOptions>(options =>
+            {
+                options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
+                options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
+            });
+
+            services.AddAuthentication()
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                    TestAuthHandler.SchemeName,
+                    _ => { });
+        });
+    }
+
+    public HttpClient CreateAuthenticatedClient(string userId = TestAuthHandler.DefaultUserId, string? roles = null)
+    {
+        var client = CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(TestAuthHandler.SchemeName, "test");
+        client.DefaultRequestHeaders.Add("X-Test-User", userId);
+        if (!string.IsNullOrWhiteSpace(roles))
+            client.DefaultRequestHeaders.Add("X-Test-Roles", roles);
+        return client;
+    }
+
+    public async Task<Property> SeedPropertyAsync(string ownerId = TestAuthHandler.DefaultUserId, decimal nightlyRate = 100m)
+    {
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var property = new Property
+        {
+            OwnerId = ownerId,
+            Name = "Pricing Integration Property",
+            Description = "Integration test property",
+            Address = $"Via Test {Guid.NewGuid():N}",
+            City = "Rome",
+            PostalCode = $"00{Random.Shared.Next(100, 999)}",
+            Latitude = 41.9028m,
+            Longitude = 12.4964m,
+            Bedrooms = 2,
+            Bathrooms = 1,
+            MaxGuests = 4,
+            NightlyRate = nightlyRate,
+            CleaningFee = 50m,
+            DamageDeposit = 200m,
+            CinCode = "IT-ABC123-DEF456",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        db.Properties.Add(property);
+        await db.SaveChangesAsync();
+        return property;
+    }
+
+    public async Task SeedPricingHistoryAsync(Guid propertyId, int count = 3)
+    {
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        for (var i = 0; i < count; i++)
+        {
+            db.PricingHistories.Add(new PricingHistory
+            {
+                PropertyId = propertyId,
+                AdaptationDate = DateTime.UtcNow.AddDays(-i),
+                PreviousPrice = 100m,
+                NewPrice = 110m + i,
+                ChangeReason = $"Adaptation {i + 1}",
+                AiConfidence = 0.85m,
+                OtasSynced = "airbnb",
+                SyncStatus = "Synced",
+                CreatedAt = DateTime.UtcNow.AddDays(-i),
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+
+    private static void RemoveService<T>(IServiceCollection services)
+    {
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(T));
+        if (descriptor != null)
+            services.Remove(descriptor);
+    }
+
+}

--- a/Casazen.Tests/Integration/PricingAdapterIntegrationTests.cs
+++ b/Casazen.Tests/Integration/PricingAdapterIntegrationTests.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Xunit;
+
+namespace Casazen.Tests.Integration;
+
+/// <summary>
+/// Integration tests for PricingAdapterController (spec AC1–AC9).
+/// Uses in-memory EF and TestAuthHandler — runs in CI on Linux.
+/// </summary>
+public class PricingAdapterIntegrationTests : IClassFixture<CasazenWebApplicationFactory>
+{
+    private readonly CasazenWebApplicationFactory _factory;
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    public PricingAdapterIntegrationTests(CasazenWebApplicationFactory factory) => _factory = factory;
+
+    private static void AssertNoApiKeyInBody(string body)
+    {
+        Assert.DoesNotContain("apikey", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static object ConfigRequest(bool enabled = true) => new
+    {
+        isEnabled = enabled,
+        adaptationFrequency = "daily",
+        includeSeasonality = true,
+        includePublicHolidays = true,
+    };
+
+    [Fact]
+    public async Task AC1_SaveConfig_Enabled_ReturnsConfigWithIsEnabledTrue()
+    {
+        var property = await _factory.SeedPropertyAsync();
+        var client = _factory.CreateAuthenticatedClient();
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/pricing-adapter/config/{property.Id}",
+            ConfigRequest(enabled: true));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        AssertNoApiKeyInBody(body);
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.True(doc.RootElement.GetProperty("isEnabled").GetBoolean());
+        Assert.Equal("daily", doc.RootElement.GetProperty("adaptationFrequency").GetString());
+    }
+
+    [Fact]
+    public async Task AC2_GetConfig_ReturnsAllConfigFields()
+    {
+        var property = await _factory.SeedPropertyAsync();
+        var client = _factory.CreateAuthenticatedClient();
+
+        await client.PostAsJsonAsync($"/api/pricing-adapter/config/{property.Id}", ConfigRequest());
+
+        var response = await client.GetAsync($"/api/pricing-adapter/config/{property.Id}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        AssertNoApiKeyInBody(body);
+
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("adaptationFrequency", out _));
+        Assert.True(root.TryGetProperty("includeSeasonality", out _));
+        Assert.True(root.TryGetProperty("includePublicHolidays", out _));
+        Assert.True(root.TryGetProperty("nextScheduledRunAt", out var nextRun));
+        Assert.False(nextRun.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined);
+    }
+
+    [Fact]
+    public async Task AC3_DeleteConfig_ThenGet_ReturnsDisabledOrNotFound()
+    {
+        var property = await _factory.SeedPropertyAsync();
+        var client = _factory.CreateAuthenticatedClient();
+
+        await client.PostAsJsonAsync($"/api/pricing-adapter/config/{property.Id}", ConfigRequest());
+
+        var deleteResponse = await client.DeleteAsync($"/api/pricing-adapter/config/{property.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var getResponse = await client.GetAsync($"/api/pricing-adapter/config/{property.Id}");
+        Assert.True(
+            getResponse.StatusCode == HttpStatusCode.NotFound ||
+            (getResponse.StatusCode == HttpStatusCode.OK &&
+             !JsonDocument.Parse(await getResponse.Content.ReadAsStringAsync())
+                 .RootElement.GetProperty("isEnabled").GetBoolean()));
+    }
+
+    [Fact]
+    public async Task AC4_GetPreview_ReturnsExactlyNinetyItems()
+    {
+        var property = await _factory.SeedPropertyAsync();
+        var client = _factory.CreateAuthenticatedClient();
+
+        await client.PostAsJsonAsync($"/api/pricing-adapter/config/{property.Id}", ConfigRequest());
+
+        var response = await client.GetAsync($"/api/pricing-adapter/preview/{property.Id}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        AssertNoApiKeyInBody(body);
+
+        using var doc = JsonDocument.Parse(body);
+        var prices = doc.RootElement.GetProperty("prices");
+        Assert.Equal(90, prices.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task AC5_TriggerSync_ReturnsAcceptedWithJobId()
+    {
+        var property = await _factory.SeedPropertyAsync();
+        var client = _factory.CreateAuthenticatedClient();
+
+        await client.PostAsJsonAsync($"/api/pricing-adapter/config/{property.Id}", ConfigRequest());
+
+        var response = await client.PostAsync($"/api/pricing-adapter/sync/{property.Id}", null);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        AssertNoApiKeyInBody(body);
+
+        using var doc = JsonDocument.Parse(body);
+        var jobId = doc.RootElement.GetProperty("jobId").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(jobId));
+    }
+
+    [Fact]
+    public async Task AC6_GetHistory_ReturnsPaginatedEnvelope()
+    {
+        var property = await _factory.SeedPropertyAsync();
+        await _factory.SeedPricingHistoryAsync(property.Id, count: 5);
+        var client = _factory.CreateAuthenticatedClient();
+
+        await client.PostAsJsonAsync($"/api/pricing-adapter/config/{property.Id}", ConfigRequest());
+
+        var response = await client.GetAsync($"/api/pricing-adapter/history/{property.Id}?page=1&pageSize=2");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        AssertNoApiKeyInBody(body);
+
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("items", out var items));
+        Assert.True(root.TryGetProperty("total", out var total));
+        Assert.True(root.TryGetProperty("page", out var page));
+        Assert.Equal(2, items.GetArrayLength());
+        Assert.True(total.GetInt32() >= 5);
+        Assert.Equal(1, page.GetInt32());
+    }
+
+    [Theory]
+    [InlineData("/api/pricing-adapter/config/{0}", "POST")]
+    [InlineData("/api/pricing-adapter/config/{0}", "GET")]
+    [InlineData("/api/pricing-adapter/config/{0}", "DELETE")]
+    [InlineData("/api/pricing-adapter/preview/{0}", "GET")]
+    [InlineData("/api/pricing-adapter/sync/{0}", "POST")]
+    [InlineData("/api/pricing-adapter/history/{0}", "GET")]
+    public async Task AC7_Endpoints_WithoutJwt_ReturnUnauthorized(string routeTemplate, string method)
+    {
+        var property = await _factory.SeedPropertyAsync();
+        var client = _factory.CreateClient();
+        var route = string.Format(routeTemplate, property.Id);
+
+        var request = new HttpRequestMessage(new HttpMethod(method), route);
+        if (method == "POST" && route.Contains("/config/"))
+            request.Content = JsonContent.Create(ConfigRequest());
+
+        var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AC8_NonOwner_OnAllEndpoints_ReturnsForbidden()
+    {
+        var property = await _factory.SeedPropertyAsync(ownerId: TestAuthHandler.DefaultUserId);
+        var otherClient = _factory.CreateAuthenticatedClient(userId: "auth0|other-user-456");
+        var propertyId = property.Id;
+
+        var save = await otherClient.PostAsJsonAsync($"/api/pricing-adapter/config/{propertyId}", ConfigRequest());
+        Assert.Equal(HttpStatusCode.Forbidden, save.StatusCode);
+
+        // Seed config as owner for remaining endpoints
+        var ownerClient = _factory.CreateAuthenticatedClient();
+        await ownerClient.PostAsJsonAsync($"/api/pricing-adapter/config/{propertyId}", ConfigRequest());
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await otherClient.GetAsync($"/api/pricing-adapter/config/{propertyId}")).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await otherClient.DeleteAsync($"/api/pricing-adapter/config/{propertyId}")).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await otherClient.GetAsync($"/api/pricing-adapter/preview/{propertyId}")).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await otherClient.PostAsync($"/api/pricing-adapter/sync/{propertyId}", null)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await otherClient.GetAsync($"/api/pricing-adapter/history/{propertyId}")).StatusCode);
+    }
+
+    [Fact]
+    public async Task AC9_AllResponses_DoNotContainApiKeyField()
+    {
+        var property = await _factory.SeedPropertyAsync();
+        await _factory.SeedPricingHistoryAsync(property.Id);
+        var client = _factory.CreateAuthenticatedClient();
+
+        await client.PostAsJsonAsync($"/api/pricing-adapter/config/{property.Id}", ConfigRequest());
+
+        var endpoints = new[]
+        {
+            await client.GetAsync($"/api/pricing-adapter/config/{property.Id}"),
+            await client.GetAsync($"/api/pricing-adapter/preview/{property.Id}"),
+            await client.PostAsync($"/api/pricing-adapter/sync/{property.Id}", null),
+            await client.GetAsync($"/api/pricing-adapter/history/{property.Id}"),
+        };
+
+        foreach (var response in endpoints)
+        {
+            response.EnsureSuccessStatusCode();
+            AssertNoApiKeyInBody(await response.Content.ReadAsStringAsync());
+        }
+    }
+}

--- a/Casazen.Tests/Integration/TestAuthHandler.cs
+++ b/Casazen.Tests/Integration/TestAuthHandler.cs
@@ -1,0 +1,40 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Casazen.Tests.Integration;
+
+/// <summary>
+/// Test authentication handler activated when the Authorization header is present.
+/// User id and roles are supplied via X-Test-User and X-Test-Roles headers.
+/// </summary>
+public class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "Test";
+    public const string DefaultUserId = "auth0|pricing-test-owner";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.ContainsKey("Authorization"))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var userId = Request.Headers["X-Test-User"].FirstOrDefault() ?? DefaultUserId;
+        var rolesHeader = Request.Headers["X-Test-Roles"].FirstOrDefault();
+
+        var claims = new List<Claim> { new("sub", userId) };
+        if (!string.IsNullOrWhiteSpace(rolesHeader))
+        {
+            foreach (var role in rolesHeader.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(principal, SchemeName)));
+    }
+}

--- a/Casazen.Tests/Unit/BackgroundJobs/DynamicPricingJobTests.cs
+++ b/Casazen.Tests/Unit/BackgroundJobs/DynamicPricingJobTests.cs
@@ -336,6 +336,58 @@ public class DynamicPricingJobTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_OnePropertyThrows_ContinuesProcessingOthers()
+    {
+        var propertyId1 = Guid.NewGuid();
+        var propertyId2 = Guid.NewGuid();
+        var config1 = new PricingAdapterConfig
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId1,
+            IsEnabled = true,
+            IncludeSeasonality = true,
+            IncludePublicHolidays = false,
+            AdaptationFrequency = "daily",
+        };
+        var config2 = new PricingAdapterConfig
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId2,
+            IsEnabled = true,
+            IncludeSeasonality = false,
+            IncludePublicHolidays = false,
+            AdaptationFrequency = "daily",
+        };
+
+        _configRepositoryMock.Setup(r => r.GetEnabledConfigsAsync())
+            .ReturnsAsync(new[] { config1, config2 });
+
+        _pricingServiceMock.Setup(s => s.CalculatePricingMultiplierAsync(
+                It.IsAny<DateTime>(),
+                true,
+                false))
+            .ThrowsAsync(new InvalidOperationException("Pricing computation failed"));
+
+        _pricingServiceMock.Setup(s => s.CalculatePricingMultiplierAsync(
+                It.IsAny<DateTime>(),
+                false,
+                false))
+            .ReturnsAsync(1.1m);
+
+        _historyRepositoryMock.Setup(r => r.AddAsync(It.IsAny<PricingHistory>()))
+            .ReturnsAsync((PricingHistory h) => h);
+
+        _otaManagerMock.Setup(m => m.SyncAllAsync(propertyId2))
+            .ReturnsAsync(true);
+
+        await _job.ExecuteAsync();
+
+        _configRepositoryMock.Verify(r => r.UpdateAsync(config2), Times.Once);
+        _otaManagerMock.Verify(m => m.SyncAllAsync(propertyId2), Times.Once);
+        _configRepositoryMock.Verify(r => r.UpdateAsync(config1), Times.Never);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_PricingHistorySyncStatusIsPending()
     {
         // Arrange

--- a/Casazen.Tests/Unit/Services/PricingAdapterServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/PricingAdapterServiceTests.cs
@@ -267,5 +267,71 @@ public class PricingAdapterServiceTests
         Assert.Equal("Synced", result.SyncStatus);
     }
 
+    [Fact]
+    public async Task DisableConfigAsync_WithExistingConfig_SetsIsEnabledFalse()
+    {
+        var propertyId = Guid.NewGuid();
+        var config = new PricingAdapterConfig { PropertyId = propertyId, IsEnabled = true };
+        _mockConfigRepository.Setup(x => x.GetByPropertyIdAsync(propertyId)).ReturnsAsync(config);
+
+        await _service.DisableConfigAsync(propertyId);
+
+        Assert.False(config.IsEnabled);
+        _mockConfigRepository.Verify(x => x.UpdateAsync(config), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetHistoryPagedAsync_ReturnsCorrectPageAndTotal()
+    {
+        var propertyId = Guid.NewGuid();
+        var histories = Enumerable.Range(1, 5).Select(i => new PricingHistory
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId,
+            AdaptationDate = DateTime.UtcNow.AddDays(-i),
+            PreviousPrice = 100m,
+            NewPrice = 110m,
+            ChangeReason = $"Change {i}",
+            AiConfidence = 0.8m,
+            SyncStatus = "Synced",
+        }).ToList();
+
+        _mockHistoryRepository
+            .Setup(x => x.GetByPropertyIdAndDateRangeAsync(propertyId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(histories);
+
+        var (items, total) = await _service.GetHistoryPagedAsync(
+            propertyId, DateTime.UtcNow.AddDays(-30), DateTime.UtcNow, page: 2, pageSize: 2);
+
+        Assert.Equal(5, total);
+        Assert.Equal(2, items.Count());
+    }
+
+    [Fact]
+    public async Task PreviewPricesAsync_ReturnsNinetyItemsWithNonNegativePrices()
+    {
+        var propertyId = Guid.NewGuid();
+        var config = new PricingAdapterConfig
+        {
+            PropertyId = propertyId,
+            IsEnabled = true,
+            IncludeSeasonality = true,
+            IncludePublicHolidays = false,
+        };
+
+        _mockPublicHolidayService.Setup(x => x.IsPublicHolidayAsync(It.IsAny<DateTime>())).ReturnsAsync(false);
+
+        var preview = await _service.PreviewPricesAsync(propertyId, basePrice: 100m, config);
+        var items = preview.ToList();
+
+        Assert.Equal(90, items.Count);
+        Assert.All(items, item =>
+        {
+            Assert.True(item.SuggestedPrice >= 0);
+            Assert.True(item.BasePrice >= 0);
+            Assert.False(string.IsNullOrWhiteSpace(item.Reason));
+        });
+    }
+
     #endregion
 }

--- a/Casazen.Web/Controllers/PricingAdapterController.cs
+++ b/Casazen.Web/Controllers/PricingAdapterController.cs
@@ -56,7 +56,7 @@ public class PricingAdapterController(
         }
 
         var existing = await pricingService.GetConfigAsync(propertyId);
-        var config = existing ?? new PricingAdapterConfig { PropertyId = propertyId };
+        var config = existing ?? new PricingAdapterConfig { Id = Guid.Empty, PropertyId = propertyId };
 
         config.IsEnabled = request.IsEnabled;
         config.AdaptationFrequency = request.AdaptationFrequency;

--- a/Casazen.Web/appsettings.Testing.json
+++ b/Casazen.Web/appsettings.Testing.json
@@ -1,0 +1,9 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  },
+  "Auth0": {
+    "Domain": "test.auth0.com",
+    "Audience": "https://test-api.casazen.app"
+  }
+}


### PR DESCRIPTION
## Summary
- Add WebApplicationFactory integration tests for all PricingAdapter endpoints (AC1–AC9): config CRUD, preview, sync, history, auth 401/403, and apiKey regression.
- Extend unit tests for preview (90 days), history pagination, disable config, and DynamicPricingJob per-property error isolation (AC10).
- Fix first-time config save: new `PricingAdapterConfig` rows now use `Id = Guid.Empty` so EF inserts instead of failing with `DbUpdateConcurrencyException`.
- Add `verify-test` CI smoke step for `/api/pricing-adapter/config/{id}` (never 500).

## Test plan
- [x] `dotnet test` — 407 passed
- [x] `dotnet format --verify-no-changes`
- [ ] CI green on PR
- [ ] Railway test smoke passes after merge to develop

Made with [Cursor](https://cursor.com)