### PR TITLE
fix(ops): auto-migrate on startup + expand Railway smoke gates

### DIFF
--- a/.claude/sdlc/05-release/harness.md
+++ b/.claude/sdlc/05-release/harness.md
@@ -35,7 +35,10 @@ Run after develop deploy completes (~90–120s post-merge).
 | # | Gate | Command | Pass condition |
 |---|---|---|---|
 | G5 | Railway test health | `curl -sf $RAILWAY_TEST_URL/api/health` | HTTP 200 |
-| G6 | Auth smoke | `curl -sw "%{http_code}" $RAILWAY_TEST_URL/api/properties` | 401 (not 5xx) |
+| G6 | Auth smoke | `curl` on `/api/properties`, `/api/bookings`, `/api/users/me`, `/api/me/contexts` | 401 each (never 5xx) |
+| G6b | API regression E2E | `E2E_STAGING=1 npm run test:e2e -- api-regression-smoke` | Authenticated: no 500 |
+| G6c | Vercel deploy smoke | `E2E_DEPLOY_SMOKE=1 npm run test:e2e -- vercel-deploy-smoke` | `#root` + no API 500 on load |
+| G6d | EF migrations applied | `.\scripts\migrate.ps1 -Target test` (and `prod` before Phase D if new migration) | Exit 0 |
 | G7 | Backend tests (release candidate) | `dotnet test` (in `casazen/backend` on `develop`) | All tests pass, 0 failures (N/A if no BE changes in release) |
 | G8 | E2E tests (release candidate) | `npm run test:e2e` (in `casazen/frontend` on `develop`) | All Playwright tests pass, 0 failures (N/A if no FE changes in release) |
 | G9 | Feature AC validated | Automated E2E + spot-check vs Issue `#N` ACs on staging URLs | All ACs pass on staging BE+FE |

--- a/.claude/skills/sdlc-pipeline/SKILL.md
+++ b/.claude/skills/sdlc-pipeline/SKILL.md
@@ -243,6 +243,12 @@ These rules apply throughout the pipeline and cannot be bypassed:
 - **Never push directly to `main` or `develop`** — feature PRs → `develop`; release PR `develop` → `main` (Stage 05 Phase C)
 - **Never promote to `main` before staging validation** — Stage 05 Phase B must pass on develop deploy, including **`dotnet test`**, **`npm run test:e2e`**, and staging FE serving the React SPA (`id="root"`)
 - **Tests from acceptance criteria in Stage 03** — test-engineer adds Vitest + Playwright E2E for each Issue AC before PR; Stage 05 re-runs BE + E2E before main promotion
+- **Mandatory deploy regression E2E (non-negotiable)** — every release must include:
+  1. **Demo E2E** for new feature ACs (`npm run test:e2e` in CI)
+  2. **Live API regression** (`E2E_STAGING=1 npm run test:e2e -- api-regression-smoke`) — authenticated calls to `/api/properties`, `/api/bookings`, `/api/users/me`, `/api/me/contexts` must **never** return 500
+  3. **Vercel deploy smoke** (`E2E_DEPLOY_SMOKE=1 npm run test:e2e -- vercel-deploy-smoke`) — prod/preview FE must serve `id="root"` with no API 500 storm on load
+  4. Run (3) and (4) on **Railway test** before `develop`→`main` and on **prod** after Phase D
+- **EF migrations before promote** — if Stage 03 adds a migration: run `.\scripts\migrate.ps1 -Target test` before Phase B staging validation and `.\scripts\migrate.ps1 -Target prod` before Phase D (startup auto-migrate is a safety net, not a substitute for the release checklist)
 - **Stage 06 runs on production (`main`) only** — not against develop/staging URLs
 - **Stage 05 auto-increments patch semver** from latest tag on backend repo unless specified otherwise
 - **Stage 05 Phase D G20/G21** — `main` and `develop` same tip **and** both build; promote only `develop`→`main`; never merge broken `main` into `develop`

--- a/.cursor/rules/sdlc-mandatory-e2e-deploy-smoke.mdc
+++ b/.cursor/rules/sdlc-mandatory-e2e-deploy-smoke.mdc
@@ -1,0 +1,27 @@
+---
+description: SDLC pipeline requires full E2E coverage and live deploy smoke on Vercel + Railway
+alwaysApply: true
+---
+
+# SDLC — Mandatory E2E & Deploy Smoke
+
+## Stage 03 (before PR)
+
+1. **Playwright E2E** for every acceptance criterion (demo mode, `npm run test:e2e`).
+2. **Vitest** for pure logic helpers.
+3. **Backend integration tests** for new API endpoints.
+
+## Stage 05 (before and after promote)
+
+| Check | Command | Pass |
+|---|---|---|
+| Demo E2E | `npm run test:e2e` | 0 failures |
+| API regression (auth) | `E2E_STAGING=1 npm run test:e2e -- api-regression-smoke` | No 500 on core endpoints |
+| Vercel FE smoke | `E2E_DEPLOY_SMOKE=1 npm run test:e2e -- vercel-deploy-smoke` | `#root` present, no API 500 on load |
+| EF migration | `.\scripts\migrate.ps1 -Target test` then `-Target prod` when migration added | Exit 0 |
+
+## Never ship when
+
+- Authenticated API returns **500** on staging (almost always pending EF migration).
+- Vercel serves placeholder/env file instead of React SPA.
+- New feature AC lacks a corresponding E2E spec.

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -88,7 +88,7 @@ jobs:
           STATUS=$(curl -o /dev/null -sw "%{http_code}" \
             "${RAILWAY_TEST_URL}/api/bookings")
           if [ "$STATUS" = "500" ]; then
