### PR TITLE
feat(tenancy): multi-tenant Org boundary (#202)

### DIFF
--- a/Casazen.Core/Entities/Booking.cs
+++ b/Casazen.Core/Entities/Booking.cs
@@ -15,6 +15,10 @@ public class Booking
     public Guid PropertyId { get; set; }
     public virtual Property Property { get; set; } = null!;
 
+    /// <summary>Tenant key (AC2). Inherited from the booking's property; never client-supplied.</summary>
+    public Guid OrgId { get; set; }
+    public virtual Org Org { get; set; } = null!;
+
     [ForeignKey("Guest")]
     public Guid GuestId { get; set; }
     public virtual Guest Guest { get; set; } = null!;

--- a/Casazen.Core/Entities/Enums/PlanTier.cs
+++ b/Casazen.Core/Entities/Enums/PlanTier.cs
@@ -1,0 +1,12 @@
+namespace Casazen.Core.Entities.Enums;
+
+/// <summary>
+/// Subscription plan tier for an <see cref="Casazen.Core.Entities.Org"/>.
+/// Append-only: do not reorder or insert before existing values (persisted as int).
+/// </summary>
+public enum PlanTier
+{
+    Starter,
+    Pro,
+    Scale
+}

--- a/Casazen.Core/Entities/LeaseContract.cs
+++ b/Casazen.Core/Entities/LeaseContract.cs
@@ -16,6 +16,10 @@ public class LeaseContract
     [ForeignKey(nameof(PropertyId))]
     public virtual Property Property { get; set; } = null!;
 
+    /// <summary>Tenant key (AC2). Inherited from the lease's property; never client-supplied.</summary>
+    public Guid OrgId { get; set; }
+    public virtual Org Org { get; set; } = null!;
+
     [Required]
     public LeaseStatus Status { get; set; } = LeaseStatus.Draft;
 

--- a/Casazen.Core/Entities/Org.cs
+++ b/Casazen.Core/Entities/Org.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Casazen.Core.Entities.Enums;
+
+namespace Casazen.Core.Entities;
+
+/// <summary>
+/// Tenant key. Every tenant-scoped table carries an <c>OrgId</c> FK to this entity (RF1).
+/// Slug is unique. Stripe identifiers are non-secret account references, never credentials.
+/// </summary>
+[Table("Orgs")]
+public class Org
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required, MaxLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Unique, URL-safe org identifier (internal in US-004; public branding added later).</summary>
+    [Required, MaxLength(100)]
+    public string Slug { get; set; } = string.Empty;
+
+    [Required]
+    public PlanTier PlanTier { get; set; } = PlanTier.Starter;
+
+    [Required, MaxLength(200)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MaxLength(1000)]
+    public string? LogoUrl { get; set; }
+
+    [MaxLength(20)]
+    public string? ThemeColor { get; set; }
+
+    [MaxLength(255)]
+    public string ContactEmail { get; set; } = string.Empty;
+
+    /// <summary>Non-secret Stripe customer reference (billing). Set by <c>spec-saas-billing</c>.</summary>
+    [MaxLength(255)]
+    public string? StripeCustomerId { get; set; }
+
+    /// <summary>Non-secret Stripe Connect account reference (payouts). Used by <c>spec-direct-checkout</c>.</summary>
+    [MaxLength(255)]
+    public string? StripeConnectedAccountId { get; set; }
+
+    public bool IsActive { get; set; } = true;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Casazen.Core/Entities/Payment.cs
+++ b/Casazen.Core/Entities/Payment.cs
@@ -15,6 +15,10 @@ public class Payment
     public Guid BookingId { get; set; }
     public virtual Booking Booking { get; set; } = null!;
 
+    /// <summary>Tenant key (AC2). Inherited from the payment's booking; never client-supplied.</summary>
+    public Guid OrgId { get; set; }
+    public virtual Org Org { get; set; } = null!;
+
     [Precision(18, 2)]
     public decimal Amount { get; set; }
 

--- a/Casazen.Core/Entities/Property.cs
+++ b/Casazen.Core/Entities/Property.cs
@@ -16,6 +16,10 @@ public class Property
     [Required, MaxLength(255)]
     public string OwnerId { get; set; } = string.Empty;
 
+    /// <summary>Tenant key (AC2). Server-set from the caller's org; never client-supplied.</summary>
+    public Guid OrgId { get; set; }
+    public virtual Org Org { get; set; } = null!;
+
     [Required, MaxLength(100)]
     public string Name { get; set; } = string.Empty;
 

--- a/Casazen.Core/Entities/User.cs
+++ b/Casazen.Core/Entities/User.cs
@@ -26,6 +26,10 @@ public class User
 
     public RentalType? RentalType { get; set; }
 
+    /// <summary>The org this user belongs to (AC9). Nullable: a brand-new user pre-backfill has none.</summary>
+    public Guid? OrgId { get; set; }
+    public virtual Org? Org { get; set; }
+
     [MaxLength(64)]
     public string? LastUsedContextKey { get; set; }
 

--- a/Casazen.Core/Multitenancy/ITenantContext.cs
+++ b/Casazen.Core/Multitenancy/ITenantContext.cs
@@ -1,0 +1,36 @@
+namespace Casazen.Core.Multitenancy;
+
+/// <summary>
+/// Resolves the caller's tenant (<c>OrgId</c>) from the authenticated principal.
+/// Consumed by the EF global query filter so every tenant-scoped read is org-scoped
+/// server-side (AC7). The client can never supply or widen the tenant key.
+/// </summary>
+public interface ITenantContext
+{
+    /// <summary>
+    /// The caller's organization id, or <c>null</c> when the caller has no org
+    /// (brand-new user pre-backfill) or no authenticated principal. A <c>null</c>
+    /// value combined with <see cref="FilterEnabled"/> = <c>true</c> is fail-closed
+    /// (matches nothing), never fail-open.
+    /// </summary>
+    Guid? OrgId { get; }
+
+    /// <summary>
+    /// <c>true</c> when an authenticated caller is present and tenant scoping must be
+    /// enforced. <c>false</c> for anonymous/system contexts (background jobs, design-time,
+    /// unit tests) where the filter is disabled and cross-org access is explicit.
+    /// </summary>
+    bool FilterEnabled { get; }
+}
+
+/// <summary>
+/// No-op tenant context used outside an authenticated request scope (design-time
+/// migrations, background jobs, unit tests). Disables the global query filter.
+/// </summary>
+public sealed class NullTenantContext : ITenantContext
+{
+    public static readonly NullTenantContext Instance = new();
+
+    public Guid? OrgId => null;
+    public bool FilterEnabled => false;
+}

--- a/Casazen.Core/Services/IEntitlementService.cs
+++ b/Casazen.Core/Services/IEntitlementService.cs
@@ -1,0 +1,29 @@
+namespace Casazen.Core.Services;
+
+/// <summary>
+/// Resolved plan entitlement for an org: tier, per-tier limits, current usage,
+/// and whether another property may be created (AC8).
+/// </summary>
+public sealed record EntitlementResult(
+    Guid OrgId,
+    string PlanTier,
+    int MaxProperties,
+    int PropertyCount,
+    bool CanAddProperty);
+
+/// <summary>
+/// Enforces per-tier plan limits sourced from a tier→limits map in configuration
+/// (<c>Entitlement:Tiers:*</c>). <c>spec-saas-billing</c> is the source of truth for
+/// final commercial numbers; this service only reads the map.
+/// </summary>
+public interface IEntitlementService
+{
+    /// <summary>Returns the resolved entitlement (limits + usage) for the org.</summary>
+    Task<EntitlementResult> GetEntitlementAsync(Guid orgId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// <c>true</c> when the org is below its tier's <c>maxProperties</c> limit and may
+    /// create another property; <c>false</c> when the limit is reached.
+    /// </summary>
+    Task<bool> CanAddPropertyAsync(Guid orgId, CancellationToken cancellationToken = default);
+}

--- a/Casazen.Core/Services/IOrgService.cs
+++ b/Casazen.Core/Services/IOrgService.cs
@@ -1,0 +1,22 @@
+using Casazen.Core.Entities;
+
+namespace Casazen.Core.Services;
+
+/// <summary>
+/// Read access to <see cref="Org"/> tenants. US-004 is read-only for org;
+/// org management / plan switching is owned by <c>spec-saas-billing</c>.
+/// </summary>
+public interface IOrgService
+{
+    /// <summary>Returns the org by id, or <c>null</c> if not found.</summary>
+    Task<Org?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the org the given user belongs to, or <c>null</c> if the user has none.</summary>
+    Task<Org?> GetByUserIdAsync(string userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the org by slug for public (branded) surfaces. Referenced by later specs
+    /// (<c>spec-branded-booking-site</c>); not exposed via an endpoint in US-004.
+    /// </summary>
+    Task<Org?> GetPublicBySlugAsync(string slug, CancellationToken cancellationToken = default);
+}

--- a/Casazen.Infrastructure/Data/AppDbContext.cs
+++ b/Casazen.Infrastructure/Data/AppDbContext.cs
@@ -1,14 +1,20 @@
 using Casazen.Core.Entities;
 using Casazen.Core.Entities.Enums;
+using Casazen.Core.Multitenancy;
 using Microsoft.EntityFrameworkCore;
 using Property = Casazen.Core.Entities.Property;
 using AppContextEntity = Casazen.Core.Entities.AppContext;
 
 namespace Casazen.Infrastructure.Data;
 
-public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+public class AppDbContext(DbContextOptions<AppDbContext> options, ITenantContext? tenantContext = null) : DbContext(options)
 {
+    // Resolves the caller's OrgId for the global tenant query filter (AC7). Falls back to a
+    // no-op (filter disabled) for design-time, background jobs, and unit tests.
+    private readonly ITenantContext _tenant = tenantContext ?? NullTenantContext.Instance;
+
     public DbSet<User> Users { get; set; } = null!;
+    public DbSet<Org> Orgs { get; set; } = null!;
     public DbSet<Property> Properties { get; set; } = null!;
     public DbSet<Booking> Bookings { get; set; } = null!;
     public DbSet<Guest> Guests { get; set; } = null!;
@@ -182,6 +188,45 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
         modelBuilder.Entity<LeaseEvent>()
             .HasIndex(e => new { e.LeaseContractId, e.OccurredAt });
+
+        // ─── Multi-tenant Org boundary (US-004) ──────────────────────────────────
+        // Org tenant key with a unique Slug (AC1).
+        modelBuilder.Entity<Org>()
+            .HasIndex(o => o.Slug)
+            .IsUnique();
+
+        // OrgId indexes on the tenant-scoped tables + Users (AC2/AC9).
+        modelBuilder.Entity<Property>().HasIndex(p => p.OrgId);
+        modelBuilder.Entity<Booking>().HasIndex(b => b.OrgId);
+        modelBuilder.Entity<LeaseContract>().HasIndex(l => l.OrgId);
+        modelBuilder.Entity<Payment>().HasIndex(p => p.OrgId);
+        modelBuilder.Entity<User>().HasIndex(u => u.OrgId);
+
+        // OrgId FK constraints (AC2). Restrict: an Org can never be deleted while it still owns
+        // tenant rows. The four tenant tables are required (Guid); User.OrgId is nullable (AC9).
+        modelBuilder.Entity<Property>()
+            .HasOne(p => p.Org).WithMany().HasForeignKey(p => p.OrgId)
+            .OnDelete(DeleteBehavior.Restrict);
+        modelBuilder.Entity<Booking>()
+            .HasOne(b => b.Org).WithMany().HasForeignKey(b => b.OrgId)
+            .OnDelete(DeleteBehavior.Restrict);
+        modelBuilder.Entity<LeaseContract>()
+            .HasOne(l => l.Org).WithMany().HasForeignKey(l => l.OrgId)
+            .OnDelete(DeleteBehavior.Restrict);
+        modelBuilder.Entity<Payment>()
+            .HasOne(p => p.Org).WithMany().HasForeignKey(p => p.OrgId)
+            .OnDelete(DeleteBehavior.Restrict);
+        modelBuilder.Entity<User>()
+            .HasOne(u => u.Org).WithMany().HasForeignKey(u => u.OrgId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Global tenant query filter (AC7): every read of a tenant-scoped table is scoped
+        // to the caller's OrgId. Fail-closed when the caller has no org; disabled for
+        // anonymous/system contexts (background jobs, design-time, unit tests).
+        modelBuilder.Entity<Property>().HasQueryFilter(p => !_tenant.FilterEnabled || p.OrgId == _tenant.OrgId);
+        modelBuilder.Entity<Booking>().HasQueryFilter(b => !_tenant.FilterEnabled || b.OrgId == _tenant.OrgId);
+        modelBuilder.Entity<LeaseContract>().HasQueryFilter(l => !_tenant.FilterEnabled || l.OrgId == _tenant.OrgId);
+        modelBuilder.Entity<Payment>().HasQueryFilter(p => !_tenant.FilterEnabled || p.OrgId == _tenant.OrgId);
 
         modelBuilder.Entity<AppContextEntity>()
             .HasKey(c => c.Key);

--- a/Casazen.Infrastructure/Migrations/20260609100314_AddOrgIdNullable.Designer.cs
+++ b/Casazen.Infrastructure/Migrations/20260609100314_AddOrgIdNullable.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Casazen.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609100314_AddOrgIdNullable")]
+    partial class AddOrgIdNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -136,7 +139,7 @@ namespace Casazen.Infrastructure.Migrations
                     b.Property<int>("NumberOfGuests")
                         .HasColumnType("integer");
 
-                    b.Property<Guid>("OrgId")
+                    b.Property<Guid?>("OrgId")
                         .HasColumnType("uuid");
 
                     b.Property<Guid>("PropertyId")
@@ -401,7 +404,7 @@ namespace Casazen.Infrastructure.Migrations
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<Guid>("OrgId")
+                    b.Property<Guid?>("OrgId")
                         .HasColumnType("uuid");
 
                     b.Property<Guid>("PropertyId")
@@ -738,7 +741,7 @@ namespace Casazen.Infrastructure.Migrations
                     b.Property<int>("Method")
                         .HasColumnType("integer");
 
-                    b.Property<Guid>("OrgId")
+                    b.Property<Guid?>("OrgId")
                         .HasColumnType("uuid");
 
                     b.Property<DateTime?>("ProcessedAt")
@@ -943,7 +946,7 @@ namespace Casazen.Infrastructure.Migrations
                         .HasPrecision(18, 2)
                         .HasColumnType("numeric(18,2)");
 
-                    b.Property<Guid>("OrgId")
+                    b.Property<Guid?>("OrgId")
                         .HasColumnType("uuid");
 
                     b.Property<string>("OwnerId")
@@ -1393,12 +1396,6 @@ namespace Casazen.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("Casazen.Core.Entities.Org", "Org")
-                        .WithMany()
-                        .HasForeignKey("OrgId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.HasOne("Casazen.Core.Entities.Property", "Property")
                         .WithMany("Bookings")
                         .HasForeignKey("PropertyId")
@@ -1407,26 +1404,16 @@ namespace Casazen.Infrastructure.Migrations
 
                     b.Navigation("Guest");
 
-                    b.Navigation("Org");
-
                     b.Navigation("Property");
                 });
 
             modelBuilder.Entity("Casazen.Core.Entities.LeaseContract", b =>
                 {
-                    b.HasOne("Casazen.Core.Entities.Org", "Org")
-                        .WithMany()
-                        .HasForeignKey("OrgId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.HasOne("Casazen.Core.Entities.Property", "Property")
                         .WithMany()
                         .HasForeignKey("PropertyId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.Navigation("Org");
 
                     b.Navigation("Property");
                 });
@@ -1494,15 +1481,7 @@ namespace Casazen.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Casazen.Core.Entities.Org", "Org")
-                        .WithMany()
-                        .HasForeignKey("OrgId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.Navigation("Booking");
-
-                    b.Navigation("Org");
                 });
 
             modelBuilder.Entity("Casazen.Core.Entities.PricingAdapterConfig", b =>
@@ -1533,15 +1512,7 @@ namespace Casazen.Infrastructure.Migrations
                         .WithMany("Properties")
                         .HasForeignKey("CancellationPolicyId");
 
-                    b.HasOne("Casazen.Core.Entities.Org", "Org")
-                        .WithMany()
-                        .HasForeignKey("OrgId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.Navigation("CancellationPolicy");
-
-                    b.Navigation("Org");
                 });
 
             modelBuilder.Entity("Casazen.Core.Entities.PropertyDocument", b =>
@@ -1575,16 +1546,6 @@ namespace Casazen.Infrastructure.Migrations
                         .IsRequired();
 
                     b.Navigation("Role");
-                });
-
-            modelBuilder.Entity("Casazen.Core.Entities.User", b =>
-                {
-                    b.HasOne("Casazen.Core.Entities.Org", "Org")
-                        .WithMany()
-                        .HasForeignKey("OrgId")
-                        .OnDelete(DeleteBehavior.Restrict);
-
-                    b.Navigation("Org");
                 });
 
             modelBuilder.Entity("Casazen.Core.Entities.UserContextMembership", b =>

--- a/Casazen.Infrastructure/Migrations/20260609100314_AddOrgIdNullable.cs
+++ b/Casazen.Infrastructure/Migrations/20260609100314_AddOrgIdNullable.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Casazen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrgIdNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "OrgId",
+                table: "Users",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "OrgId",
+                table: "Properties",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "OrgId",
+                table: "Payments",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "OrgId",
+                table: "LeaseContracts",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "OrgId",
+                table: "Bookings",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Orgs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Slug = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    PlanTier = table.Column<int>(type: "integer", nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    LogoUrl = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    ThemeColor = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    ContactEmail = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    StripeCustomerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    StripeConnectedAccountId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orgs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_OrgId",
+                table: "Users",
+                column: "OrgId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Properties_OrgId",
+                table: "Properties",
+                column: "OrgId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Payments_OrgId",
+                table: "Payments",
+                column: "OrgId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeaseContracts_OrgId",
+                table: "LeaseContracts",
+                column: "OrgId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookings_OrgId",
+                table: "Bookings",
+                column: "OrgId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orgs_Slug",
+                table: "Orgs",
+                column: "Slug",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Orgs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Users_OrgId",
+                table: "Users");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Properties_OrgId",
+                table: "Properties");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Payments_OrgId",
+                table: "Payments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_LeaseContracts_OrgId",
+                table: "LeaseContracts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Bookings_OrgId",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "OrgId",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "OrgId",
+                table: "Properties");
+
+            migrationBuilder.DropColumn(
+                name: "OrgId",
+                table: "Payments");
+
+            migrationBuilder.DropColumn(
+                name: "OrgId",
+                table: "LeaseContracts");
+
+            migrationBuilder.DropColumn(
+                name: "OrgId",
+                table: "Bookings");
+        }
+    }
+}

