### PR TITLE
feat(auth): role-based onboarding API (#198)

### DIFF
--- a/Casazen.Core/Entities/User.cs
+++ b/Casazen.Core/Entities/User.cs
@@ -24,6 +24,8 @@ public class User
     [Required]
     public UserRole Role { get; set; } = UserRole.PropertyOwner;
 
+    public RentalType? RentalType { get; set; }
+
     [MaxLength(64)]
     public string? LastUsedContextKey { get; set; }
 
@@ -43,4 +45,11 @@ public enum UserRole
     Guest,
     Staff,
     LongTermLandlord // 5 — append only, do not insert before existing values
+}
+
+public enum RentalType
+{
+    ShortTerm,
+    LongTerm,
+    Both
 }

--- a/Casazen.Core/Services/IAuth0ManagementService.cs
+++ b/Casazen.Core/Services/IAuth0ManagementService.cs
@@ -5,4 +5,9 @@ namespace Casazen.Core.Services;
 public interface IAuth0ManagementService
 {
     Task AssignRoleAsync(string userId, UserRole role);
+
+    /// <summary>
+    /// Replaces onboarding-related roles (PropertyOwner, LongTermLandlord) while preserving others (e.g. Admin).
+    /// </summary>
+    Task AssignOnboardingRolesAsync(string userId, IReadOnlyList<UserRole> roles);
 }

--- a/Casazen.Core/Services/IUserService.cs
+++ b/Casazen.Core/Services/IUserService.cs
@@ -20,4 +20,10 @@ public interface IUserService
         string? search, string? role, bool? isActive, int page, int pageSize);
 
     Task ChangeRoleAsync(string id, UserRole newRole, string adminSub);
+
+    /// <summary>
+    /// Completes or updates onboarding: persists rental type, syncs Auth0 onboarding roles.
+    /// </summary>
+    Task<(User User, IReadOnlyList<string> RolesAssigned)> CompleteOnboardingAsync(
+        string sub, RentalType rentalType, string email, string firstName, string lastName);
 }

--- a/Casazen.Infrastructure/Migrations/20260605132951_AddUserRentalType.Designer.cs
+++ b/Casazen.Infrastructure/Migrations/20260605132951_AddUserRentalType.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Casazen.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260605132951_AddUserRentalType")]
+    partial class AddUserRentalType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Casazen.Infrastructure/Migrations/20260605132951_AddUserRentalType.cs
+++ b/Casazen.Infrastructure/Migrations/20260605132951_AddUserRentalType.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Casazen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserRentalType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "RentalType",
+                table: "Users",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RentalType",
+                table: "Users");
+        }
+    }
+}

--- a/Casazen.Infrastructure/Services/Auth0ManagementService.cs
+++ b/Casazen.Infrastructure/Services/Auth0ManagementService.cs
@@ -28,6 +28,12 @@ public class Auth0ManagementService(
         { UserRole.LongTermLandlord, "LongTermLandlord" },
     };
 
+    private static readonly UserRole[] OnboardingRoles =
+    [
+        UserRole.PropertyOwner,
+        UserRole.LongTermLandlord
+    ];
+
     /// <summary>
     /// Assigns a role to an Auth0 user via the Management API.
     /// All existing roles are removed; the new one is assigned.