-            echo "❌ /api/bookings returned 500 — likely pending EF migration (AddContextAuthorization)"
+            echo "❌ /api/bookings returned 500 — likely pending EF migration"
             exit 1
           fi
           if [ "$STATUS" != "401" ]; then
@@ -96,6 +96,25 @@ jobs:
             exit 1
           fi
           echo "✅ Bookings auth gate OK"
+
+      - name: Smoke test (users/me, contexts — never 500 without auth)
+        env:
+          RAILWAY_TEST_URL: ${{ vars.RAILWAY_TEST_URL }}
+        run: |
+          if [ -z "$RAILWAY_TEST_URL" ]; then exit 0; fi
+          for PATH_SUFFIX in users/me me/contexts users; do
+            STATUS=$(curl -o /dev/null -sw "%{http_code}" \
+              "${RAILWAY_TEST_URL}/api/${PATH_SUFFIX}")
+            if [ "$STATUS" = "500" ]; then
+              echo "❌ /api/${PATH_SUFFIX} returned 500 — run scripts/migrate.ps1 -Target test"
+              exit 1
+            fi
+            if [ "$STATUS" != "401" ]; then
+              echo "❌ Expected 401 on /api/${PATH_SUFFIX}, got $STATUS"
+              exit 1
+            fi
+            echo "✅ /api/${PATH_SUFFIX} auth gate OK"
+          done
 
       - name: Verify pricing adapter endpoint (auth gate — never 500)
         env:
@@ -149,10 +168,16 @@ jobs:
           RAILWAY_PROD_URL: ${{ vars.RAILWAY_PROD_URL }}
         run: |
           if [ -z "$RAILWAY_PROD_URL" ]; then exit 0; fi
-          STATUS=$(curl -o /dev/null -sw "%{http_code}" \
-            "${RAILWAY_PROD_URL}/api/properties")
-          if [ "$STATUS" != "401" ]; then
-            echo "❌ Expected 401 on /api/properties, got $STATUS"
-            exit 1
-          fi
-          echo "✅ Production auth gate OK"
+          for PATH_SUFFIX in properties bookings users/me me/contexts; do
+            STATUS=$(curl -o /dev/null -sw "%{http_code}" \
+              "${RAILWAY_PROD_URL}/api/${PATH_SUFFIX}")
+            if [ "$STATUS" = "500" ]; then
+              echo "❌ /api/${PATH_SUFFIX} returned 500 — run scripts/migrate.ps1 -Target prod"
+              exit 1
+            fi
+            if [ "$STATUS" != "401" ]; then
+              echo "❌ Expected 401 on /api/${PATH_SUFFIX}, got $STATUS"
+              exit 1
+            fi
+            echo "✅ Production /api/${PATH_SUFFIX} auth gate OK"
+          done

--- a/Casazen.Web/Program.cs
+++ b/Casazen.Web/Program.cs
@@ -15,6 +15,7 @@ using Casazen.Web.Middleware;
 using Hangfire;
 using Hangfire.PostgreSql;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using SendGrid.Extensions.DependencyInjection;
 
@@ -179,6 +180,14 @@ builder.Services.AddSwaggerGen(options =>
 });
 
 var app = builder.Build();
+
+// Apply pending EF migrations on startup (Railway deploy). Skipped in Testing (in-memory DB).
+if (!string.IsNullOrEmpty(connectionString) && !app.Environment.IsEnvironment("Testing"))
+{
+    using var migrateScope = app.Services.CreateScope();
+    var db = migrateScope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.Migrate();
+}
 
 // Swagger (must be before Authentication to allow anonymous access to swagger.json)
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
## Fix
- Apply EF migrations on Railway startup (prevents 500 after schema changes)
- Expand CI smoke: users/me, me/contexts, bookings
- SDLC mandatory E2E deploy smoke rules

Root cause of user 500s: AddUserRentalType migration was not applied to Supabase test/prod (applied manually).

Made with [Cursor](https://cursor.com)