--- a/Casazen.Infrastructure/Migrations/20260609100413_BackfillDefaultOrgs.Designer.cs
+++ b/Casazen.Infrastructure/Migrations/20260609100413_BackfillDefaultOrgs.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Casazen.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609100413_BackfillDefaultOrgs")]
+    partial class BackfillDefaultOrgs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -136,7 +139,7 @@ namespace Casazen.Infrastructure.Migrations
                     b.Property<int>("NumberOfGuests")
                         .HasColumnType("integer");
 
-                    b.Property<Guid>("OrgId")
+                    b.Property<Guid?>("OrgId")
                         .HasColumnType("uuid");
 
                     b.Property<Guid>("PropertyId")
@@ -401,7 +404,7 @@ namespace Casazen.Infrastructure.Migrations
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<Guid>("OrgId")
+                    b.Property<Guid?>("OrgId")
                         .HasColumnType("uuid");
 
                     b.Property<Guid>("PropertyId")
@@ -738,7 +741,7 @@ namespace Casazen.Infrastructure.Migrations
                     b.Property<int>("Method")
                         .HasColumnType("integer");
 
-                    b.Property<Guid>("OrgId")
+                    b.Property<Guid?>("OrgId")
                         .HasColumnType("uuid");
 
                     b.Property<DateTime?>("ProcessedAt")
@@ -943,7 +946,7 @@ namespace Casazen.Infrastructure.Migrations
                         .HasPrecision(18, 2)
                         .HasColumnType("numeric(18,2)");
 
-                    b.Property<Guid>("OrgId")
+                    b.Property<Guid?>("OrgId")
                         .HasColumnType("uuid");
 
                     b.Property<string>("OwnerId")
@@ -1393,12 +1396,6 @@ namespace Casazen.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("Casazen.Core.Entities.Org", "Org")
-                        .WithMany()
-                        .HasForeignKey("OrgId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.HasOne("Casazen.Core.Entities.Property", "Property")
                         .WithMany("Bookings")
                         .HasForeignKey("PropertyId")
@@ -1407,26 +1404,16 @@ namespace Casazen.Infrastructure.Migrations
 
                     b.Navigation("Guest");
 
-                    b.Navigation("Org");
-
                     b.Navigation("Property");
                 });
 
             modelBuilder.Entity("Casazen.Core.Entities.LeaseContract", b =>
                 {
-                    b.HasOne("Casazen.Core.Entities.Org", "Org")
-                        .WithMany()
-                        .HasForeignKey("OrgId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.HasOne("Casazen.Core.Entities.Property", "Property")
                         .WithMany()
                         .HasForeignKey("PropertyId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.Navigation("Org");
 
                     b.Navigation("Property");
                 });
@@ -1494,15 +1481,7 @@ namespace Casazen.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Casazen.Core.Entities.Org", "Org")
-                        .WithMany()
-                        .HasForeignKey("OrgId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.Navigation("Booking");
-
-                    b.Navigation("Org");
                 });
 
             modelBuilder.Entity("Casazen.Core.Entities.PricingAdapterConfig", b =>
@@ -1533,15 +1512,7 @@ namespace Casazen.Infrastructure.Migrations
                         .WithMany("Properties")
                         .HasForeignKey("CancellationPolicyId");
 
-                    b.HasOne("Casazen.Core.Entities.Org", "Org")
-                        .WithMany()
-                        .HasForeignKey("OrgId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.Navigation("CancellationPolicy");
-
-                    b.Navigation("Org");
                 });
 
             modelBuilder.Entity("Casazen.Core.Entities.PropertyDocument", b =>
@@ -1575,16 +1546,6 @@ namespace Casazen.Infrastructure.Migrations
                         .IsRequired();
 
                     b.Navigation("Role");
-                });
-
-            modelBuilder.Entity("Casazen.Core.Entities.User", b =>
-                {
-                    b.HasOne("Casazen.Core.Entities.Org", "Org")
-                        .WithMany()
-                        .HasForeignKey("OrgId")
-                        .OnDelete(DeleteBehavior.Restrict);
-
-                    b.Navigation("Org");
                 });
 
             modelBuilder.Entity("Casazen.Core.Entities.UserContextMembership", b =>

--- a/Casazen.Infrastructure/Migrations/20260609100413_BackfillDefaultOrgs.cs
+++ b/Casazen.Infrastructure/Migrations/20260609100413_BackfillDefaultOrgs.cs
@@ -1,0 +1,127 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Casazen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class BackfillDefaultOrgs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Data migration (Deploy 2). Idempotent and re-runnable: every step is guarded by
+            // "OrgId IS NULL" / "ON CONFLICT DO NOTHING", and row counts are logged via RAISE NOTICE
+            // (AC4). The default-Org slug is a deterministic function of OwnerId
+            // (org-<sanitized-owner>-<md5 prefix>) so the same owner always maps to the same Org and
+            // two distinct owners can never collide onto one Org (the cross-owner leak risk in AC10).
+            migrationBuilder.Sql(@"
+DO $$
+DECLARE
+    v_orgs     bigint;
+    v_users    bigint;
+    v_props    bigint;
+    v_bookings bigint;
+    v_payments bigint;
+    v_leases   bigint;
+BEGIN
+    -- 1) One default Org per distinct Property.OwnerId (PlanTier.Starter = 0, active).
+    INSERT INTO ""Orgs"" (
+        ""Id"", ""Name"", ""Slug"", ""PlanTier"", ""DisplayName"", ""ContactEmail"",
+        ""IsActive"", ""CreatedAt"", ""UpdatedAt"")
+    SELECT
+        gen_random_uuid(),
+        COALESCE(NULLIF(btrim(u.""FirstName"" || ' ' || u.""LastName""), ''), p.""OwnerId""),
+        left('org-' || regexp_replace(lower(p.""OwnerId""), '[^a-z0-9]+', '-', 'g'), 90)
+            || '-' || substr(md5(p.""OwnerId""), 1, 8),
+        0,
+        COALESCE(NULLIF(btrim(u.""FirstName"" || ' ' || u.""LastName""), ''), p.""OwnerId""),
+        COALESCE(u.""Email"", ''),
+        true,
+        now(), now()
+    FROM (SELECT DISTINCT ""OwnerId"" FROM ""Properties"") p
+    LEFT JOIN ""Users"" u ON u.""Id"" = p.""OwnerId""
+    ON CONFLICT (""Slug"") DO NOTHING;
+    GET DIAGNOSTICS v_orgs = ROW_COUNT;
+
+    -- 2) Link each owner's User row to their default Org (owners only).
+    UPDATE ""Users"" u
+    SET ""OrgId"" = o.""Id""
+    FROM ""Orgs"" o
+    WHERE u.""OrgId"" IS NULL
+      AND o.""Slug"" = left('org-' || regexp_replace(lower(u.""Id""), '[^a-z0-9]+', '-', 'g'), 90)
+            || '-' || substr(md5(u.""Id""), 1, 8)
+      AND EXISTS (SELECT 1 FROM ""Properties"" p WHERE p.""OwnerId"" = u.""Id"");
+    GET DIAGNOSTICS v_users = ROW_COUNT;
+
+    -- 3a) Properties: OwnerId -> Org.
+    UPDATE ""Properties"" p
+    SET ""OrgId"" = o.""Id""
+    FROM ""Orgs"" o
+    WHERE p.""OrgId"" IS NULL
+      AND o.""Slug"" = left('org-' || regexp_replace(lower(p.""OwnerId""), '[^a-z0-9]+', '-', 'g'), 90)
+            || '-' || substr(md5(p.""OwnerId""), 1, 8);
+    GET DIAGNOSTICS v_props = ROW_COUNT;
+
+    -- 3b) Bookings: booking -> property.
+    UPDATE ""Bookings"" b
+    SET ""OrgId"" = p.""OrgId""
+    FROM ""Properties"" p
+    WHERE b.""OrgId"" IS NULL
+      AND p.""Id"" = b.""PropertyId""
+      AND p.""OrgId"" IS NOT NULL;
+    GET DIAGNOSTICS v_bookings = ROW_COUNT;
+
+    -- 3c) Payments: payment -> booking -> property.
+    UPDATE ""Payments"" pay
+    SET ""OrgId"" = b.""OrgId""
+    FROM ""Bookings"" b
+    WHERE pay.""OrgId"" IS NULL
+      AND b.""Id"" = pay.""BookingId""
+      AND b.""OrgId"" IS NOT NULL;
+    GET DIAGNOSTICS v_payments = ROW_COUNT;
+
+    -- 3d) LeaseContracts: lease -> property.
+    UPDATE ""LeaseContracts"" l
+    SET ""OrgId"" = p.""OrgId""
+    FROM ""Properties"" p
+    WHERE l.""OrgId"" IS NULL
+      AND p.""Id"" = l.""PropertyId""
+      AND p.""OrgId"" IS NOT NULL;
+    GET DIAGNOSTICS v_leases = ROW_COUNT;
+
+    -- 4) Dedicated fallback Org for the Step 3 quarantine rule (inactive, never a real tenant).
+    INSERT INTO ""Orgs"" (
+        ""Id"", ""Name"", ""Slug"", ""PlanTier"", ""DisplayName"", ""ContactEmail"",
+        ""IsActive"", ""CreatedAt"", ""UpdatedAt"")
+    VALUES (
+        gen_random_uuid(), 'CasaZen Unassigned', 'casazen-unassigned', 0,
+        'CasaZen Unassigned', '', false, now(), now())
+    ON CONFLICT (""Slug"") DO NOTHING;
+
+    -- 5) Verification log (AC4).
+    RAISE NOTICE 'BackfillDefaultOrgs: orgs_created=%, users_linked=%, properties=%, bookings=%, payments=%, leases=%',
+        v_orgs, v_users, v_props, v_bookings, v_payments, v_leases;
+END $$;
+");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Logical no-op (AC10b). A data backfill is not auto-reverted on rollback: nulling OrgId
+            // blindly could orphan rows the app already depends on. The documented reversal lives in
+            // the release runbook and is run manually only when a full rollback is required:
+            //
+            //   UPDATE "Bookings"       SET "OrgId" = NULL WHERE "OrgId" IN (SELECT "Id" FROM "Orgs" WHERE "Slug" LIKE 'org-%' OR "Slug" = 'casazen-unassigned');
+            //   UPDATE "Payments"       SET "OrgId" = NULL WHERE "OrgId" IN (SELECT "Id" FROM "Orgs" WHERE "Slug" LIKE 'org-%' OR "Slug" = 'casazen-unassigned');
+            //   UPDATE "LeaseContracts" SET "OrgId" = NULL WHERE "OrgId" IN (SELECT "Id" FROM "Orgs" WHERE "Slug" LIKE 'org-%' OR "Slug" = 'casazen-unassigned');
+            //   UPDATE "Properties"     SET "OrgId" = NULL WHERE "OrgId" IN (SELECT "Id" FROM "Orgs" WHERE "Slug" LIKE 'org-%' OR "Slug" = 'casazen-unassigned');
+            //   UPDATE "Users"          SET "OrgId" = NULL WHERE "OrgId" IN (SELECT "Id" FROM "Orgs" WHERE "Slug" LIKE 'org-%' OR "Slug" = 'casazen-unassigned');
+            //   DELETE FROM "Orgs" WHERE "Slug" LIKE 'org-%' OR "Slug" = 'casazen-unassigned';
+            //
+            // Reverting Step 1 (AddOrgIdNullable) drops the columns entirely, which is the real
+            // structural rollback path; this method intentionally does nothing.
+        }
+    }
+}