@@ -57,7 +63,6 @@ public class Auth0ManagementService(
         {
             var client = new ManagementApiClient(token, new Uri($"https://{domain}/api/v2"));
 
-            // Fetch existing roles for the user
             var existingRoles = await client.Users.GetRolesAsync(userId);
             if (existingRoles != null && existingRoles.Count > 0)
             {
@@ -67,7 +72,6 @@ public class Auth0ManagementService(
                 });
             }
 
-            // Find the target role ID by name
             var allRoles = await client.Roles.GetAllAsync(new GetRolesRequest { NameFilter = roleName });
             var targetRole = allRoles?.FirstOrDefault(r =>
                 string.Equals(r.Name, roleName, StringComparison.OrdinalIgnoreCase));
@@ -91,9 +95,82 @@ public class Auth0ManagementService(
         }
         catch (Exception ex)
         {
-            // Auth0 role sync is best-effort — log but do not propagate so DB update is committed.
             logger.LogError(ex,
                 "Auth0ManagementService: Failed to sync role {Role} for user {UserId}", role, userId);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task AssignOnboardingRolesAsync(string userId, IReadOnlyList<UserRole> roles)
+    {
+        var token = configuration["Auth0:ManagementApiToken"];
+        var domain = configuration["Auth0:ManagementApiDomain"]
+                     ?? configuration["Auth0:Domain"];
+
+        if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(domain))
+        {
+            logger.LogWarning(
+                "Auth0ManagementService: ManagementApiToken or Domain not configured — " +
+                "skipping role sync for user {UserId}", userId);
+            return;
+        }
+
+        var targetRoleNames = roles
+            .Where(r => RoleNames.ContainsKey(r))
+            .Select(r => RoleNames[r])
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (targetRoleNames.Count == 0)
+        {
+            logger.LogWarning("Auth0ManagementService: No valid Auth0 role mapping for onboarding user {UserId}", userId);
+            return;
+        }
+
+        try
+        {
+            var client = new ManagementApiClient(token, new Uri($"https://{domain}/api/v2"));
+            var existingRoles = await client.Users.GetRolesAsync(userId);
+
+            var onboardingRoleNames = OnboardingRoles
+                .Select(r => RoleNames[r])
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var rolesToRemove = existingRoles
+                .Where(r => onboardingRoleNames.Contains(r.Name ?? string.Empty))
+                .Select(r => r.Id)
+                .ToArray();
+
+            if (rolesToRemove.Length > 0)
+            {
+                await client.Users.RemoveRolesAsync(userId, new AssignRolesRequest { Roles = rolesToRemove });
+            }
+
+            var allRoles = await client.Roles.GetAllAsync(new GetRolesRequest());
+            var roleIdsToAssign = allRoles?
+                .Where(r => targetRoleNames.Contains(r.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+                .Select(r => r.Id)
+                .Distinct()
+                .ToArray() ?? [];
+
+            if (roleIdsToAssign.Length == 0)
+            {
+                logger.LogWarning(
+                    "Auth0ManagementService: Target onboarding roles not found in Auth0 for user {UserId}",
+                    userId);
+                return;
+            }
+
+            await client.Users.AssignRolesAsync(userId, new AssignRolesRequest { Roles = roleIdsToAssign });
+
+            logger.LogInformation(
+                "Auth0ManagementService: Assigned onboarding roles [{Roles}] to user {UserId}",
+                string.Join(", ", targetRoleNames), userId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Auth0ManagementService: Failed to sync onboarding roles for user {UserId}", userId);
         }
     }
 }

--- a/Casazen.Infrastructure/Services/UserService.cs
+++ b/Casazen.Infrastructure/Services/UserService.cs
@@ -133,4 +133,35 @@ public class UserService(
             "Role changed: userId={UserId} newRole={Role} changedBy={AdminId}",
             id, newRole, adminSub);
     }
+
+    /// <inheritdoc />
+    public async Task<(User User, IReadOnlyList<string> RolesAssigned)> CompleteOnboardingAsync(
+        string sub, RentalType rentalType, string email, string firstName, string lastName)
+    {
+        var roles = MapRentalTypeToRoles(rentalType);
+        var user = await GetCurrentUserAsync(sub, email, firstName, lastName);
+
+        user.RentalType = rentalType;
+        user.Role = roles[0];
+        user.UpdatedAt = DateTime.UtcNow;
+        await repository.UpdateAsync(user);
+
+        await auth0Management.AssignOnboardingRolesAsync(sub, roles);
+
+        var assigned = roles.Select(r => r.ToString()).ToArray();
+        logger.LogInformation(
+            "Onboarding completed: userId={UserId} rentalType={RentalType} roles=[{Roles}]",
+            sub, rentalType, string.Join(", ", assigned));
+
+        return (user, assigned);
+    }
+
+    private static IReadOnlyList<UserRole> MapRentalTypeToRoles(RentalType rentalType) =>
+        rentalType switch
+        {
+            RentalType.ShortTerm => [UserRole.PropertyOwner],
+            RentalType.LongTerm => [UserRole.LongTermLandlord],
+            RentalType.Both => [UserRole.PropertyOwner, UserRole.LongTermLandlord],
+            _ => throw new ArgumentOutOfRangeException(nameof(rentalType), rentalType, "Unknown rental type")
+        };
 }

--- a/Casazen.Tests/Integration/OnboardingIntegrationTests.cs
+++ b/Casazen.Tests/Integration/OnboardingIntegrationTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Xunit;
+
+namespace Casazen.Tests.Integration;
+
+public class OnboardingIntegrationTests : IClassFixture<CasazenWebApplicationFactory>
+{
+    private readonly CasazenWebApplicationFactory _factory;
+
+    public OnboardingIntegrationTests(CasazenWebApplicationFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task PostOnboarding_WithoutAuth_Returns401()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/users/onboarding", new { rentalType = "ShortTerm" });
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostOnboarding_InvalidRentalType_Returns400()
+    {
+        using var client = _factory.CreateAuthenticatedClient(roles: string.Empty);
+        var response = await client.PostAsJsonAsync("/api/users/onboarding", new { rentalType = "Invalid" });
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostOnboarding_ShortTerm_ReturnsPropertyOwner()
+    {
+        await AssertOnboardingSuccess("ShortTerm", ["PropertyOwner"]);
+    }
+
+    [Fact]
+    public async Task PostOnboarding_LongTerm_ReturnsLongTermLandlord()
+    {
+        await AssertOnboardingSuccess("LongTerm", ["LongTermLandlord"]);
+    }
+
+    [Fact]
+    public async Task PostOnboarding_Both_ReturnsBothRoles()
+    {
+        await AssertOnboardingSuccess("Both", ["PropertyOwner", "LongTermLandlord"]);
+    }
+
+    private async Task AssertOnboardingSuccess(string rentalType, string[] expectedRoles)
+    {
+        var userId = $"auth0|onboarding-{Guid.NewGuid():N}";
+        using var client = _factory.CreateAuthenticatedClient(userId, roles: string.Empty);
+
+        var response = await client.PostAsJsonAsync("/api/users/onboarding", new { rentalType });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var assigned = body.GetProperty("rolesAssigned").EnumerateArray().Select(e => e.GetString()).ToArray();
+        foreach (var role in expectedRoles)
+            Assert.Contains(role, assigned);
+
+        var me = await client.GetAsync("/api/users/me");
+        Assert.Equal(HttpStatusCode.OK, me.StatusCode);
+        var profile = await me.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(rentalType, profile.GetProperty("rentalType").GetString());
+    }
+
+    [Fact]
+    public async Task PutOnboarding_UpdatesRentalType_Idempotent()
+    {
+        var userId = $"auth0|onboarding-put-{Guid.NewGuid():N}";
+        using var client = _factory.CreateAuthenticatedClient(userId, roles: string.Empty);
+
+        var post = await client.PostAsJsonAsync("/api/users/onboarding", new { rentalType = "ShortTerm" });
+        Assert.Equal(HttpStatusCode.OK, post.StatusCode);
+
+        var put = await client.PutAsJsonAsync("/api/users/onboarding", new { rentalType = "LongTerm" });
+        Assert.Equal(HttpStatusCode.OK, put.StatusCode);
+
+        var body = await put.Content.ReadFromJsonAsync<JsonElement>();
+        var assigned = body.GetProperty("rolesAssigned").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Single(assigned);
+        Assert.Equal("LongTermLandlord", assigned[0]);
+    }
+}

--- a/Casazen.Tests/Unit/Services/UserServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/UserServiceTests.cs
@@ -96,6 +96,30 @@ public class UserServiceTests
             () => _service.ChangeRoleAsync("nonexistent", UserRole.Admin, "admin"));
     }
 
+    // ─── CompleteOnboardingAsync ────────────────────────────────────────────
+
+    [Fact]
+    public async Task CompleteOnboardingAsync_ShortTerm_UpdatesUserAndCallsAuth0()
+    {
+        var sub = "auth0|onboard1";
+        var user = new User { Id = sub, Email = "a@b.com", FirstName = "A", LastName = "B" };
+        _repoMock.Setup(r => r.GetBySubAsync(sub)).ReturnsAsync(user);
+        _repoMock.Setup(r => r.UpdateAsync(It.IsAny<User>())).Returns(Task.CompletedTask);
+        _auth0Mock.Setup(a => a.AssignOnboardingRolesAsync(sub, It.IsAny<IReadOnlyList<UserRole>>()))
+            .Returns(Task.CompletedTask);
+
+        var (result, roles) = await _service.CompleteOnboardingAsync(
+            sub, RentalType.ShortTerm, "a@b.com", "A", "B");
+
+        Assert.Equal(RentalType.ShortTerm, result.RentalType);
+        Assert.Equal(UserRole.PropertyOwner, result.Role);
+        Assert.Single(roles);
+        Assert.Equal("PropertyOwner", roles[0]);
+        _auth0Mock.Verify(a => a.AssignOnboardingRolesAsync(
+            sub, It.Is<IReadOnlyList<UserRole>>(list => list.Count == 1 && list[0] == UserRole.PropertyOwner)),
+            Times.Once);
+    }
+
     // ─── GetPagedAsync ──────────────────────────────────────────────────────
 
     [Fact]

--- a/Casazen.Web/Controllers/UsersController.cs
+++ b/Casazen.Web/Controllers/UsersController.cs
@@ -79,6 +79,16 @@ public class UsersController(
         return Ok(ToDetail(user));
     }
 
+    /// <summary>Completes first-time onboarding by assigning roles from rental type choice.</summary>
+    [HttpPost("onboarding")]
+    public Task<ActionResult<OnboardingResponseDto>> PostOnboarding([FromBody] OnboardingRequestDto dto) =>
+        CompleteOnboardingAsync(dto);
+
+    /// <summary>Updates rental type and Auth0 roles (idempotent re-onboarding).</summary>
+    [HttpPut("onboarding")]
+    public Task<ActionResult<OnboardingResponseDto>> PutOnboarding([FromBody] OnboardingRequestDto dto) =>
+        CompleteOnboardingAsync(dto);
+
     /// <summary>Updates the caller's own profile (first name, last name, phone).</summary>
     [HttpPut("me")]
     public async Task<ActionResult<UserDetailDto>> UpdateMe([FromBody] UpdateProfileDto dto)
@@ -145,6 +155,35 @@ public class UsersController(
         return NoContent();
     }
 
+    private async Task<ActionResult<OnboardingResponseDto>> CompleteOnboardingAsync(OnboardingRequestDto dto)
+    {
+        if (!Enum.TryParse<RentalType>(dto.RentalType, ignoreCase: true, out var rentalType))
+            return BadRequest(new { error = $"Unknown rentalType: {dto.RentalType}" });
+
+        var sub = GetSub();
+        if (sub == null)
+            return Unauthorized();
+
+        var email = User.FindFirst("email")?.Value
+                    ?? User.FindFirst(ClaimTypes.Email)?.Value
+                    ?? string.Empty;
+        var firstName = User.FindFirst("given_name")?.Value
+                        ?? User.FindFirst("name")?.Value?.Split(' ').FirstOrDefault()
+                        ?? string.Empty;
+        var lastName = User.FindFirst("family_name")?.Value
+                       ?? User.FindFirst("name")?.Value?.Split(' ').Skip(1).FirstOrDefault()
+                       ?? string.Empty;
+
+        var (user, rolesAssigned) = await userService.CompleteOnboardingAsync(
+            sub, rentalType, email, firstName, lastName);
+
+        return Ok(new OnboardingResponseDto
+        {
+            RolesAssigned = rolesAssigned.ToArray(),
+            RentalType = user.RentalType?.ToString() ?? rentalType.ToString()
+        });
+    }
+
     // ─── Helpers ────────────────────────────────────────────────────────────
 
     private string? GetSub() =>
@@ -159,6 +198,7 @@ public class UsersController(
         FirstName = u.FirstName,
         LastName = u.LastName,
         Role = u.Role.ToString(),
+        RentalType = u.RentalType?.ToString(),
         IsActive = u.IsActive,
         CreatedAt = u.CreatedAt
     };
@@ -170,6 +210,7 @@ public class UsersController(
         FirstName = u.FirstName,
         LastName = u.LastName,
         Role = u.Role.ToString(),
+        RentalType = u.RentalType?.ToString(),
         IsActive = u.IsActive,
         CreatedAt = u.CreatedAt,
         PhoneNumber = u.PhoneNumber,

--- a/Casazen.Web/DTOs/Users/OnboardingRequestDto.cs
+++ b/Casazen.Web/DTOs/Users/OnboardingRequestDto.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Casazen.Web.DTOs.Users;
+
+public class OnboardingRequestDto
+{
+    [Required]
+    public string RentalType { get; set; } = string.Empty;
+}

--- a/Casazen.Web/DTOs/Users/OnboardingResponseDto.cs
+++ b/Casazen.Web/DTOs/Users/OnboardingResponseDto.cs
@@ -1,0 +1,7 @@
+namespace Casazen.Web.DTOs.Users;
+
+public class OnboardingResponseDto
+{
+    public string[] RolesAssigned { get; set; } = [];
+    public string RentalType { get; set; } = string.Empty;
+}

--- a/Casazen.Web/DTOs/Users/UserSummaryDto.cs
+++ b/Casazen.Web/DTOs/Users/UserSummaryDto.cs
@@ -7,6 +7,7 @@ public class UserSummaryDto
     public string FirstName { get; set; } = string.Empty;
     public string LastName { get; set; } = string.Empty;
     public string Role { get; set; } = string.Empty;
+    public string? RentalType { get; set; }
     public bool IsActive { get; set; }
     public DateTime CreatedAt { get; set; }
 }


### PR DESCRIPTION
## Summary
- Add `POST/PUT /api/users/onboarding` to assign Auth0 roles from rental type choice
- Add nullable `User.RentalType` enum + EF migration
- Extend `Auth0ManagementService` with multi-role onboarding sync
- Integration + unit tests (AC7–AC10)

## Test plan
- [x] `dotnet test` — 414 passed
- [x] Onboarding integration tests (401, 400, ShortTerm/LongTerm/Both, PUT idempotent)

Closes #198