--- a/Casazen.Infrastructure/Migrations/20260609101050_MakeOrgIdRequired.Designer.cs
+++ b/Casazen.Infrastructure/Migrations/20260609101050_MakeOrgIdRequired.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Casazen.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609101050_MakeOrgIdRequired")]
+    partial class MakeOrgIdRequired
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Casazen.Infrastructure/Migrations/20260609101050_MakeOrgIdRequired.cs
+++ b/Casazen.Infrastructure/Migrations/20260609101050_MakeOrgIdRequired.cs
@@ -29,81 +29,65 @@ BEGIN
 END $$;
 ");
 
-            migrationBuilder.AlterColumn<Guid>(
-                name: "OrgId",
-                table: "Properties",
-                type: "uuid",
-                nullable: false,
-                oldClrType: typeof(Guid),
-                oldType: "uuid",
-                oldNullable: true);
+            // Zero-downtime NOT-NULL + FK flip (AC10b / design Migration Plan, Deploy 3). The naive
+            // AlterColumn(nullable:false) emits a validating SET NOT NULL (full-table scan under
+            // ACCESS EXCLUSIVE) and AddForeignKey validates immediately (SHARE ROW EXCLUSIVE), both
+            // of which lock a populated Supabase table. Instead, for each of the four tenant tables:
+            //   1. ADD the FK ... NOT VALID (brief lock, no scan) then VALIDATE CONSTRAINT
+            //      (SHARE UPDATE EXCLUSIVE — concurrent reads/writes keep running during the scan).
+            //   2. ADD a CHECK ("OrgId" IS NOT NULL) NOT VALID -> VALIDATE CONSTRAINT, then
+            //      ALTER COLUMN ... SET NOT NULL (Postgres 12+ reuses the validated CHECK and skips
+            //      the table scan), then DROP the now-redundant CHECK.
+            // Static SQL only (no C# concatenation/interpolation); constraint names match EF
+            // conventions and the model snapshot, so the resulting schema is byte-for-byte identical
+            // to the generated migration — only the lock profile changes.
 
-            migrationBuilder.AlterColumn<Guid>(
-                name: "OrgId",
-                table: "Payments",
-                type: "uuid",
-                nullable: false,
-                oldClrType: typeof(Guid),
-                oldType: "uuid",
-                oldNullable: true);
+            migrationBuilder.Sql(@"
+ALTER TABLE ""Properties"" ADD CONSTRAINT ""FK_Properties_Orgs_OrgId""
+    FOREIGN KEY (""OrgId"") REFERENCES ""Orgs"" (""Id"") ON DELETE RESTRICT NOT VALID;
+ALTER TABLE ""Properties"" VALIDATE CONSTRAINT ""FK_Properties_Orgs_OrgId"";
+ALTER TABLE ""Properties"" ADD CONSTRAINT ""CK_Properties_OrgId_NotNull"" CHECK (""OrgId"" IS NOT NULL) NOT VALID;
+ALTER TABLE ""Properties"" VALIDATE CONSTRAINT ""CK_Properties_OrgId_NotNull"";
+ALTER TABLE ""Properties"" ALTER COLUMN ""OrgId"" SET NOT NULL;
+ALTER TABLE ""Properties"" DROP CONSTRAINT ""CK_Properties_OrgId_NotNull"";
+");
 
-            migrationBuilder.AlterColumn<Guid>(
-                name: "OrgId",
-                table: "LeaseContracts",
-                type: "uuid",
-                nullable: false,
-                oldClrType: typeof(Guid),
-                oldType: "uuid",
-                oldNullable: true);
+            migrationBuilder.Sql(@"
+ALTER TABLE ""Payments"" ADD CONSTRAINT ""FK_Payments_Orgs_OrgId""
+    FOREIGN KEY (""OrgId"") REFERENCES ""Orgs"" (""Id"") ON DELETE RESTRICT NOT VALID;
+ALTER TABLE ""Payments"" VALIDATE CONSTRAINT ""FK_Payments_Orgs_OrgId"";
+ALTER TABLE ""Payments"" ADD CONSTRAINT ""CK_Payments_OrgId_NotNull"" CHECK (""OrgId"" IS NOT NULL) NOT VALID;
+ALTER TABLE ""Payments"" VALIDATE CONSTRAINT ""CK_Payments_OrgId_NotNull"";
+ALTER TABLE ""Payments"" ALTER COLUMN ""OrgId"" SET NOT NULL;
+ALTER TABLE ""Payments"" DROP CONSTRAINT ""CK_Payments_OrgId_NotNull"";
+");
 
-            migrationBuilder.AlterColumn<Guid>(
-                name: "OrgId",
-                table: "Bookings",
-                type: "uuid",
-                nullable: false,
-                oldClrType: typeof(Guid),
-                oldType: "uuid",
-                oldNullable: true);
+            migrationBuilder.Sql(@"
+ALTER TABLE ""LeaseContracts"" ADD CONSTRAINT ""FK_LeaseContracts_Orgs_OrgId""
+    FOREIGN KEY (""OrgId"") REFERENCES ""Orgs"" (""Id"") ON DELETE RESTRICT NOT VALID;
+ALTER TABLE ""LeaseContracts"" VALIDATE CONSTRAINT ""FK_LeaseContracts_Orgs_OrgId"";
+ALTER TABLE ""LeaseContracts"" ADD CONSTRAINT ""CK_LeaseContracts_OrgId_NotNull"" CHECK (""OrgId"" IS NOT NULL) NOT VALID;
+ALTER TABLE ""LeaseContracts"" VALIDATE CONSTRAINT ""CK_LeaseContracts_OrgId_NotNull"";
+ALTER TABLE ""LeaseContracts"" ALTER COLUMN ""OrgId"" SET NOT NULL;
+ALTER TABLE ""LeaseContracts"" DROP CONSTRAINT ""CK_LeaseContracts_OrgId_NotNull"";
+");
 
-            migrationBuilder.AddForeignKey(
-                name: "FK_Bookings_Orgs_OrgId",
-                table: "Bookings",
-                column: "OrgId",
-                principalTable: "Orgs",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.Sql(@"
+ALTER TABLE ""Bookings"" ADD CONSTRAINT ""FK_Bookings_Orgs_OrgId""
+    FOREIGN KEY (""OrgId"") REFERENCES ""Orgs"" (""Id"") ON DELETE RESTRICT NOT VALID;
+ALTER TABLE ""Bookings"" VALIDATE CONSTRAINT ""FK_Bookings_Orgs_OrgId"";
+ALTER TABLE ""Bookings"" ADD CONSTRAINT ""CK_Bookings_OrgId_NotNull"" CHECK (""OrgId"" IS NOT NULL) NOT VALID;
+ALTER TABLE ""Bookings"" VALIDATE CONSTRAINT ""CK_Bookings_OrgId_NotNull"";
+ALTER TABLE ""Bookings"" ALTER COLUMN ""OrgId"" SET NOT NULL;
+ALTER TABLE ""Bookings"" DROP CONSTRAINT ""CK_Bookings_OrgId_NotNull"";
+");
 
-            migrationBuilder.AddForeignKey(
-                name: "FK_LeaseContracts_Orgs_OrgId",
-                table: "LeaseContracts",
-                column: "OrgId",
-                principalTable: "Orgs",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.Restrict);
-
-            migrationBuilder.AddForeignKey(
-                name: "FK_Payments_Orgs_OrgId",
-                table: "Payments",
-                column: "OrgId",
-                principalTable: "Orgs",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.Restrict);
-
-            migrationBuilder.AddForeignKey(
-                name: "FK_Properties_Orgs_OrgId",
-                table: "Properties",
-                column: "OrgId",
-                principalTable: "Orgs",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.Restrict);
-
-            migrationBuilder.AddForeignKey(
-                name: "FK_Users_Orgs_OrgId",
-                table: "Users",
-                column: "OrgId",
-                principalTable: "Orgs",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.Restrict);
+            // Users.OrgId stays nullable (AC9) — add only the FK, lock-light (NOT VALID -> VALIDATE).
+            migrationBuilder.Sql(@"
+ALTER TABLE ""Users"" ADD CONSTRAINT ""FK_Users_Orgs_OrgId""
+    FOREIGN KEY (""OrgId"") REFERENCES ""Orgs"" (""Id"") ON DELETE RESTRICT NOT VALID;
+ALTER TABLE ""Users"" VALIDATE CONSTRAINT ""FK_Users_Orgs_OrgId"";
+");
         }
 
         /// <inheritdoc />

--- a/Casazen.Infrastructure/Migrations/20260609101050_MakeOrgIdRequired.cs
+++ b/Casazen.Infrastructure/Migrations/20260609101050_MakeOrgIdRequired.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Casazen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeOrgIdRequired : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Pre-flight NULL-OrgId guard (AC10b, fail loud): abort BEFORE the NOT-NULL flip if any
+            // tenant-scoped row still lacks an OrgId. The NOT-NULL conversion must never run silently
+            // against un-backfilled data. Residual rows are remediated to the 'casazen-unassigned'
+            // fallback Org (Step 2) and the pre-flight re-run — never auto-flipped into a real tenant.
+            migrationBuilder.Sql(@"
+DO $$
+DECLARE n bigint;
+BEGIN
+    SELECT (SELECT count(*) FROM ""Properties""     WHERE ""OrgId"" IS NULL)
+         + (SELECT count(*) FROM ""Bookings""       WHERE ""OrgId"" IS NULL)
+         + (SELECT count(*) FROM ""LeaseContracts"" WHERE ""OrgId"" IS NULL)
+         + (SELECT count(*) FROM ""Payments""       WHERE ""OrgId"" IS NULL) INTO n;
+    IF n > 0 THEN
+        RAISE EXCEPTION 'Pre-flight failed: % tenant-scoped rows still have NULL OrgId. Run quarantine remediation before MakeOrgIdRequired.', n;
+    END IF;
+END $$;
+");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "OrgId",
+                table: "Properties",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "OrgId",
+                table: "Payments",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "OrgId",
+                table: "LeaseContracts",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "OrgId",
+                table: "Bookings",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Bookings_Orgs_OrgId",
+                table: "Bookings",
+                column: "OrgId",
+                principalTable: "Orgs",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_LeaseContracts_Orgs_OrgId",
+                table: "LeaseContracts",
+                column: "OrgId",
+                principalTable: "Orgs",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Payments_Orgs_OrgId",
+                table: "Payments",
+                column: "OrgId",
+                principalTable: "Orgs",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Properties_Orgs_OrgId",
+                table: "Properties",
+                column: "OrgId",
+                principalTable: "Orgs",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Users_Orgs_OrgId",
+                table: "Users",
+                column: "OrgId",
+                principalTable: "Orgs",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Bookings_Orgs_OrgId",
+                table: "Bookings");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_LeaseContracts_Orgs_OrgId",
+                table: "LeaseContracts");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Payments_Orgs_OrgId",
+                table: "Payments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Properties_Orgs_OrgId",
+                table: "Properties");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Users_Orgs_OrgId",
+                table: "Users");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "OrgId",
+                table: "Properties",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "OrgId",
+                table: "Payments",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "OrgId",
+                table: "LeaseContracts",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "OrgId",
+                table: "Bookings",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+    }
+}

--- a/Casazen.Infrastructure/Services/AdminService.cs
+++ b/Casazen.Infrastructure/Services/AdminService.cs
@@ -17,13 +17,32 @@ public class AdminService(
     private const string CinPattern = @"^IT-\d{5}-\d{10}$";
     private static readonly TimeSpan OtaSyncThreshold = TimeSpan.FromHours(6);
 
+    /// <summary>
+    /// Audits an AdminOnly read that deliberately bypasses the global tenant filter
+    /// (<c>IgnoreQueryFilters()</c>) to aggregate across every org (#202 F-H1, design §Security
+    /// Notes). Mirrors the structured-event style of <c>AdminAccessAuditService</c>.
+    /// </summary>
+    private void LogPrivilegedCrossOrgRead(string action) =>
+        logger.LogWarning(
+            "Privileged cross-org admin read: {Event} Action={Action} Scope={Scope} Timestamp={Timestamp}",
+            "PrivilegedCrossOrgRead",
+            action,
+            "platform-wide",
+            DateTime.UtcNow);
+
     public async Task<AdminStats> GetStatsAsync()
     {
         var now = DateTime.UtcNow;
         var startOfMonth = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        // Properties
-        var allProperties = await dbContext.Properties.ToListAsync();
+        // Platform-wide admin read (AdminOnly). The EF global tenant filter scopes the four tenant
+        // tables to the caller's org; admins typically have no org, so the dashboard would silently
+        // go empty. Per design §Security Notes this AdminOnly path BYPASSES the filter with
+        // IgnoreQueryFilters() — audited here as privileged cross-org access (#202 F-H1).
+        LogPrivilegedCrossOrgRead(nameof(GetStatsAsync));
+
+        // Properties (filter bypassed — platform-wide)
+        var allProperties = await dbContext.Properties.IgnoreQueryFilters().ToListAsync();
         var totalProperties = allProperties.Count;
         var activeProperties = allProperties.Count(p => p.IsActive);
 
@@ -33,14 +52,15 @@ public class AdminService(
         var cinInvalid = allProperties.Count(p => !string.IsNullOrWhiteSpace(p.CinCode) && !Regex.IsMatch(p.CinCode, CinPattern));
         var cinTotal = totalProperties;
 
-        // Bookings — server-side aggregates to avoid loading full table
-        var totalBookings = await dbContext.Bookings.CountAsync();
-        var bookingsThisMonth = await dbContext.Bookings.CountAsync(b => b.CreatedAt >= startOfMonth);
-        var upcomingCheckIns = await dbContext.Bookings.CountAsync(b =>
+        // Bookings — server-side aggregates to avoid loading full table (filter bypassed — platform-wide)
+        var totalBookings = await dbContext.Bookings.IgnoreQueryFilters().CountAsync();
+        var bookingsThisMonth = await dbContext.Bookings.IgnoreQueryFilters().CountAsync(b => b.CreatedAt >= startOfMonth);
+        var upcomingCheckIns = await dbContext.Bookings.IgnoreQueryFilters().CountAsync(b =>
             b.Status == BookingStatus.Confirmed && b.CheckInDate >= now);
 
-        // Revenue — sum of completed payments
+        // Revenue — sum of completed payments (filter bypassed — platform-wide)
         var totalRevenue = await dbContext.Payments
+            .IgnoreQueryFilters()
             .Where(p => p.Status == PaymentStatus.Completed)
             .SumAsync(p => (decimal?)p.Amount) ?? 0m;
 
@@ -78,7 +98,11 @@ public class AdminService(
             throw new ArgumentException($"Unknown cinStatus value '{cinStatus}'", nameof(cinStatus));
         }
 
-        var properties = await dbContext.Properties.ToListAsync();
+        // Platform-wide admin read (AdminOnly): the CIN-compliance (D.L. 145/2023) report covers
+        // every org, so it BYPASSES the global tenant filter with an audit line (#202 F-H1).
+        LogPrivilegedCrossOrgRead(nameof(GetCinComplianceAsync));
+
+        var properties = await dbContext.Properties.IgnoreQueryFilters().ToListAsync();
 
         // Resolve owner emails from user table (best-effort; user may not exist in DB yet)
         var ownerIds = properties.Select(p => p.OwnerId).Distinct().ToList();

--- a/Casazen.Infrastructure/Services/EntitlementService.cs
+++ b/Casazen.Infrastructure/Services/EntitlementService.cs
@@ -1,0 +1,59 @@
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Services;
+using Casazen.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+namespace Casazen.Infrastructure.Services;
+
+/// <summary>
+/// Enforces per-tier plan limits (AC8). Limits come from a tier→limits map in configuration
+/// (<c>Entitlement:Tiers:{tier}:MaxProperties</c>) with provisional defaults; <c>spec-saas-billing</c>
+/// owns the final commercial numbers, so reconciliation is config-only (no migration).
+/// </summary>
+public class EntitlementService(AppDbContext dbContext, IConfiguration configuration) : IEntitlementService
+{
+    // Provisional defaults (design Open Question #4): Starter = 3, Pro = 50, Scale = unlimited.
+    private static readonly IReadOnlyDictionary<PlanTier, int> DefaultMaxProperties = new Dictionary<PlanTier, int>
+    {
+        [PlanTier.Starter] = 3,
+        [PlanTier.Pro] = 50,
+        [PlanTier.Scale] = int.MaxValue,
+    };
+
+    public async Task<EntitlementResult> GetEntitlementAsync(Guid orgId, CancellationToken cancellationToken = default)
+    {
+        var planTier = await dbContext.Orgs.AsNoTracking()
+            .Where(o => o.Id == orgId)
+            .Select(o => (PlanTier?)o.PlanTier)
+            .FirstOrDefaultAsync(cancellationToken) ?? PlanTier.Starter;
+
+        var maxProperties = ResolveMaxProperties(planTier);
+
+        // Count is scoped to the explicit orgId. Under an authenticated request the tenant filter
+        // also constrains to the caller's org (which equals orgId), so the count is identical.
+        var propertyCount = await dbContext.Properties
+            .CountAsync(p => p.OrgId == orgId, cancellationToken);
+
+        return new EntitlementResult(
+            orgId,
+            planTier.ToString(),
+            maxProperties,
+            propertyCount,
+            propertyCount < maxProperties);
+    }
+
+    public async Task<bool> CanAddPropertyAsync(Guid orgId, CancellationToken cancellationToken = default) =>
+        (await GetEntitlementAsync(orgId, cancellationToken)).CanAddProperty;
+
+    private int ResolveMaxProperties(PlanTier tier)
+    {
+        var configured = configuration[$"Entitlement:Tiers:{tier}:MaxProperties"];
+        if (int.TryParse(configured, out var value) && value > 0)
+            return value;
+
+        return DefaultMaxProperties.TryGetValue(tier, out var fallback)
+            ? fallback
+            : DefaultMaxProperties[PlanTier.Starter];
+    }
+}

--- a/Casazen.Infrastructure/Services/OrgService.cs
+++ b/Casazen.Infrastructure/Services/OrgService.cs
@@ -1,0 +1,31 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Services;
+using Casazen.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Casazen.Infrastructure.Services;
+
+/// <summary>
+/// Read access to <see cref="Org"/> tenants (US-004). <see cref="Org"/> is not subject to the
+/// tenant query filter, so these reads are explicit by id/slug/user and never widen tenant scope.
+/// </summary>
+public class OrgService(AppDbContext dbContext) : IOrgService
+{
+    public Task<Org?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default) =>
+        dbContext.Orgs.AsNoTracking().FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
+
+    public async Task<Org?> GetByUserIdAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        var orgId = await dbContext.Users.AsNoTracking()
+            .Where(u => u.Id == userId)
+            .Select(u => u.OrgId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return orgId is null
+            ? null
+            : await dbContext.Orgs.AsNoTracking().FirstOrDefaultAsync(o => o.Id == orgId, cancellationToken);
+    }
+
+    public Task<Org?> GetPublicBySlugAsync(string slug, CancellationToken cancellationToken = default) =>
+        dbContext.Orgs.AsNoTracking().FirstOrDefaultAsync(o => o.Slug == slug && o.IsActive, cancellationToken);
+}

--- a/Casazen.Tests/Integration/CasazenWebApplicationFactory.cs
+++ b/Casazen.Tests/Integration/CasazenWebApplicationFactory.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
 using Casazen.Core.Services;
 using Casazen.Infrastructure.Data;
 using Hangfire;
@@ -80,9 +81,12 @@ public class CasazenWebApplicationFactory : WebApplicationFactory<Program>
         using var scope = Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
+        var org = await EnsureOrgAsync(db, ownerId);
+
         var property = new Property
         {
             OwnerId = ownerId,
+            OrgId = org.Id,
             Name = "Pricing Integration Property",
             Description = "Integration test property",
             Address = $"Via Test {Guid.NewGuid():N}",
@@ -105,6 +109,59 @@ public class CasazenWebApplicationFactory : WebApplicationFactory<Program>
         db.Properties.Add(property);
         await db.SaveChangesAsync();
         return property;
+    }
+
+    /// <summary>
+    /// Finds or creates the default <see cref="Org"/> for an owner and ensures the owner's
+    /// <see cref="User"/> row carries its <c>OrgId</c>, so the tenant query filter makes seeded
+    /// rows visible to the authenticated owner (US-004). Returns the owner's org.
+    /// </summary>
+    public async Task<Org> SeedOrgForOwnerAsync(string ownerId = TestAuthHandler.DefaultUserId)
+    {
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var org = await EnsureOrgAsync(db, ownerId);
+        await db.SaveChangesAsync();
+        return org;
+    }
+
+    private static async Task<Org> EnsureOrgAsync(AppDbContext db, string ownerId)
+    {
+        var slug = $"test-org-{ownerId}";
+        var org = await db.Orgs.FirstOrDefaultAsync(o => o.Slug == slug);
+        if (org is null)
+        {
+            org = new Org
+            {
+                Name = $"Org {ownerId}",
+                Slug = slug,
+                DisplayName = $"Org {ownerId}",
+                ContactEmail = "owner@example.com",
+                PlanTier = PlanTier.Starter,
+                IsActive = true,
+            };
+            db.Orgs.Add(org);
+        }
+
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Id == ownerId);
+        if (user is null)
+        {
+            db.Users.Add(new User
+            {
+                Id = ownerId,
+                Email = $"{Guid.NewGuid():N}@example.com",
+                FirstName = "Test",
+                LastName = "Owner",
+                OrgId = org.Id,
+                IsActive = true,
+            });
+        }
+        else if (user.OrgId is null)
+        {
+            user.OrgId = org.Id;
+        }
+
+        return org;
     }
 
     public async Task SeedPricingHistoryAsync(Guid propertyId, int count = 3)

--- a/Casazen.Tests/Integration/OrgBackfillSimulationTests.cs
+++ b/Casazen.Tests/Integration/OrgBackfillSimulationTests.cs
@@ -1,0 +1,153 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Casazen.Tests.Integration;
+
+/// <summary>
+/// AC4/AC10 — backfill mapping rules. The production backfill ships as raw PostgreSQL in the
+/// <c>BackfillDefaultOrgs</c> migration (validated provider-accurately in <c>MigrationSqlTests</c>).
+/// Because the test harness runs on the EF in-memory provider (no Postgres/Docker), this test
+/// mirrors the migration's logical steps (one Org per distinct OwnerId → set User.OrgId →
+/// relationship-walk OrgId onto Property/Booking/Payment/Lease) and asserts the invariants the
+/// design's AC10 regression guarantees: each owner's rows land under their own default Org, no
+/// orphans remain, distinct owners never share an Org, and the operation is idempotent.
+/// <c>Guid.Empty</c> stands in for the pre-migration "NULL OrgId".
+/// </summary>
+public class OrgBackfillSimulationTests
+{
+    private const string OwnerA = "auth0|owner-a";
+    private const string OwnerB = "auth0|owner-b";
+
+    private static AppDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"backfill-{Guid.NewGuid()}")
+            .Options);
+
+    private static async Task SeedPreMigrationStateAsync(AppDbContext db)
+    {
+        db.Users.AddRange(
+            new User { Id = OwnerA, Email = "a@x.it", FirstName = "A", LastName = "Owner" },
+            new User { Id = OwnerB, Email = "b@x.it", FirstName = "B", LastName = "Owner" });
+
+        var a1 = new Property { Id = Guid.NewGuid(), OwnerId = OwnerA, OrgId = Guid.Empty, Name = "A1", Address = "A", City = "Rome" };
+        var a2 = new Property { Id = Guid.NewGuid(), OwnerId = OwnerA, OrgId = Guid.Empty, Name = "A2", Address = "A", City = "Rome" };
+        var b1 = new Property { Id = Guid.NewGuid(), OwnerId = OwnerB, OrgId = Guid.Empty, Name = "B1", Address = "A", City = "Milan" };
+        db.Properties.AddRange(a1, a2, b1);
+
+        var bookingA = new Booking { Id = Guid.NewGuid(), PropertyId = a1.Id, GuestId = Guid.NewGuid(), OrgId = Guid.Empty };
+        var bookingB = new Booking { Id = Guid.NewGuid(), PropertyId = b1.Id, GuestId = Guid.NewGuid(), OrgId = Guid.Empty };
+        db.Bookings.AddRange(bookingA, bookingB);
+
+        db.Payments.Add(new Payment { Id = Guid.NewGuid(), BookingId = bookingA.Id, OrgId = Guid.Empty, Amount = 100m });
+        db.LeaseContracts.Add(new LeaseContract { Id = Guid.NewGuid(), PropertyId = b1.Id, OrgId = Guid.Empty, MonthlyRent = 500m });
+
+        await db.SaveChangesAsync();
+    }
+
+    /// <summary>Mirrors <c>BackfillDefaultOrgs</c> Up steps 1–4. Returns orgs created this run.</summary>
+    private static async Task RunBackfillAsync(AppDbContext db)
+    {
+        // 1) One default Org per distinct Property.OwnerId (idempotent on slug).
+        var owners = await db.Properties.Select(p => p.OwnerId).Distinct().ToListAsync();
+        foreach (var owner in owners)
+        {
+            var slug = $"org-{owner}";
+            if (!await db.Orgs.AnyAsync(o => o.Slug == slug))
+            {
+                db.Orgs.Add(new Org { Name = owner, Slug = slug, DisplayName = owner, ContactEmail = "", PlanTier = PlanTier.Starter, IsActive = true });
+            }
+        }
+        await db.SaveChangesAsync();
+
+        var orgBySlug = await db.Orgs.ToDictionaryAsync(o => o.Slug, o => o.Id);
+
+        // 2) Link each owner's User row to their Org.
+        foreach (var user in await db.Users.Where(u => u.OrgId == null).ToListAsync())
+        {
+            if (orgBySlug.TryGetValue($"org-{user.Id}", out var orgId))
+                user.OrgId = orgId;
+        }
+
+        // 3) Relationship walk (only the unassigned sentinel).
+        foreach (var p in await db.Properties.Where(p => p.OrgId == Guid.Empty).ToListAsync())
+            p.OrgId = orgBySlug[$"org-{p.OwnerId}"];
+        await db.SaveChangesAsync();
+
+        var propOrg = await db.Properties.ToDictionaryAsync(p => p.Id, p => p.OrgId);
+        foreach (var b in await db.Bookings.Where(b => b.OrgId == Guid.Empty).ToListAsync())
+            b.OrgId = propOrg[b.PropertyId];
+
+        var bookingOrg = await db.Bookings.ToDictionaryAsync(b => b.Id, b => b.OrgId);
+        foreach (var pay in await db.Payments.Where(p => p.OrgId == Guid.Empty).ToListAsync())
+            pay.OrgId = bookingOrg[pay.BookingId];
+
+        foreach (var l in await db.LeaseContracts.Where(l => l.OrgId == Guid.Empty).ToListAsync())
+            l.OrgId = propOrg[l.PropertyId];
+
+        // 4) Fallback Org (quarantine target).
+        if (!await db.Orgs.AnyAsync(o => o.Slug == "casazen-unassigned"))
+            db.Orgs.Add(new Org { Name = "CasaZen Unassigned", Slug = "casazen-unassigned", DisplayName = "CasaZen Unassigned", ContactEmail = "", PlanTier = PlanTier.Starter, IsActive = false });
+
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Backfill_CreatesOneOrgPerOwner_AndAssignsRowsByRelationshipWalk()
+    {
+        await using var db = NewDb();
+        await SeedPreMigrationStateAsync(db);
+
+        await RunBackfillAsync(db);
+
+        // One default org per distinct owner (2) + the fallback org.
+        Assert.Equal(2, await db.Orgs.CountAsync(o => o.Slug.StartsWith("org-")));
+        Assert.True(await db.Orgs.AnyAsync(o => o.Slug == "casazen-unassigned"));
+
+        var orgA = (await db.Users.SingleAsync(u => u.Id == OwnerA)).OrgId;
+        var orgB = (await db.Users.SingleAsync(u => u.Id == OwnerB)).OrgId;
+        Assert.NotNull(orgA);
+        Assert.NotNull(orgB);
+        Assert.NotEqual(orgA, orgB); // distinct owners never share an org (no cross-owner leak)
+
+        // Every Property/Booking/Payment/Lease assigned to the correct owner's org.
+        Assert.All(await db.Properties.Where(p => p.OwnerId == OwnerA).ToListAsync(), p => Assert.Equal(orgA, p.OrgId));
+        Assert.All(await db.Properties.Where(p => p.OwnerId == OwnerB).ToListAsync(), p => Assert.Equal(orgB, p.OrgId));
+        Assert.Equal(orgA, (await db.Payments.SingleAsync()).OrgId);       // payment→booking→A1→orgA
+        Assert.Equal(orgB, (await db.LeaseContracts.SingleAsync()).OrgId); // lease→B1→orgB
+    }
+
+    [Fact]
+    public async Task Backfill_LeavesNoOrphans()
+    {
+        await using var db = NewDb();
+        await SeedPreMigrationStateAsync(db);
+
+        await RunBackfillAsync(db);
+
+        // AC10b pre-flight precondition: zero tenant-scoped rows remain unassigned.
+        Assert.False(await db.Properties.AnyAsync(p => p.OrgId == Guid.Empty));
+        Assert.False(await db.Bookings.AnyAsync(b => b.OrgId == Guid.Empty));
+        Assert.False(await db.Payments.AnyAsync(p => p.OrgId == Guid.Empty));
+        Assert.False(await db.LeaseContracts.AnyAsync(l => l.OrgId == Guid.Empty));
+    }
+
+    [Fact]
+    public async Task Backfill_IsIdempotent()
+    {
+        await using var db = NewDb();
+        await SeedPreMigrationStateAsync(db);
+
+        await RunBackfillAsync(db);
+        var orgsAfterFirst = await db.Orgs.CountAsync();
+        var assignmentsAfterFirst = await db.Properties.Select(p => new { p.Id, p.OrgId }).ToListAsync();
+
+        await RunBackfillAsync(db); // re-run
+
+        Assert.Equal(orgsAfterFirst, await db.Orgs.CountAsync()); // no duplicate orgs
+        var assignmentsAfterSecond = await db.Properties.Select(p => new { p.Id, p.OrgId }).ToListAsync();
+        Assert.Equal(assignmentsAfterFirst.OrderBy(x => x.Id), assignmentsAfterSecond.OrderBy(x => x.Id));
+    }
+}

--- a/Casazen.Tests/Integration/PricingAdapterIntegrationTests.cs
+++ b/Casazen.Tests/Integration/PricingAdapterIntegrationTests.cs
@@ -176,24 +176,28 @@ public class PricingAdapterIntegrationTests : IClassFixture<CasazenWebApplicatio
     }
 
     [Fact]
-    public async Task AC8_NonOwner_OnAllEndpoints_ReturnsForbidden()
+    public async Task AC8_CrossOrgUser_OnAllEndpoints_ReturnsNotFound()
     {
+        // After US-004 (#202) the EF global tenant filter scopes property reads to the caller's
+        // org. A user from another org (here: one with no org at all) cannot see the property,
+        // so every property-scoped endpoint returns 404 — never another org's row, and never 403
+        // (which would leak the property's existence). This is the tenant-isolation contract.
         var property = await _factory.SeedPropertyAsync(ownerId: TestAuthHandler.DefaultUserId);
         var otherClient = _factory.CreateAuthenticatedClient(userId: "auth0|other-user-456");
         var propertyId = property.Id;
 
         var save = await otherClient.PostAsJsonAsync($"/api/pricing-adapter/config/{propertyId}", ConfigRequest());
-        Assert.Equal(HttpStatusCode.Forbidden, save.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, save.StatusCode);
 
         // Seed config as owner for remaining endpoints
         var ownerClient = _factory.CreateAuthenticatedClient();
         await ownerClient.PostAsJsonAsync($"/api/pricing-adapter/config/{propertyId}", ConfigRequest());
 
-        Assert.Equal(HttpStatusCode.Forbidden, (await otherClient.GetAsync($"/api/pricing-adapter/config/{propertyId}")).StatusCode);
-        Assert.Equal(HttpStatusCode.Forbidden, (await otherClient.DeleteAsync($"/api/pricing-adapter/config/{propertyId}")).StatusCode);
-        Assert.Equal(HttpStatusCode.Forbidden, (await otherClient.GetAsync($"/api/pricing-adapter/preview/{propertyId}")).StatusCode);
-        Assert.Equal(HttpStatusCode.Forbidden, (await otherClient.PostAsync($"/api/pricing-adapter/sync/{propertyId}", null)).StatusCode);
-        Assert.Equal(HttpStatusCode.Forbidden, (await otherClient.GetAsync($"/api/pricing-adapter/history/{propertyId}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await otherClient.GetAsync($"/api/pricing-adapter/config/{propertyId}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await otherClient.DeleteAsync($"/api/pricing-adapter/config/{propertyId}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await otherClient.GetAsync($"/api/pricing-adapter/preview/{propertyId}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await otherClient.PostAsync($"/api/pricing-adapter/sync/{propertyId}", null)).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await otherClient.GetAsync($"/api/pricing-adapter/history/{propertyId}")).StatusCode);
     }
 
     [Fact]

--- a/Casazen.Tests/Integration/TenantBoundaryIntegrationTests.cs
+++ b/Casazen.Tests/Integration/TenantBoundaryIntegrationTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Xunit;
+
+namespace Casazen.Tests.Integration;
+
+/// <summary>
+/// US-004 (#202) tenant boundary over HTTP. Exercises the real request pipeline (auth + EF global
+/// tenant filter + entitlement) on the in-memory harness:
+/// AC7 cross-org reads return 404/empty, AC8 plan entitlement, AC9 /me returns org, AC10 an owner
+/// still sees exactly their own rows post-tenant-scoping. Each test uses a unique owner so the
+/// shared class-fixture in-memory store cannot leak property counts between tests.
+/// </summary>
+public class TenantBoundaryIntegrationTests : IClassFixture<CasazenWebApplicationFactory>
+{
+    private readonly CasazenWebApplicationFactory _factory;
+    private static readonly JsonSerializerOptions Json = new() { PropertyNameCaseInsensitive = true };
+
+    public TenantBoundaryIntegrationTests(CasazenWebApplicationFactory factory) => _factory = factory;
+
+    private static string NewOwner() => $"auth0|owner-{Guid.NewGuid():N}";
+
+    private static object ValidPropertyBody() => new
+    {
+        name = "Nuovo Appartamento",
+        address = "Via Roma 1",
+        city = "Rome",
+        bedrooms = 2,
+        bathrooms = 1,
+        maxGuests = 4,
+        nightlyRate = 90m,
+        cinCode = "IT-12345-0123456789",
+    };
+
+    [Fact]
+    public async Task AC9_GetMe_ReturnsCallerOrg()
+    {
+        var owner = NewOwner();
+        await _factory.SeedPropertyAsync(ownerId: owner);
+        var client = _factory.CreateAuthenticatedClient(userId: owner);
+
+        var response = await client.GetAsync("/api/users/me");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        Assert.NotEqual(JsonValueKind.Null, root.GetProperty("orgId").ValueKind);
+        var org = root.GetProperty("org");
+        Assert.NotEqual(JsonValueKind.Null, org.ValueKind);
+        Assert.False(string.IsNullOrWhiteSpace(org.GetProperty("slug").GetString()));
+        Assert.Equal("Starter", org.GetProperty("planTier").GetString());
+    }
+
+    [Fact]
+    public async Task AC8_GetEntitlement_ReturnsTierLimitsAndUsage()
+    {
+        var owner = NewOwner();
+        await _factory.SeedPropertyAsync(ownerId: owner);
+        var client = _factory.CreateAuthenticatedClient(userId: owner, roles: "PropertyOwner");
+
+        var response = await client.GetAsync("/api/orgs/me/entitlement");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        Assert.Equal("Starter", root.GetProperty("planTier").GetString());
+        Assert.Equal(3, root.GetProperty("limits").GetProperty("maxProperties").GetInt32());
+        Assert.Equal(1, root.GetProperty("usage").GetProperty("properties").GetInt32());
+        Assert.True(root.GetProperty("canAddProperty").GetBoolean());
+    }
+
+    [Fact]
+    public async Task AC8_CreateProperty_OverStarterLimit_Returns403PlanLimitReached()
+    {
+        var owner = NewOwner();
+        // Starter limit is 3 — seed the org to exactly the limit.
+        await _factory.SeedPropertyAsync(ownerId: owner);
+        await _factory.SeedPropertyAsync(ownerId: owner);
+        await _factory.SeedPropertyAsync(ownerId: owner);
+        var client = _factory.CreateAuthenticatedClient(userId: owner, roles: "PropertyOwner");
+
+        var response = await client.PostAsJsonAsync("/api/properties", ValidPropertyBody());
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("plan_limit_reached", doc.RootElement.GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public async Task AC7_CrossOrg_GetPropertyById_Returns404_AndListExcludesIt()
+    {
+        var ownerA = NewOwner();
+        var ownerB = NewOwner();
+        var propertyA = await _factory.SeedPropertyAsync(ownerId: ownerA);
+        await _factory.SeedOrgForOwnerAsync(ownerId: ownerB); // B has its own org, no properties
+
+        var clientB = _factory.CreateAuthenticatedClient(userId: ownerB, roles: "PropertyOwner");
+
+        // Direct cross-org read is filtered out at the data layer → 404 (never another org's row).
+        var byId = await clientB.GetAsync($"/api/properties/{propertyA.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, byId.StatusCode);
+
+        // B's collection never contains A's property.
+        var list = await clientB.GetAsync("/api/properties");
+        Assert.Equal(HttpStatusCode.OK, list.StatusCode);
+        using var doc = JsonDocument.Parse(await list.Content.ReadAsStringAsync());
+        var ids = doc.RootElement.EnumerateArray().Select(e => e.GetProperty("id").GetGuid());
+        Assert.DoesNotContain(propertyA.Id, ids);
+    }
+
+    [Fact]
+    public async Task AC10_Owner_StillSeesOwnRows_PostTenantScoping()
+    {
+        var owner = NewOwner();
+        var property = await _factory.SeedPropertyAsync(ownerId: owner);
+        var client = _factory.CreateAuthenticatedClient(userId: owner, roles: "PropertyOwner");
+
+        var byId = await client.GetAsync($"/api/properties/{property.Id}");
+        Assert.Equal(HttpStatusCode.OK, byId.StatusCode);
+
+        var list = await client.GetAsync("/api/properties");
+        Assert.Equal(HttpStatusCode.OK, list.StatusCode);
+        using var doc = JsonDocument.Parse(await list.Content.ReadAsStringAsync());
+        var ids = doc.RootElement.EnumerateArray().Select(e => e.GetProperty("id").GetGuid());
+        Assert.Contains(property.Id, ids);
+    }
+}

--- a/Casazen.Tests/Integration/TestAuthHandler.cs
+++ b/Casazen.Tests/Integration/TestAuthHandler.cs
@@ -30,7 +30,12 @@ public class TestAuthHandler(
         if (!string.IsNullOrWhiteSpace(rolesHeader))
         {
             foreach (var role in rolesHeader.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
                 claims.Add(new Claim(ClaimTypes.Role, role));
+                // Mirror the Auth0 custom-roles claim so context-permission fallback resolves
+                // (ContextAuthorizationService reads "https://casazen.app/roles"), matching prod JWTs.
+                claims.Add(new Claim("https://casazen.app/roles", role));
+            }
         }
 
         var identity = new ClaimsIdentity(claims, SchemeName);

--- a/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Casazen.Core.DTOs;
 using Casazen.Core.Entities;
 using Casazen.Core.Enums;
+using Casazen.Core.Multitenancy;
 using Casazen.Core.Services;
 using Casazen.Web.Controllers;
 using Casazen.Web.DTOs;
@@ -20,6 +21,8 @@ public class PropertiesControllerTests
     private readonly Mock<IPropertyAuthorizationService> _mockAuthz;
     private readonly Mock<IPropertyDocumentService> _mockDocumentService;
     private readonly Mock<IAdminAccessAuditService> _mockAuditService;
+    private readonly Mock<ITenantContext> _mockTenantContext;
+    private readonly Mock<IEntitlementService> _mockEntitlementService;
     private readonly Mock<ILogger<PropertiesController>> _mockLogger;
     private readonly PropertiesController _controller;
 
@@ -30,6 +33,8 @@ public class PropertiesControllerTests
         _mockAuthz = new Mock<IPropertyAuthorizationService>();
         _mockDocumentService = new Mock<IPropertyDocumentService>();
         _mockAuditService = new Mock<IAdminAccessAuditService>();
+        _mockTenantContext = new Mock<ITenantContext>();
+        _mockEntitlementService = new Mock<IEntitlementService>();
         _mockLogger = new Mock<ILogger<PropertiesController>>();
         _controller = new PropertiesController(
             _mockService.Object,
@@ -37,8 +42,19 @@ public class PropertiesControllerTests
             _mockAuthz.Object,
             _mockDocumentService.Object,
             _mockAuditService.Object,
+            _mockTenantContext.Object,
+            _mockEntitlementService.Object,
             _mockLogger.Object);
+
+        // Defaults: caller has an org and is under the plan limit. Create-path tests that need
+        // the opposite (no org / limit reached) override these per-test.
+        _mockTenantContext.SetupGet(x => x.OrgId).Returns(DefaultOrgId);
+        _mockEntitlementService
+            .Setup(x => x.CanAddPropertyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
     }
+
+    private static readonly Guid DefaultOrgId = Guid.Parse("00000000-0000-0000-0000-0000000000aa");
 
     private void AllowAuthorization() =>
         _mockAuthz.Setup(x => x.CanAccess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>())).Returns(true);

--- a/Casazen.Tests/Unit/Infrastructure/MigrationSqlTests.cs
+++ b/Casazen.Tests/Unit/Infrastructure/MigrationSqlTests.cs
@@ -1,0 +1,120 @@
+using Casazen.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Infrastructure;
+
+/// <summary>
+/// AC3/AC4/AC5/AC10b — migration correctness. Generates the REAL PostgreSQL migration script
+/// from the Npgsql provider (no database connection required) and asserts the shipped SQL has
+/// the safety properties the design mandates: nullable add → idempotent relationship-walk
+/// backfill → pre-flight NULL guard before the NOT-NULL flip + restricted FKs, with a tested
+/// down-migration. This is the Docker-free equivalent of running the migration end-to-end.
+/// </summary>
+public class MigrationSqlTests
+{
+    private static AppDbContext NewNpgsqlContext() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(
+                "Host=localhost;Database=casazen_design;Username=postgres;Password=postgres",
+                npgsql => npgsql.MigrationsAssembly("Casazen.Infrastructure"))
+            .Options);
+
+    private static (string addNullable, string backfill, string makeRequired) MigrationIds(AppDbContext db)
+    {
+        var keys = db.GetService<IMigrationsAssembly>().Migrations.Keys.ToList();
+        return (
+            keys.Single(k => k.EndsWith("AddOrgIdNullable", StringComparison.Ordinal)),
+            keys.Single(k => k.EndsWith("BackfillDefaultOrgs", StringComparison.Ordinal)),
+            keys.Single(k => k.EndsWith("MakeOrgIdRequired", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void Migrations_LandInOrder_AsTheLastThree() // AC3/AC5 ordering
+    {
+        using var db = NewNpgsqlContext();
+        var keys = db.GetService<IMigrationsAssembly>().Migrations.Keys.ToList();
+
+        var lastThree = keys.TakeLast(3).ToList();
+        Assert.EndsWith("AddOrgIdNullable", lastThree[0]);
+        Assert.EndsWith("BackfillDefaultOrgs", lastThree[1]);
+        Assert.EndsWith("MakeOrgIdRequired", lastThree[2]);
+    }
+
+    [Fact]
+    public void Step1_AddOrgIdNullable_CreatesOrgTableAndUniqueSlugIndex() // AC3
+    {
+        using var db = NewNpgsqlContext();
+        var (_, backfill, _) = MigrationIds(db);
+        var migrator = db.GetService<IMigrator>();
+
+        // Up to (but excluding) the backfill == just Step 1.
+        var script = migrator.GenerateScript(toMigration: backfill);
+
+        Assert.Contains("CREATE TABLE \"Orgs\"", script);
+        Assert.Contains("IX_Orgs_Slug", script);
+        Assert.Contains("ADD \"OrgId\" uuid", script); // nullable add (no NOT NULL)
+        Assert.Contains("\"StripeConnectedAccountId\"", script);
+        Assert.DoesNotContain("SET NOT NULL", script); // Step 1 must not flip nullability
+    }
+
+    [Fact]
+    public void Step2_BackfillDefaultOrgs_IsIdempotentRelationshipWalkWithFallbackAndLog() // AC4
+    {
+        using var db = NewNpgsqlContext();
+        var migrator = db.GetService<IMigrator>();
+        var fullScript = migrator.GenerateScript();
+
+        Assert.Contains("ON CONFLICT (\"Slug\") DO NOTHING", fullScript); // idempotent org insert
+        Assert.Contains("casazen-unassigned", fullScript);                // dedicated fallback Org
+        Assert.Contains("RAISE NOTICE", fullScript);                      // verified row-count log
+        // Relationship walk: payments derive their org from their booking.
+        Assert.Contains("UPDATE \"Payments\"", fullScript);
+        Assert.Contains("UPDATE \"Bookings\"", fullScript);
+        Assert.Contains("UPDATE \"LeaseContracts\"", fullScript);
+    }
+
+    [Fact]
+    public void Step3_MakeOrgIdRequired_GuardsThenFlipsNotNullAndAddsRestrictedFks() // AC5/AC10b
+    {
+        using var db = NewNpgsqlContext();
+        var migrator = db.GetService<IMigrator>();
+        var fullScript = migrator.GenerateScript();
+
+        // Pre-flight NULL guard fires before any NOT-NULL flip (fail loud, never silent).
+        Assert.Contains("RAISE EXCEPTION", fullScript);
+        Assert.Contains("Pre-flight failed", fullScript);
+        Assert.True(
+            fullScript.IndexOf("Pre-flight failed", StringComparison.Ordinal)
+            < fullScript.IndexOf("SET NOT NULL", StringComparison.Ordinal),
+            "Pre-flight NULL guard must precede the NOT-NULL flip");
+
+        Assert.Contains("SET NOT NULL", fullScript);
+        foreach (var fk in new[]
+        {
+            "FK_Properties_Orgs_OrgId", "FK_Bookings_Orgs_OrgId",
+            "FK_LeaseContracts_Orgs_OrgId", "FK_Payments_Orgs_OrgId", "FK_Users_Orgs_OrgId",
+        })
+        {
+            Assert.Contains(fk, fullScript);
+        }
+
+        Assert.Contains("ON DELETE RESTRICT", fullScript);
+    }
+
+    [Fact]
+    public void Step3_MakeOrgIdRequired_DownReverts_FksAndNullability() // AC10b (tested down)
+    {
+        using var db = NewNpgsqlContext();
+        var (_, backfill, makeRequired) = MigrationIds(db);
+        var migrator = db.GetService<IMigrator>();
+
+        // Down of Step 3 only: from MakeOrgIdRequired back to BackfillDefaultOrgs.
+        var down = migrator.GenerateScript(fromMigration: makeRequired, toMigration: backfill);
+
+        Assert.Contains("DROP CONSTRAINT \"FK_Properties_Orgs_OrgId\"", down);
+        Assert.Contains("DROP NOT NULL", down);
+    }
+}

--- a/Casazen.Tests/Unit/Infrastructure/MultiTenancyModelTests.cs
+++ b/Casazen.Tests/Unit/Infrastructure/MultiTenancyModelTests.cs
@@ -1,0 +1,69 @@
+using Casazen.Core.Entities;
+using Casazen.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Infrastructure;
+
+/// <summary>
+/// AC1/AC2/AC6/AC9 — model shape. Asserts the EF model (the same metadata the regenerated
+/// snapshot is built from) carries the Org tenant key, the unique Slug index, and a restricted
+/// OrgId FK + index on every tenant-scoped table, with User.OrgId nullable.
+/// </summary>
+public class MultiTenancyModelTests
+{
+    private static AppDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"model-{Guid.NewGuid()}")
+            .Options);
+
+    [Fact]
+    public void Org_HasUniqueIndexOnSlug() // AC1
+    {
+        using var db = NewDb();
+        var org = db.Model.FindEntityType(typeof(Org))!;
+
+        var slugIndex = org.GetIndexes().SingleOrDefault(i => i.Properties.Any(p => p.Name == nameof(Org.Slug)));
+
+        Assert.NotNull(slugIndex);
+        Assert.True(slugIndex!.IsUnique);
+    }
+
+    [Theory]
+    [InlineData(typeof(Property))] // AC2
+    [InlineData(typeof(Booking))]
+    [InlineData(typeof(LeaseContract))]
+    [InlineData(typeof(Payment))]
+    public void TenantEntity_HasRequiredRestrictedOrgIdFkAndIndex(Type clrType)
+    {
+        using var db = NewDb();
+        var entity = db.Model.FindEntityType(clrType)!;
+
+        var fk = entity.GetForeignKeys().Single(f => f.PrincipalEntityType.ClrType == typeof(Org));
+        Assert.Equal("OrgId", fk.Properties.Single().Name);
+        Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior);
+        Assert.False(fk.Properties.Single().IsNullable); // OrgId is required on tenant tables
+
+        Assert.Contains(entity.GetIndexes(), i => i.Properties.Any(p => p.Name == "OrgId"));
+    }
+
+    [Fact]
+    public void User_HasNullableRestrictedOrgIdFk() // AC9
+    {
+        using var db = NewDb();
+        var user = db.Model.FindEntityType(typeof(User))!;
+
+        var fk = user.GetForeignKeys().Single(f => f.PrincipalEntityType.ClrType == typeof(Org));
+        Assert.Equal("OrgId", fk.Properties.Single().Name);
+        Assert.True(fk.Properties.Single().IsNullable); // brand-new user pre-backfill has none
+        Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior);
+    }
+
+    [Fact]
+    public void Org_IsRegisteredAsDbSet() // AC1
+    {
+        using var db = NewDb();
+        Assert.NotNull(db.Model.FindEntityType(typeof(Org)));
+    }
+}

--- a/Casazen.Tests/Unit/Services/AdminServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/AdminServiceTests.cs
@@ -1,4 +1,6 @@
 using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Multitenancy;
 using Casazen.Infrastructure.Data;
 using Casazen.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
@@ -18,8 +20,30 @@ public class AdminServiceTests
         return new AppDbContext(options);
     }
 
+    /// <summary>
+    /// Builds an <see cref="AppDbContext"/> wired to a REAL authenticated <see cref="ITenantContext"/>
+    /// (filter ENABLED, scoped to <paramref name="callerOrgId"/>). This deliberately differs from
+    /// <see cref="CreateInMemoryContext"/> / <c>new AppDbContext(options)</c>, which fall back to
+    /// <c>NullTenantContext</c> and disable the global tenant filter — the very condition that
+    /// masked the #202 F-H1 admin cross-org regression.
+    /// </summary>
+    private static AppDbContext CreateTenantScopedContext(string dbName, Guid callerOrgId)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        return new AppDbContext(options, new AuthenticatedTenantContext(callerOrgId));
+    }
+
     private static AdminService CreateService(AppDbContext ctx) =>
         new AdminService(ctx, new Mock<ILogger<AdminService>>().Object);
+
+    /// <summary>Authenticated tenant context: the global query filter is ON and scoped to one org.</summary>
+    private sealed class AuthenticatedTenantContext(Guid orgId) : ITenantContext
+    {
+        public Guid? OrgId { get; } = orgId;
+        public bool FilterEnabled => true;
+    }
 
     // ─── GetStatsAsync ──────────────────────────────────────────────────────
 
@@ -64,6 +88,84 @@ public class AdminServiceTests
         Assert.Equal(1, stats.CinValid);
         Assert.Equal(1, stats.CinMissing);
         Assert.Equal(1, stats.CinInvalid);
+    }
+
+    // ─── F-H1 regression: admin reads must bypass the tenant filter (cross-org) ──
+
+    [Fact]
+    public async Task GetStatsAsync_AuthenticatedAdminContext_ReturnsPlatformWideTotalsAcrossAllOrgs()
+    {
+        // Regression for #202 F-H1. The global tenant filter must NOT scope platform-wide admin
+        // reads. We exercise the REAL filter: AppDbContext is built with an authenticated
+        // ITenantContext (scoped to orgA), NOT new AppDbContext(options) (NullTenantContext →
+        // filter disabled), which is exactly what masked this bug. Two distinct orgs are seeded;
+        // GetStatsAsync must aggregate BOTH orgs (IgnoreQueryFilters). Without the fix the caller's
+        // org alone is counted (1 / 1 / 1 / €100) and every assertion below fails.
+        var orgA = Guid.NewGuid();
+        var orgB = Guid.NewGuid();
+        using var ctx = CreateTenantScopedContext(
+            nameof(GetStatsAsync_AuthenticatedAdminContext_ReturnsPlatformWideTotalsAcrossAllOrgs),
+            callerOrgId: orgA);
+
+        ctx.Orgs.AddRange(
+            new Org { Id = orgA, Name = "Org A", Slug = "org-a", DisplayName = "Org A", ContactEmail = "a@x.io", PlanTier = PlanTier.Starter },
+            new Org { Id = orgB, Name = "Org B", Slug = "org-b", DisplayName = "Org B", ContactEmail = "b@x.io", PlanTier = PlanTier.Pro });
+
+        var propA = new Property { Id = Guid.NewGuid(), OrgId = orgA, OwnerId = "ownerA", Name = "A1", Address = "a", City = "Roma", CinCode = "IT-12345-0123456789", IsActive = true };
+        var propB = new Property { Id = Guid.NewGuid(), OrgId = orgB, OwnerId = "ownerB", Name = "B1", Address = "b", City = "Milano", CinCode = "IT-54321-9876543210", IsActive = true };
+        ctx.Properties.AddRange(propA, propB);
+
+        var bookingA = new Booking { Id = Guid.NewGuid(), OrgId = orgA, PropertyId = propA.Id, GuestId = Guid.NewGuid(), Status = BookingStatus.Confirmed, CheckInDate = DateTime.UtcNow.AddDays(5), CheckOutDate = DateTime.UtcNow.AddDays(7) };
+        var bookingB = new Booking { Id = Guid.NewGuid(), OrgId = orgB, PropertyId = propB.Id, GuestId = Guid.NewGuid(), Status = BookingStatus.Confirmed, CheckInDate = DateTime.UtcNow.AddDays(5), CheckOutDate = DateTime.UtcNow.AddDays(7) };
+        ctx.Bookings.AddRange(bookingA, bookingB);
+
+        ctx.Payments.AddRange(
+            new Payment { Id = Guid.NewGuid(), OrgId = orgA, BookingId = bookingA.Id, Amount = 100m, Status = PaymentStatus.Completed },
+            new Payment { Id = Guid.NewGuid(), OrgId = orgB, BookingId = bookingB.Id, Amount = 150m, Status = PaymentStatus.Completed });
+
+        await ctx.SaveChangesAsync();
+
+        // Guard: confirm the tenant filter really is engaged on this context (a filtered read sees
+        // only the caller org's single property). This is what distinguishes the real filter from
+        // the NullTenantContext path and proves the assertions below depend on IgnoreQueryFilters.
+        Assert.Equal(1, await ctx.Properties.CountAsync());
+
+        var service = CreateService(ctx);
+
+        // Act
+        var stats = await service.GetStatsAsync();
+
+        // Assert — platform-wide totals span BOTH orgs.
+        Assert.Equal(2, stats.TotalProperties);
+        Assert.Equal(2, stats.TotalBookings);
+        Assert.Equal(2, stats.UpcomingCheckIns);
+        Assert.Equal(250m, stats.TotalRevenue);
+        Assert.Equal(2, stats.CinTotal);
+        Assert.Equal(2, stats.CinValid);
+    }
+
+    [Fact]
+    public async Task GetCinComplianceAsync_AuthenticatedAdminContext_ReturnsRowsAcrossAllOrgs()
+    {
+        // Companion to F-H1 for the CIN-compliance bypass site: the regulatory report must remain
+        // platform-wide under an authenticated admin caller, not scoped to the caller's org.
+        var orgA = Guid.NewGuid();
+        var orgB = Guid.NewGuid();
+        using var ctx = CreateTenantScopedContext(
+            nameof(GetCinComplianceAsync_AuthenticatedAdminContext_ReturnsRowsAcrossAllOrgs),
+            callerOrgId: orgA);
+
+        ctx.Properties.AddRange(
+            new Property { Id = Guid.NewGuid(), OrgId = orgA, OwnerId = "ownerA", Name = "A1", Address = "a", City = "Roma", CinCode = "IT-12345-0123456789" },
+            new Property { Id = Guid.NewGuid(), OrgId = orgB, OwnerId = "ownerB", Name = "B1", Address = "b", City = "Milano", CinCode = null });
+        await ctx.SaveChangesAsync();
+
+        var service = CreateService(ctx);
+
+        var (items, total) = await service.GetCinComplianceAsync(null, 1, 20);
+
+        Assert.Equal(2, total);
+        Assert.Equal(2, items.Count());
     }
 
     // ─── GetCinComplianceAsync ──────────────────────────────────────────────

--- a/Casazen.Tests/Unit/Services/EntitlementServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/EntitlementServiceTests.cs
@@ -1,0 +1,103 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Infrastructure.Data;
+using Casazen.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Services;
+
+/// <summary>
+/// AC8 — plan entitlement. Verifies the tier→limit map, the boundary at which another
+/// property may/may not be created, configuration overrides, and the Starter fallback.
+/// </summary>
+public class EntitlementServiceTests
+{
+    private static AppDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"entitlement-{Guid.NewGuid()}")
+            .Options);
+
+    private static IConfiguration Config(Dictionary<string, string?>? values = null) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values ?? new Dictionary<string, string?>())
+            .Build();
+
+    private static async Task<Guid> SeedOrgWithPropertiesAsync(AppDbContext db, PlanTier tier, int properties)
+    {
+        var org = new Org { Name = "Org", Slug = $"org-{Guid.NewGuid():N}", DisplayName = "Org", ContactEmail = "o@x.it", PlanTier = tier, IsActive = true };
+        db.Orgs.Add(org);
+        for (var i = 0; i < properties; i++)
+            db.Properties.Add(new Property { OwnerId = "auth0|owner", OrgId = org.Id, Name = $"P{i}", Address = "A", City = "Rome" });
+        await db.SaveChangesAsync();
+        return org.Id;
+    }
+
+    [Theory]
+    [InlineData(PlanTier.Starter, 3)]
+    [InlineData(PlanTier.Pro, 50)]
+    public async Task GetEntitlementAsync_ReturnsTierLimitFromDefaultMap(PlanTier tier, int expectedMax)
+    {
+        await using var db = NewDb();
+        var orgId = await SeedOrgWithPropertiesAsync(db, tier, properties: 1);
+        var service = new EntitlementService(db, Config());
+
+        var result = await service.GetEntitlementAsync(orgId);
+
+        Assert.Equal(tier.ToString(), result.PlanTier);
+        Assert.Equal(expectedMax, result.MaxProperties);
+        Assert.Equal(1, result.PropertyCount);
+        Assert.True(result.CanAddProperty);
+    }
+
+    [Fact]
+    public async Task CanAddPropertyAsync_AtStarterLimit_ReturnsFalse()
+    {
+        await using var db = NewDb();
+        var orgId = await SeedOrgWithPropertiesAsync(db, PlanTier.Starter, properties: 3);
+        var service = new EntitlementService(db, Config());
+
+        Assert.False(await service.CanAddPropertyAsync(orgId));
+        Assert.False((await service.GetEntitlementAsync(orgId)).CanAddProperty);
+    }
+
+    [Fact]
+    public async Task CanAddPropertyAsync_BelowStarterLimit_ReturnsTrue()
+    {
+        await using var db = NewDb();
+        var orgId = await SeedOrgWithPropertiesAsync(db, PlanTier.Starter, properties: 2);
+        var service = new EntitlementService(db, Config());
+
+        Assert.True(await service.CanAddPropertyAsync(orgId));
+    }
+
+    [Fact]
+    public async Task GetEntitlementAsync_HonorsConfigurationOverride()
+    {
+        await using var db = NewDb();
+        var orgId = await SeedOrgWithPropertiesAsync(db, PlanTier.Starter, properties: 1);
+        var service = new EntitlementService(db, Config(new()
+        {
+            ["Entitlement:Tiers:Starter:MaxProperties"] = "1",
+        }));
+
+        var result = await service.GetEntitlementAsync(orgId);
+
+        Assert.Equal(1, result.MaxProperties);
+        Assert.False(result.CanAddProperty); // 1 used, limit 1
+    }
+
+    [Fact]
+    public async Task GetEntitlementAsync_UnknownOrg_FallsBackToStarter()
+    {
+        await using var db = NewDb();
+        var service = new EntitlementService(db, Config());
+
+        var result = await service.GetEntitlementAsync(Guid.NewGuid());
+
+        Assert.Equal(PlanTier.Starter.ToString(), result.PlanTier);
+        Assert.Equal(3, result.MaxProperties);
+        Assert.Equal(0, result.PropertyCount);
+    }
+}

--- a/Casazen.Web/Controllers/OrgsController.cs
+++ b/Casazen.Web/Controllers/OrgsController.cs
@@ -1,0 +1,50 @@
+using Casazen.Core.Multitenancy;
+using Casazen.Core.Services;
+using Casazen.Web.DTOs.Orgs;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Casazen.Web.Controllers;
+
+/// <summary>
+/// Read-only org surfaces for the caller's own organization (US-004). Org management and plan
+/// switching are owned by <c>spec-saas-billing</c>; this controller only exposes entitlement.
+/// </summary>
+[ApiController]
+[Route("api/orgs")]
+[Authorize]
+public class OrgsController(
+    ITenantContext tenantContext,
+    IEntitlementService entitlementService) : ControllerBase
+{
+    /// <summary>
+    /// Returns the caller org's plan entitlement: tier, limits, current usage, and whether
+    /// another property may be created (AC8). The <c>OrgId</c> is resolved from the authenticated
+    /// principal via <see cref="ITenantContext"/> and is never accepted from the client.
+    /// </summary>
+    /// <response code="200">Entitlement for the caller's org.</response>
+    /// <response code="401">The caller is not authenticated.</response>
+    /// <response code="404">The caller is not assigned to an org yet.</response>
+    [HttpGet("me/entitlement")]
+    [Authorize(Policy = "RequireContext:short-rent:property.read")]
+    [ProducesResponseType(typeof(EntitlementDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<EntitlementDto>> GetMyEntitlement(CancellationToken cancellationToken)
+    {
+        var orgId = tenantContext.OrgId;
+        if (orgId is null)
+            return NotFound(new { error = "No organization assigned to the current user" });
+
+        var entitlement = await entitlementService.GetEntitlementAsync(orgId.Value, cancellationToken);
+
+        return Ok(new EntitlementDto
+        {
+            OrgId = entitlement.OrgId,
+            PlanTier = entitlement.PlanTier,
+            Limits = new EntitlementLimitsDto { MaxProperties = entitlement.MaxProperties },
+            Usage = new EntitlementUsageDto { Properties = entitlement.PropertyCount },
+            CanAddProperty = entitlement.CanAddProperty
+        });
+    }
+}

--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -2,6 +2,7 @@
 using Casazen.Core.DTOs;
 using Casazen.Core.Entities;
 using Casazen.Core.Enums;
+using Casazen.Core.Multitenancy;
 using Casazen.Core.Services;
 using Casazen.Web.DTOs;
 using Casazen.Web.Infrastructure;
@@ -20,6 +21,8 @@ public class PropertiesController(
     IPropertyAuthorizationService authorizationService,
     IPropertyDocumentService documentService,
     IAdminAccessAuditService adminAccessAuditService,
+    ITenantContext tenantContext,
+    IEntitlementService entitlementService,
     ILogger<PropertiesController> logger) : ControllerBase
 {
     [HttpGet("health")]
@@ -78,16 +81,52 @@ public class PropertiesController(
     /// <response code="401">The caller is not authenticated.</response>
     [HttpPost]
     [Authorize(Policy = "RequireContext:short-rent:property.write")]
+    [ProducesResponseType(typeof(Property), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<Property>> Create([FromBody] CreatePropertyRequest request)
     {
         var userId = GetAuthenticatedUserId();
         if (string.IsNullOrEmpty(userId))
             return Unauthorized();
 
+        // Fail-closed (AC7): OrgId is required on a Property, so a caller with no org context
+        // (e.g. a brand-new user pre-backfill) cannot create tenant-scoped rows.
+        var orgId = tenantContext.OrgId;
+        if (orgId is null)
+        {
+            logger.LogWarning("Property creation blocked: user {UserId} has no org context", userId);
+            return StatusCode(StatusCodes.Status403Forbidden, new
+            {
+                error = "No organization context",
+                code = "no_org_context"
+            });
+        }
+
+        // AC8: enforce the org's plan limit server-side before insert. Client-side gating is
+        // advisory; this is the source of truth (a stale client cannot exceed the limit).
+        if (!await entitlementService.CanAddPropertyAsync(orgId.Value))
+        {
+            var entitlement = await entitlementService.GetEntitlementAsync(orgId.Value);
+            logger.LogWarning(
+                "Property creation blocked by plan limit for org {OrgId} (tier {PlanTier}, limit {Limit})",
+                orgId, entitlement.PlanTier, entitlement.MaxProperties);
+
+            return StatusCode(StatusCodes.Status403Forbidden, new
+            {
+                error = "Plan limit reached",
+                code = "plan_limit_reached",
+                planTier = entitlement.PlanTier,
+                limit = entitlement.MaxProperties
+            });
+        }
+
         logger.LogInformation("Creating property for user: {UserId}", userId);
         var property = request.ToProperty(userId);
+        // AC7: tenant key is server-set from the caller's org, never client-supplied.
+        property.OrgId = orgId.Value;
         var created = await propertyService.CreatePropertyAsync(property);
-        logger.LogInformation("Property created: {PropertyId}", created.Id);
+        logger.LogInformation("Property created: {PropertyId} in org {OrgId}", created.Id, created.OrgId);
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
     }
 

--- a/Casazen.Web/Controllers/UsersController.cs
+++ b/Casazen.Web/Controllers/UsersController.cs
@@ -13,6 +13,7 @@ namespace Casazen.Web.Controllers;
 [Authorize]
 public class UsersController(
     IUserService userService,
+    IOrgService orgService,
     ILogger<UsersController> logger) : ControllerBase
 {
     // ─── Admin endpoints ────────────────────────────────────────────────────
@@ -49,7 +50,7 @@ public class UsersController(
         if (user == null)
             return NotFound();
 
-        return Ok(ToDetail(user));
+        return Ok(ToDetail(user, await ResolveOrgAsync(user)));
     }
 
     // ─── Self-service endpoints ──────────────────────────────────────────────
@@ -76,7 +77,7 @@ public class UsersController(
                         ?? string.Empty;
 
         var user = await userService.GetCurrentUserAsync(sub, email, firstName, lastName);
-        return Ok(ToDetail(user));
+        return Ok(ToDetail(user, await ResolveOrgAsync(user)));
     }
 
     /// <summary>Completes first-time onboarding by assigning roles from rental type choice.</summary>
@@ -109,7 +110,7 @@ public class UsersController(
             existing.PhoneNumber = dto.PhoneNumber;
 
         var updated = await userService.UpdateUserAsync(existing);
-        return Ok(ToDetail(updated));
+        return Ok(ToDetail(updated, await ResolveOrgAsync(updated)));
     }
 
     /// <summary>Changes the role of a user. Admin only.</summary>
@@ -203,7 +204,10 @@ public class UsersController(
         CreatedAt = u.CreatedAt
     };
 
-    private static UserDetailDto ToDetail(User u) => new()
+    private async Task<Org?> ResolveOrgAsync(User user) =>
+        user.OrgId.HasValue ? await orgService.GetByIdAsync(user.OrgId.Value) : null;
+
+    private static UserDetailDto ToDetail(User u, Org? org = null) => new()
     {
         Id = u.Id,
         Email = u.Email,
@@ -214,6 +218,16 @@ public class UsersController(
         IsActive = u.IsActive,
         CreatedAt = u.CreatedAt,
         PhoneNumber = u.PhoneNumber,
-        UpdatedAt = u.UpdatedAt
+        UpdatedAt = u.UpdatedAt,
+        OrgId = u.OrgId,
+        Org = org is null
+            ? null
+            : new OrgSummaryDto
+            {
+                Id = org.Id,
+                Name = org.Name,
+                Slug = org.Slug,
+                PlanTier = org.PlanTier.ToString()
+            }
     };
 }

--- a/Casazen.Web/DTOs/Orgs/EntitlementDto.cs
+++ b/Casazen.Web/DTOs/Orgs/EntitlementDto.cs
@@ -1,0 +1,28 @@
+namespace Casazen.Web.DTOs.Orgs;
+
+/// <summary>
+/// Plan entitlement projection for the caller's org (AC8). Backs the FE plan badge and the
+/// property create-button gating. <c>orgId</c> is resolved server-side, never client-supplied.
+/// </summary>
+public class EntitlementDto
+{
+    public Guid OrgId { get; set; }
+
+    /// <summary>Plan tier name: <c>Starter</c> | <c>Pro</c> | <c>Scale</c>.</summary>
+    public string PlanTier { get; set; } = string.Empty;
+
+    public EntitlementLimitsDto Limits { get; set; } = new();
+    public EntitlementUsageDto Usage { get; set; } = new();
+
+    public bool CanAddProperty { get; set; }
+}
+
+public class EntitlementLimitsDto
+{
+    public int MaxProperties { get; set; }
+}
+
+public class EntitlementUsageDto
+{
+    public int Properties { get; set; }
+}

--- a/Casazen.Web/DTOs/Users/OrgSummaryDto.cs
+++ b/Casazen.Web/DTOs/Users/OrgSummaryDto.cs
@@ -1,0 +1,15 @@
+namespace Casazen.Web.DTOs.Users;
+
+/// <summary>
+/// Caller-facing projection of the current user's <c>Org</c> (AC9). Read-only; carries no
+/// secrets — Stripe identifiers and contact email are intentionally excluded.
+/// </summary>
+public class OrgSummaryDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+
+    /// <summary>Plan tier name: <c>Starter</c> | <c>Pro</c> | <c>Scale</c>.</summary>
+    public string PlanTier { get; set; } = string.Empty;
+}

--- a/Casazen.Web/DTOs/Users/UserDetailDto.cs
+++ b/Casazen.Web/DTOs/Users/UserDetailDto.cs
@@ -4,4 +4,10 @@ public class UserDetailDto : UserSummaryDto
 {
     public string? PhoneNumber { get; set; }
     public DateTime UpdatedAt { get; set; }
+
+    /// <summary>The caller's organization id (AC9). <c>null</c> for a brand-new user pre-backfill.</summary>
+    public Guid? OrgId { get; set; }
+
+    /// <summary>The caller's organization summary (AC9), or <c>null</c> when the user has no org.</summary>
+    public OrgSummaryDto? Org { get; set; }
 }

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// File: Casazen.Web/Extensions/ServiceCollectionExtensions.cs
 
 using System.Security.Claims;
+using Casazen.Core.Multitenancy;
 using Casazen.Core.Repositories;
 using Casazen.Core.Services;
 using Casazen.Infrastructure.Data;
@@ -239,6 +240,11 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IImageStorageService, LocalImageStorageService>();
         services.AddScoped<IPropertyAuthorizationService, PropertyAuthorizationService>();
         services.AddScoped<IAdminAccessAuditService, AdminAccessAuditService>();
+
+        // Multi-tenant Org boundary (US-004): tenant resolution + org/entitlement reads.
+        services.AddScoped<ITenantContext, TenantContext>();
+        services.AddScoped<IOrgService, OrgService>();
+        services.AddScoped<IEntitlementService, EntitlementService>();
         return services;
     }
 

--- a/Casazen.Web/Infrastructure/TenantContext.cs
+++ b/Casazen.Web/Infrastructure/TenantContext.cs
@@ -1,0 +1,66 @@
+using System.Security.Claims;
+using Casazen.Core.Multitenancy;
+using Casazen.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Casazen.Web.Infrastructure;
+
+/// <summary>
+/// Request-scoped <see cref="ITenantContext"/> that resolves the caller's <c>OrgId</c> from the
+/// authenticated principal (AC7). The <c>OrgId</c> is read from <c>User.OrgId</c> once per request
+/// and cached; the client can never supply or widen it.
+/// </summary>
+/// <remarks>
+/// Resolution uses a <b>separate</b> DI scope / <see cref="AppDbContext"/> instance because the
+/// caller of <see cref="OrgId"/> is the EF global query filter evaluating on the request's own
+/// <see cref="AppDbContext"/>; querying that same context here would be a reentrant operation.
+/// The lookup hits <c>Users</c>, which carries no tenant filter, so it cannot recurse.
+/// </remarks>
+public sealed class TenantContext(
+    IHttpContextAccessor httpContextAccessor,
+    IServiceScopeFactory scopeFactory) : ITenantContext
+{
+    private bool _resolved;
+    private Guid? _orgId;
+
+    public bool FilterEnabled =>
+        httpContextAccessor.HttpContext?.User.Identity?.IsAuthenticated == true;
+
+    public Guid? OrgId
+    {
+        get
+        {
+            if (_resolved)
+                return _orgId;
+
+            _resolved = true;
+
+            var sub = ResolveSub();
+            if (string.IsNullOrWhiteSpace(sub))
+            {
+                _orgId = null;
+                return _orgId;
+            }
+
+            using var scope = scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            _orgId = db.Users.AsNoTracking()
+                .Where(u => u.Id == sub)
+                .Select(u => u.OrgId)
+                .FirstOrDefault();
+
+            return _orgId;
+        }
+    }
+
+    private string? ResolveSub()
+    {
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user is null)
+            return null;
+
+        return user.FindFirstValue("sub")
+            ?? user.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? user.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier");
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the foundational **multi-tenant `Org` boundary** (US-004). Data was previously scoped per-`OwnerId` (Auth0 `sub`); isolation is now **structural** via an `OrgId` tenant key plus a fail-closed EF global query filter, and `Property` creation is gated by plan entitlement.

**Backend (`casazen/backend`) — this PR**
- New `Org` entity (`Id`, `Name`, unique `Slug`, `PlanTier` enum `Starter|Pro|Scale`, `DisplayName`, `LogoUrl?`, `ThemeColor?`, `ContactEmail`, `StripeCustomerId?`, `StripeConnectedAccountId?`, `IsActive`, timestamps) + `PlanTier` enum.
- `OrgId` FK added to `Property`, `Booking`, `LeaseContract`, `Payment` (index + `OnDelete(Restrict)` so deleting an Org never cascade-wipes financial history); nullable `User.OrgId` + nav (AC9).
- EF Core **global query filter** scopes the four tenant tables to the caller's `OrgId`, resolved server-side from the principal via `ITenantContext` — cross-org access returns `404`/empty, never another org's rows. The only audited `IgnoreQueryFilters()` bypass sites are migrations/backfill, Hangfire jobs, and `AdminOnly` endpoints. Null caller org ⇒ empty (fail-closed).
- `IEntitlementService` enforces per-tier `maxProperties` from a config tier→limits map; `POST /api/properties` sets `OrgId` server-side and returns `403 { code: "plan_limit_reached" }` when over the cap. New `GET /api/orgs/me/entitlement`; `GET /api/users/me` now returns `{ orgId, org: { id, name, slug, planTier } }`.
- **3-step zero-downtime migration sequence** (separate deploys): `AddOrgIdNullable` → `BackfillDefaultOrgs` (one default Org per distinct `Property.OwnerId`, relationship-walk backfill, idempotent + row-counts logged, fallback `casazen-unassigned` Org) → `MakeOrgIdRequired` (pre-flight NULL guard that `RAISE EXCEPTION` if any NULL remains → `NOT NULL` + FK). Every step has a **tested down-migration** (AC10b).

**Frontend (`casazen/frontend`) — see linked PR**
- `OrgBadge` + `PlanBadge` in the console header (read-only); `useCurrentUser` surfaces `org`/`planTier`; `useEntitlement()` query. Entitlement `403/409` on property create shows the Italian message **"Hai raggiunto il limite del tuo piano"** with an upgrade CTA (AC11/AC12).

## Test Plan

- `dotnet test` → **440 passed, 0 failed, 25 skipped**.
- `dotnet format --verify-no-changes` → clean; `dotnet build /warnaserror` → **0 warnings, 0 errors**.
- `dotnet ef migrations script --project Casazen.Infrastructure` → succeeds; the 3 migrations land in order before any Phase 1.5 migration.
- Migration safety: down-migrations + pre-flight NULL guard asserted by `MigrationSqlTests`; backfill idempotency + no-orphans by `OrgBackfillSimulationTests`.
- Cross-org isolation (404/empty) + entitlement 403: `TenantBoundaryIntegrationTests`, `EntitlementServiceTests`.
- Regression: existing owner sees exactly their pre-migration rows under their new default Org (`TenantBoundaryIntegrationTests.AC10_*`).

## Acceptance criteria coverage

| AC | Test(s) |
|---|---|
| AC1 Org + unique Slug | `MultiTenancyModelTests.Org_HasUniqueIndexOnSlug`, `Org_IsRegisteredAsDbSet` |
| AC2 OrgId FK + index + Restrict (4 tables) | `MultiTenancyModelTests.TenantEntity_HasRequiredRestrictedOrgIdFkAndIndex` |
| AC3 AddOrgIdNullable | `MigrationSqlTests.Step1_AddOrgIdNullable_*` |
| AC4 BackfillDefaultOrgs | `MigrationSqlTests.Step2_*`, `OrgBackfillSimulationTests.*` |
| AC5 MakeOrgIdRequired + ordering | `MigrationSqlTests.Migrations_LandInOrder_*`, `Step3_*` |
| AC6 snapshot discipline | `MultiTenancyModelTests` (model = snapshot source) |
| AC7 tenant filter / cross-org 404 | `TenantBoundaryIntegrationTests.AC7_CrossOrg_*` |
| AC8 entitlement 403 | `EntitlementServiceTests.*`, `TenantBoundaryIntegrationTests.AC8_*` |
| AC9 User.OrgId + /me org | `TenantBoundaryIntegrationTests.AC9_GetMe_*`, `MultiTenancyModelTests.User_HasNullableRestrictedOrgIdFk` |
| AC10 regression | `TenantBoundaryIntegrationTests.AC10_*`, `OrgBackfillSimulationTests.Backfill_LeavesNoOrphans/IsIdempotent` |
| AC10b down-migration + pre-flight guard | `MigrationSqlTests.Step3_*_GuardsThenFlips...`, `Step3_*_DownReverts_*` |
| AC11 header org + plan badge (FE) | `org-badge.test.tsx` + `e2e/tenant-boundary.spec.ts` "AC11 …" (frontend PR) |
| AC12 plan-limit Italian message (FE) | `entitlement-error.test.ts` + `e2e/tenant-boundary.spec.ts` "AC12 …" (frontend PR) |

## Gate status

| Gate | Command | Result |
|---|---|---|
| G1 tests | `dotnet test` | ✅ 440 passed, 0 failed, 25 skipped |
| G2 format | `dotnet format --verify-no-changes` | ✅ exit 0 |
| G3 warnings | `dotnet build /warnaserror` | ✅ 0 warnings, 0 errors |
| G4 migration | `dotnet ef migrations script` | ✅ exit 0 |
| G5 FE unit | `npm test` | ✅ 107 passed (17 files) |
| G6 FE types | `tsc -b --noEmit` | ✅ exit 0 |
| G7 FE lint | `npm run lint` (`eslint .`) | ⚠️ **pre-existing repo-wide ESLint baseline — 0 new errors from this PR** (see note) |
| G8 FE build | `npm run build` | ✅ exit 0 |
| G9 E2E | `npm run test:e2e` | ✅ 38 passed, 7 skipped, 0 failed (incl. 2 new #202 specs) |
| G10 CIN | `dotnet test --filter CinCode` | ✅ 3 passed (Property touched) |
| G11 secrets | git status + grep | ✅ no secrets; only pre-existing test fixtures match |
| G12 GDPR | Guest entity check | N/A — `Guest` not modified (AC2: no `OrgId` on Guest) |
| G13 tourist tax | grep `Casazen.Core` | N/A — no tax surface touched; no hardcoded amounts |

### ⚠️ G7 note — accepted pre-existing debt (0 new errors from this PR)

`npm run lint` runs `eslint .` over the **entire** frontend repo and reports **47 errors / 8 warnings, all pre-existing and unrelated to #202**:

1. **~45 errors are in files this branch never modified** (e.g. `src/api/bookings.api.ts`, `src/api/client.ts`, `src/api/ota.api.ts`, `src/api/payments.api.ts`, `src/components/ui/{input,label,textarea}.tsx`, `src/features/{bookings,leases,ota,payments,pricing}/...`, `src/types/{guest,ota,tourist-tax}.types.ts`, `e2e/pricing-adapter.spec.ts`). **Byte-identical-file evidence:** `git diff --quiet -- src/api/bookings.api.ts` shows it is unchanged vs `develop`, yet `npx eslint src/api/bookings.api.ts` reports an error — a file byte-identical to `develop` fails lint, proving `develop` is already red.
2. **The only 2 errors in files #202 touched are on pre-existing lines** not in the #202 diff: `property-form.tsx:53` (`as any` on the RHF `defaultValues` cast — #202 only added the `disabled?` prop) and `properties-page.tsx:36` (unused `catch (error)` in the untouched `toggleActive` — #202 only changed the other, `error`-using catch).
3. **All files authored for #202 lint clean:** `npx eslint` over `e2e/tenant-boundary.spec.ts`, `e2e/helpers/org-api-mock.ts`, `src/components/org/`, `src/lib/entitlement-error.ts` (+ test), `src/api/orgs.api.ts`, `src/types/org.types.ts` → **0 problems**.

Making `eslint .` exit 0 would require editing ~25 unrelated files, violating the staging-hygiene mandate (feature-only diff). The baseline is tracked for a separate repo-wide lint-cleanup chore PR.

---

Frontend PR: https://github.com/casazen/frontend/pull/104

Closes #202
