### PR TITLE
feat(tenancy): MVP plan management + release prod smoke (#202)

### DIFF
--- a/.claude/sdlc/05-release/agents/coordinator.md
+++ b/.claude/sdlc/05-release/agents/coordinator.md
@@ -64,11 +64,14 @@ Do **not** skip phases or reorder them. Do **not** promote to `main` if Phase B 
 ## Phase D — Post-main verification
 
 1. Wait **~90–120s** after push to `main`
-2. Spawn qa-validator against **production** (`$RAILWAY_PROD_URL`, `https://casazen.vercel.app`)
-3. Re-run critical AC smoke on production
-4. **G20 branch alignment** — both divergence counts `0` per repo. **Merge direction:** promote `develop` → `main`; sync-back `main` → `develop` only if `main` builds. If `main` is broken, fix on `develop` then promote `develop` → `main` (never poison `develop` with a broken `main`).
-5. **G21 build parity** — `npm run build` / `dotnet build` on both `origin/main` and `origin/develop` tips.
-6. Write gate results (G20 SHAs, G21 build) to `Sessions/release-<issue-N>.md`
+2. Spawn qa-validator against **production** (`$RAILWAY_PROD_URL`, `https://casazen-app.vercel.app`)
+3. **Mandatory before Phase C** if backend migrations changed: `.\scripts\migrate.ps1 -Target prod`
+4. Re-run critical AC smoke on production:
+   - `.\scripts\release-smoke.ps1` (G16b)
+   - `E2E_PROD_SMOKE=1 npm run test:e2e -- prod-deploy-smoke` in frontend (G18)
+5. **G20 branch alignment** — both divergence counts `0` per repo. **Merge direction:** promote `develop` → `main`; sync-back `main` → `develop` only if `main` builds. If `main` is broken, fix on `develop` then promote `develop` → `main` (never poison `develop` with a broken `main`).
+6. **G21 build parity** — `npm run build` / `dotnet build` on both `origin/main` and `origin/develop` tips.
+7. Write gate results (G20 SHAs, G21 build) to `Sessions/release-<issue-N>.md`
 
 ## Gate commands
 
@@ -91,7 +94,9 @@ gh release create vX.Y.Z --generate-notes
 
 # Phase D (main / production)
 curl -sf $RAILWAY_PROD_URL/api/health
-curl -sf https://casazen.vercel.app
+.\scripts\release-smoke.ps1                                    # G16b — migrations + prod smoke
+cd ../frontend && E2E_PROD_SMOKE=1 npm run test:e2e -- prod-deploy-smoke  # G18
+curl -sf https://casazen-app.vercel.app | grep 'id="root"'       # G17 — canonical prod FE URL
 
 # G20 — main ↔ develop aligned (run per repo; both must be 0)
 git fetch origin main develop

--- a/.claude/sdlc/05-release/agents/qa-validator.md
+++ b/.claude/sdlc/05-release/agents/qa-validator.md
@@ -26,20 +26,31 @@ curl -sf $STAGING_FE_URL | grep -q 'id="root"'           # G10: must match
 
 **Block main promotion** if G7, G8, G9, or G10 fail.
 
-`$STAGING_FE_URL`: Vercel project → Deployments → branch `develop` (not PR preview).
+`$STAGING_FE_URL`: Vercel project → Deployments → branch `develop` (not PR preview). Do **not** use `casazen-app.vercel.app` for staging — that URL is **Production** (branch `main`).
 
 ## Phase D — Production validation (after merge to main)
 
 Wait ~90–120s after push to `main`.
 
+**If the release includes EF migrations**, run prod migrations **before** opening the release PR or immediately after merge:
+
+```bash
+cd casazen/backend
+.\scripts\migrate.ps1 -Target prod                       # G6d — casazen_prod schema
+.\scripts\release-smoke.ps1                              # G16b — health + auth gates + FE SPA
+```
+
 ```bash
 curl -sf $RAILWAY_PROD_URL/api/health                    # G16: HTTP 200
-curl -sf https://casazen.vercel.app | grep -q 'id="root"'  # G17: SPA shell, not placeholder
-curl -o /dev/null -sw "%{http_code}" $RAILWAY_PROD_URL/api/properties  # auth gate
+curl -sf https://casazen-app.vercel.app | grep -q 'id="root"'  # G17: SPA shell (NOT casazen.vercel.app)
+curl -o /dev/null -sw "%{http_code}" $RAILWAY_PROD_URL/api/orgs/me/entitlement  # 401 without token
 
-# G18: Re-run critical acceptance criteria on PRODUCTION URLs (E2E or manual)
-# Stage 06 operations audit depends on these passing first
+# G18: Authenticated production full-stack smoke (MANDATORY)
+cd casazen/frontend
+E2E_PROD_SMOKE=1 npm run test:e2e -- prod-deploy-smoke
 ```
+
+**Why G18 matters:** staging CI historically tested `RAILWAY_TEST_URL` even on push to `main`. Authenticated calls can pass on test while prod fails (missing `casazen_prod` migration, wrong Vercel Production env vars, or prod-only 401).
 
 ## Failure classification
 
@@ -49,6 +60,7 @@ curl -o /dev/null -sw "%{http_code}" $RAILWAY_PROD_URL/api/properties  # auth ga
 | AC fail on staging | B | Route to Stage 03; block main promotion |
 | Staging FE 404 | B | Check Vercel develop deploy |
 | Prod health fail after main merge | D | Check Railway/Vercel prod logs; escalate |
+| Prod auth 401/500 (G18) | D | Check `Auth0__Audience` on Railway prod matches `VITE_AUTH0_AUDIENCE` on Vercel Production; run `migrate.ps1 -Target prod` |
 | AC fail on prod only | D | P1 — document in release report; notify Stage 06 |
 
 ## Output format
@@ -66,8 +78,9 @@ PHASE B — Staging (develop)
 
 PHASE D — Production (main)
 | G16 BE prod      | ✅/❌ | HTTP N |
-| G17 FE prod SPA  | ✅/❌ | casazen.vercel.app contains #root |
-| G18 Feature ACs  | ✅/❌ | X/Y passed on prod |
+| G16b release-smoke | ✅/❌ | migrate + gates |
+| G17 FE prod SPA  | ✅/❌ | casazen-app.vercel.app contains #root |
+| G18 Prod E2E     | ✅/❌ | prod-deploy-smoke pass |
 
 VERDICT: PASS → proceed / FAIL → block next phase
 ```

--- a/.claude/sdlc/05-release/harness.md
+++ b/.claude/sdlc/05-release/harness.md
@@ -38,11 +38,11 @@ Run after develop deploy completes (~90–120s post-merge).
 | G6 | Auth smoke | `curl` on `/api/properties`, `/api/bookings`, `/api/users/me`, `/api/me/contexts` | 401 each (never 5xx) |
 | G6b | API regression E2E | `E2E_STAGING=1 npm run test:e2e -- api-regression-smoke` | Authenticated: no 500 |
 | G6c | Vercel deploy smoke | `E2E_DEPLOY_SMOKE=1 npm run test:e2e -- vercel-deploy-smoke` | `#root` + no API 500 on load |
-| G6d | EF migrations applied | `.\scripts\migrate.ps1 -Target test` (and `prod` before Phase D if new migration) | Exit 0 |
+| G6d | EF migrations applied | `.\scripts\migrate.ps1 -Target test` before Phase B; **`.\scripts\migrate.ps1 -Target prod` mandatory before Phase C** (do not rely on startup auto-migrate alone) | Exit 0 |
 | G7 | Backend tests (release candidate) | `dotnet test` (in `casazen/backend` on `develop`) | All tests pass, 0 failures (N/A if no BE changes in release) |
 | G8 | E2E tests (release candidate) | `npm run test:e2e` (in `casazen/frontend` on `develop`) | All Playwright tests pass, 0 failures (N/A if no FE changes in release) |
 | G9 | Feature AC validated | Automated E2E + spot-check vs Issue `#N` ACs on staging URLs | All ACs pass on staging BE+FE |
-| G10 | Staging FE serves SPA | `curl -sf $STAGING_FE_URL` | HTTP 200 **and** body contains `id="root"` (not a stray `.env` or placeholder file) |
+| G10 | Staging FE serves SPA | `curl -sf $STAGING_FE_URL` | HTTP 200 **and** body contains `id="root"` — use Vercel **develop** deployment URL, **not** `casazen-app.vercel.app` (that is Production) |
 
 `$RAILWAY_TEST_URL` from GitHub variable `RAILWAY_TEST_URL`.
 `$STAGING_FE_URL` = Vercel staging URL for branch `develop` (see `docs/INFRA.md`).
@@ -77,8 +77,9 @@ Run **after** push to `main` deploys (~90–120s). Stage 06 must not start until
 | # | Gate | Command | Pass condition |
 |---|---|---|---|
 | G16 | Railway prod health | `curl -sf $RAILWAY_PROD_URL/api/health` | HTTP 200 |
-| G17 | Vercel prod health | `curl -sf https://casazen.vercel.app` | HTTP 200 **and** body contains `id="root"` |
-| G18 | Feature AC on production | Re-run E2E against prod FE URL or critical AC spot-check | Pass on prod URLs |
+| G16b | Prod migration + smoke script | `.\scripts\release-smoke.ps1` (applies `migrate.ps1 -Target prod`, then health + auth gates + FE SPA) | Exit 0 |
+| G17 | Vercel prod health | `curl -sf https://casazen-app.vercel.app` | HTTP 200 **and** body contains `id="root"` (do **not** use `casazen.vercel.app` — mislinked, #187) |
+| G18 | Feature AC on production | `E2E_PROD_SMOKE=1 npm run test:e2e -- prod-deploy-smoke` in `casazen/frontend` (authenticated prod FE + prod API; fails on 401/500) | Pass on prod URLs |
 | G19 | Docker build (backend) | `docker build -t casazen-api .` | Exit 0 — validates prod artifact (N/A if no BE changes) |
 | G20 | **main ↔ develop aligned** (both repos) | See commands below | Zero divergence; correct merge direction (see table) |
 | G21 | **Build parity** on `main` + `develop` | `dotnet build` / `npm run build` on both tips | Exit 0 on both branches per repo released |
@@ -203,10 +204,10 @@ Plus:
 
 ## Handoff to Stage 06
 
-**Precondition**: Phase D gates G16–G18, **G20**, and **G21** ✅ on **`main` / production**.
+**Precondition**: Phase D gates G16–G18, **G16b**, **G20**, and **G21** ✅ on **`main` / production**.
 
 Pass to operations:
 - Tag `vX.Y.Z`
 - `$RAILWAY_PROD_URL`
-- `https://casazen.vercel.app`
+- `https://casazen-app.vercel.app`
 - Issue `#N` + acceptance criteria for regression spot-check

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -168,7 +168,7 @@ jobs:
           RAILWAY_PROD_URL: ${{ vars.RAILWAY_PROD_URL }}
         run: |
           if [ -z "$RAILWAY_PROD_URL" ]; then exit 0; fi
-          for PATH_SUFFIX in properties bookings users/me me/contexts; do
+          for PATH_SUFFIX in properties bookings users/me me/contexts orgs/me/entitlement; do
             STATUS=$(curl -o /dev/null -sw "%{http_code}" \
               "${RAILWAY_PROD_URL}/api/${PATH_SUFFIX}")
             if [ "$STATUS" = "500" ]; then
@@ -181,3 +181,16 @@ jobs:
             fi
             echo "✅ Production /api/${PATH_SUFFIX} auth gate OK"
           done
+
+      - name: Production FE bundle sanity (must serve SPA, not placeholder)
+        run: |
+          BODY=$(curl -sf "https://casazen-app.vercel.app" || true)
+          if [ -z "$BODY" ]; then
+            echo "❌ Production FE unreachable at https://casazen-app.vercel.app"
+            exit 1
+          fi
+          if ! echo "$BODY" | grep -q 'id="root"'; then
+            echo "❌ Production FE missing React root — check Vercel Production deploy"
+            exit 1
+          fi
+          echo "✅ Production FE SPA shell OK (casazen-app.vercel.app)"

--- a/Casazen.Core/Services/IOrgService.cs
+++ b/Casazen.Core/Services/IOrgService.cs
@@ -1,22 +1,38 @@
 using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
 
 namespace Casazen.Core.Services;
 
 /// <summary>
-/// Read access to <see cref="Org"/> tenants. US-004 is read-only for org;
-/// org management / plan switching is owned by <c>spec-saas-billing</c>.
+/// Org tenant access and plan management. US-004 adds read + MVP plan selection before
+/// <c>spec-saas-billing</c> Stripe checkout replaces self-serve tier changes.
 /// </summary>
 public interface IOrgService
 {
-    /// <summary>Returns the org by id, or <c>null</c> if not found.</summary>
     Task<Org?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
 
-    /// <summary>Returns the org the given user belongs to, or <c>null</c> if the user has none.</summary>
     Task<Org?> GetByUserIdAsync(string userId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Returns the org by slug for public (branded) surfaces. Referenced by later specs
-    /// (<c>spec-branded-booking-site</c>); not exposed via an endpoint in US-004.
-    /// </summary>
     Task<Org?> GetPublicBySlugAsync(string slug, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ensures the user belongs to an org, creating one on first onboarding if needed.
+    /// Idempotent: existing orgs are returned unchanged (plan tier is not overwritten).
+    /// </summary>
+    Task<Org> EnsureOrgForUserAsync(
+        string userId,
+        string email,
+        string displayName,
+        PlanTier planTier,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Updates the org plan tier (MVP internal change until Stripe billing ships).</summary>
+    Task<Org?> UpdatePlanTierAsync(
+        Guid orgId,
+        PlanTier planTier,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyDictionary<Guid, Org>> GetByIdsAsync(
+        IEnumerable<Guid> ids,
+        CancellationToken cancellationToken = default);
 }

--- a/Casazen.Core/Services/IUserService.cs
+++ b/Casazen.Core/Services/IUserService.cs
@@ -1,4 +1,5 @@
 using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
 
 namespace Casazen.Core.Services;
 
@@ -25,5 +26,10 @@ public interface IUserService
     /// Completes or updates onboarding: persists rental type, syncs Auth0 onboarding roles.
     /// </summary>
     Task<(User User, IReadOnlyList<string> RolesAssigned)> CompleteOnboardingAsync(
-        string sub, RentalType rentalType, string email, string firstName, string lastName);
+        string sub,
+        RentalType rentalType,
+        PlanTier planTier,
+        string email,
+        string firstName,
+        string lastName);
 }

--- a/Casazen.Core/Services/PlanCatalog.cs
+++ b/Casazen.Core/Services/PlanCatalog.cs
@@ -1,0 +1,42 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+
+namespace Casazen.Core.Services;
+
+/// <summary>
+/// Shared tier catalogue and property limits. Values align with <see cref="EntitlementService"/>
+/// defaults; <c>spec-saas-billing</c> will attach Stripe Price ids later.
+/// </summary>
+public static class PlanCatalog
+{
+    public sealed record Entry(
+        PlanTier Tier,
+        string DisplayName,
+        int MaxProperties,
+        string Description);
+
+    private static readonly Entry[] Entries =
+    [
+        new(PlanTier.Starter, "Starter", 3, "Fino a 3 proprietà — ideale per iniziare."),
+        new(PlanTier.Pro, "Pro", 50, "Fino a 50 proprietà — per operatori in crescita."),
+        new(PlanTier.Scale, "Scale", int.MaxValue, "Proprietà illimitate — per agenzie e PM."),
+    ];
+
+    public static IReadOnlyList<Entry> All => Entries;
+
+    public static int MaxPropertiesFor(PlanTier tier) =>
+        Entries.First(e => e.Tier == tier).MaxProperties;
+
+    public static bool TryParseTier(string? value, out PlanTier tier)
+    {
+        tier = default;
+        if (!Enum.TryParse(value, ignoreCase: true, out PlanTier parsed))
+            return false;
+
+        if (!Entries.Any(e => e.Tier == parsed))
+            return false;
+
+        tier = parsed;
+        return true;
+    }
+}

--- a/Casazen.Infrastructure/Services/OrgService.cs
+++ b/Casazen.Infrastructure/Services/OrgService.cs
@@ -1,4 +1,6 @@
+using System.Text.RegularExpressions;
 using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
 using Casazen.Core.Services;
 using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
@@ -6,10 +8,9 @@ using Microsoft.EntityFrameworkCore;
 namespace Casazen.Infrastructure.Services;
 
 /// <summary>
-/// Read access to <see cref="Org"/> tenants (US-004). <see cref="Org"/> is not subject to the
-/// tenant query filter, so these reads are explicit by id/slug/user and never widen tenant scope.
+/// Org tenant access and MVP plan management (US-004 extension).
 /// </summary>
-public class OrgService(AppDbContext dbContext) : IOrgService
+public partial class OrgService(AppDbContext dbContext) : IOrgService
 {
     public Task<Org?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default) =>
         dbContext.Orgs.AsNoTracking().FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
@@ -28,4 +29,98 @@ public class OrgService(AppDbContext dbContext) : IOrgService
 
     public Task<Org?> GetPublicBySlugAsync(string slug, CancellationToken cancellationToken = default) =>
         dbContext.Orgs.AsNoTracking().FirstOrDefaultAsync(o => o.Slug == slug && o.IsActive, cancellationToken);
+
+    public async Task<Org> EnsureOrgForUserAsync(
+        string userId,
+        string email,
+        string displayName,
+        PlanTier planTier,
+        CancellationToken cancellationToken = default)
+    {
+        var user = await dbContext.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken)
+            ?? throw new InvalidOperationException($"User {userId} must exist before org provisioning");
+
+        if (user.OrgId.HasValue)
+        {
+            var existing = await dbContext.Orgs.FirstAsync(o => o.Id == user.OrgId.Value, cancellationToken);
+            return existing;
+        }
+
+        var slug = await AllocateUniqueSlugAsync(userId, cancellationToken);
+        var orgName = string.IsNullOrWhiteSpace(displayName) ? "La mia organizzazione" : displayName.Trim();
+        var org = new Org
+        {
+            Name = orgName,
+            DisplayName = orgName,
+            Slug = slug,
+            PlanTier = planTier,
+            ContactEmail = email,
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        dbContext.Orgs.Add(org);
+        user.OrgId = org.Id;
+        user.UpdatedAt = DateTime.UtcNow;
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return org;
+    }
+
+    public async Task<Org?> UpdatePlanTierAsync(
+        Guid orgId,
+        PlanTier planTier,
+        CancellationToken cancellationToken = default)
+    {
+        var org = await dbContext.Orgs.FirstOrDefaultAsync(o => o.Id == orgId, cancellationToken);
+        if (org is null)
+            return null;
+
+        org.PlanTier = planTier;
+        org.UpdatedAt = DateTime.UtcNow;
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return org;
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, Org>> GetByIdsAsync(
+        IEnumerable<Guid> ids,
+        CancellationToken cancellationToken = default)
+    {
+        var idList = ids.Distinct().ToList();
+        if (idList.Count == 0)
+            return new Dictionary<Guid, Org>();
+
+        var orgs = await dbContext.Orgs.AsNoTracking()
+            .Where(o => idList.Contains(o.Id))
+            .ToListAsync(cancellationToken);
+
+        return orgs.ToDictionary(o => o.Id);
+    }
+
+    private async Task<string> AllocateUniqueSlugAsync(string userId, CancellationToken cancellationToken)
+    {
+        var baseSlug = $"org-{SanitizeSlugPart(userId)}";
+        if (baseSlug.Length > 90)
+            baseSlug = baseSlug[..90];
+
+        var candidate = baseSlug;
+        var suffix = 0;
+        while (await dbContext.Orgs.AnyAsync(o => o.Slug == candidate, cancellationToken))
+        {
+            suffix++;
+            candidate = $"{baseSlug}-{suffix}";
+        }
+
+        return candidate;
+    }
+
+    private static string SanitizeSlugPart(string value)
+    {
+        var sanitized = SlugSanitizer().Replace(value.ToLowerInvariant(), "-");
+        sanitized = sanitized.Trim('-');
+        return string.IsNullOrWhiteSpace(sanitized) ? "user" : sanitized;
+    }
+
+    [GeneratedRegex(@"[^a-z0-9]+")]
+    private static partial Regex SlugSanitizer();
 }

--- a/Casazen.Infrastructure/Services/UserService.cs
+++ b/Casazen.Infrastructure/Services/UserService.cs
@@ -1,4 +1,5 @@
 using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
 using Casazen.Core.Repositories;
 using Casazen.Core.Services;
 using Microsoft.Extensions.Configuration;
@@ -9,6 +10,7 @@ namespace Casazen.Infrastructure.Services;
 public class UserService(
     IUserRepository repository,
     IAuth0ManagementService auth0Management,
+    IOrgService orgService,
     ILogger<UserService> logger) : IUserService
 {
     public async Task<User?> GetUserAsync(string id)
@@ -136,7 +138,12 @@ public class UserService(
 
     /// <inheritdoc />
     public async Task<(User User, IReadOnlyList<string> RolesAssigned)> CompleteOnboardingAsync(
-        string sub, RentalType rentalType, string email, string firstName, string lastName)
+        string sub,
+        RentalType rentalType,
+        PlanTier planTier,
+        string email,
+        string firstName,
+        string lastName)
     {
         var roles = MapRentalTypeToRoles(rentalType);
         var user = await GetCurrentUserAsync(sub, email, firstName, lastName);
@@ -146,12 +153,20 @@ public class UserService(
         user.UpdatedAt = DateTime.UtcNow;
         await repository.UpdateAsync(user);
 
+        var displayName = $"{firstName} {lastName}".Trim();
+        if (string.IsNullOrWhiteSpace(displayName))
+            displayName = email;
+
+        await orgService.EnsureOrgForUserAsync(sub, email, displayName, planTier);
+
+        user = await repository.GetByIdAsync(sub) ?? user;
+
         await auth0Management.AssignOnboardingRolesAsync(sub, roles);
 
         var assigned = roles.Select(r => r.ToString()).ToArray();
         logger.LogInformation(
-            "Onboarding completed: userId={UserId} rentalType={RentalType} roles=[{Roles}]",
-            sub, rentalType, string.Join(", ", assigned));
+            "Onboarding completed: userId={UserId} rentalType={RentalType} planTier={PlanTier} roles=[{Roles}]",
+            sub, rentalType, planTier, string.Join(", ", assigned));
 
         return (user, assigned);
     }

--- a/Casazen.Tests/Integration/TenantBoundaryIntegrationTests.cs
+++ b/Casazen.Tests/Integration/TenantBoundaryIntegrationTests.cs
@@ -125,4 +125,57 @@ public class TenantBoundaryIntegrationTests : IClassFixture<CasazenWebApplicatio
         var ids = doc.RootElement.EnumerateArray().Select(e => e.GetProperty("id").GetGuid());
         Assert.Contains(property.Id, ids);
     }
+
+    [Fact]
+    public async Task Onboarding_WithProPlan_ProvisionsOrgWithSelectedTier()
+    {
+        var owner = NewOwner();
+        var client = _factory.CreateAuthenticatedClient(userId: owner, roles: "PropertyOwner");
+
+        var response = await client.PostAsJsonAsync("/api/users/onboarding", new
+        {
+            rentalType = "ShortTerm",
+            planTier = "Pro",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var me = await client.GetAsync("/api/users/me");
+        using var doc = JsonDocument.Parse(await me.Content.ReadAsStringAsync());
+        Assert.Equal("Pro", doc.RootElement.GetProperty("org").GetProperty("planTier").GetString());
+    }
+
+    [Fact]
+    public async Task Owner_CanChangePlanTier()
+    {
+        var owner = NewOwner();
+        await _factory.SeedPropertyAsync(ownerId: owner);
+        var client = _factory.CreateAuthenticatedClient(userId: owner, roles: "PropertyOwner");
+
+        var response = await client.PutAsJsonAsync("/api/orgs/me/plan", new { planTier = "Scale" });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("Scale", doc.RootElement.GetProperty("planTier").GetString());
+        Assert.True(doc.RootElement.GetProperty("canAddProperty").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Admin_CanChangeOrgPlanTier()
+    {
+        var owner = NewOwner();
+        await _factory.SeedPropertyAsync(ownerId: owner);
+        var adminClient = _factory.CreateAuthenticatedClient(userId: "auth0|admin", roles: "Admin");
+
+        var me = await _factory.CreateAuthenticatedClient(userId: owner, roles: "PropertyOwner")
+            .GetAsync("/api/users/me");
+        var orgId = JsonDocument.Parse(await me.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("orgId").GetGuid();
+
+        var response = await adminClient.PatchAsJsonAsync($"/api/admin/orgs/{orgId}/plan", new { planTier = "Pro" });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("Pro", doc.RootElement.GetProperty("planTier").GetString());
+    }
 }

--- a/Casazen.Tests/Unit/Services/OrgServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/OrgServiceTests.cs
@@ -1,0 +1,104 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Infrastructure.Data;
+using Casazen.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Services;
+
+public class OrgServiceTests
+{
+    private static AppDbContext CreateDb(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task EnsureOrgForUserAsync_CreatesOrgWithSelectedPlanTier()
+    {
+        await using var db = CreateDb(nameof(EnsureOrgForUserAsync_CreatesOrgWithSelectedPlanTier));
+        var userId = "auth0|new-user";
+        db.Users.Add(new User
+        {
+            Id = userId,
+            Email = "owner@example.com",
+            FirstName = "Mario",
+            LastName = "Rossi",
+            Role = UserRole.PropertyOwner,
+            IsActive = true,
+        });
+        await db.SaveChangesAsync();
+
+        var service = new OrgService(db);
+        var org = await service.EnsureOrgForUserAsync(
+            userId, "owner@example.com", "Mario Rossi", PlanTier.Pro);
+
+        Assert.Equal(PlanTier.Pro, org.PlanTier);
+        var user = await db.Users.SingleAsync(u => u.Id == userId);
+        Assert.Equal(org.Id, user.OrgId);
+    }
+
+    [Fact]
+    public async Task EnsureOrgForUserAsync_IsIdempotent_DoesNotChangeExistingPlan()
+    {
+        await using var db = CreateDb(nameof(EnsureOrgForUserAsync_IsIdempotent_DoesNotChangeExistingPlan));
+        var userId = "auth0|existing";
+        var orgId = Guid.NewGuid();
+        db.Orgs.Add(new Org
+        {
+            Id = orgId,
+            Name = "Existing",
+            Slug = "org-existing",
+            DisplayName = "Existing",
+            ContactEmail = "x@y.it",
+            PlanTier = PlanTier.Starter,
+            IsActive = true,
+        });
+        db.Users.Add(new User
+        {
+            Id = userId,
+            Email = "x@y.it",
+            FirstName = "A",
+            LastName = "B",
+            Role = UserRole.PropertyOwner,
+            OrgId = orgId,
+            IsActive = true,
+        });
+        await db.SaveChangesAsync();
+
+        var service = new OrgService(db);
+        var org = await service.EnsureOrgForUserAsync(
+            userId, "x@y.it", "A B", PlanTier.Scale);
+
+        Assert.Equal(orgId, org.Id);
+        Assert.Equal(PlanTier.Starter, org.PlanTier);
+    }
+
+    [Fact]
+    public async Task UpdatePlanTierAsync_ChangesTier()
+    {
+        await using var db = CreateDb(nameof(UpdatePlanTierAsync_ChangesTier));
+        var orgId = Guid.NewGuid();
+        db.Orgs.Add(new Org
+        {
+            Id = orgId,
+            Name = "Org",
+            Slug = "org-test",
+            DisplayName = "Org",
+            ContactEmail = "x@y.it",
+            PlanTier = PlanTier.Starter,
+            IsActive = true,
+        });
+        await db.SaveChangesAsync();
+
+        var service = new OrgService(db);
+        var updated = await service.UpdatePlanTierAsync(orgId, PlanTier.Scale);
+
+        Assert.NotNull(updated);
+        Assert.Equal(PlanTier.Scale, updated!.PlanTier);
+    }
+}

--- a/Casazen.Tests/Unit/Services/UserServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/UserServiceTests.cs
@@ -1,4 +1,5 @@
 using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
 using Casazen.Core.Repositories;
 using Casazen.Core.Services;
 using Casazen.Infrastructure.Services;
@@ -12,6 +13,7 @@ public class UserServiceTests
 {
     private readonly Mock<IUserRepository> _repoMock;
     private readonly Mock<IAuth0ManagementService> _auth0Mock;
+    private readonly Mock<IOrgService> _orgMock;
     private readonly Mock<ILogger<UserService>> _loggerMock;
     private readonly UserService _service;
 
@@ -20,8 +22,9 @@ public class UserServiceTests
         _repoMock = new Mock<IUserRepository>();
         _loggerMock = new Mock<ILogger<UserService>>();
         _auth0Mock = new Mock<IAuth0ManagementService>();
+        _orgMock = new Mock<IOrgService>();
 
-        _service = new UserService(_repoMock.Object, _auth0Mock.Object, _loggerMock.Object);
+        _service = new UserService(_repoMock.Object, _auth0Mock.Object, _orgMock.Object, _loggerMock.Object);
     }
 
     // ─── GetCurrentUserAsync ────────────────────────────────────────────────
@@ -104,12 +107,16 @@ public class UserServiceTests
         var sub = "auth0|onboard1";
         var user = new User { Id = sub, Email = "a@b.com", FirstName = "A", LastName = "B" };
         _repoMock.Setup(r => r.GetBySubAsync(sub)).ReturnsAsync(user);
+        _repoMock.Setup(r => r.GetByIdAsync(sub)).ReturnsAsync(user);
         _repoMock.Setup(r => r.UpdateAsync(It.IsAny<User>())).Returns(Task.CompletedTask);
+        _orgMock.Setup(o => o.EnsureOrgForUserAsync(
+                sub, "a@b.com", "A B", PlanTier.Pro, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Org { Id = Guid.NewGuid(), PlanTier = PlanTier.Pro, Name = "A B" });
         _auth0Mock.Setup(a => a.AssignOnboardingRolesAsync(sub, It.IsAny<IReadOnlyList<UserRole>>()))
             .Returns(Task.CompletedTask);
 
         var (result, roles) = await _service.CompleteOnboardingAsync(
-            sub, RentalType.ShortTerm, "a@b.com", "A", "B");
+            sub, RentalType.ShortTerm, PlanTier.Pro, "a@b.com", "A", "B");
 
         Assert.Equal(RentalType.ShortTerm, result.RentalType);
         Assert.Equal(UserRole.PropertyOwner, result.Role);

--- a/Casazen.Web/Controllers/AdminController.cs
+++ b/Casazen.Web/Controllers/AdminController.cs
@@ -1,6 +1,7 @@
 using Casazen.Core.Services;
 using Casazen.Web.DTOs;
 using Casazen.Web.DTOs.Admin;
+using Casazen.Web.DTOs.Orgs;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -11,6 +12,8 @@ namespace Casazen.Web.Controllers;
 [Authorize(Policy = "AdminOnly")]
 public class AdminController(
     IAdminService adminService,
+    IOrgService orgService,
+    IEntitlementService entitlementService,
     ILogger<AdminController> logger) : ControllerBase
 {
     /// <summary>Returns platform KPI stats for the admin dashboard.</summary>
@@ -98,5 +101,32 @@ public class AdminController(
             LastStatus = j.LastStatus,
             NextRun = j.NextRun
         }));
+    }
+
+    /// <summary>Updates an org's plan tier. Admin only (MVP until Stripe billing).</summary>
+    [HttpPatch("orgs/{orgId:guid}/plan")]
+    public async Task<ActionResult<EntitlementDto>> UpdateOrgPlan(
+        Guid orgId,
+        [FromBody] UpdateOrgPlanDto dto,
+        CancellationToken cancellationToken)
+    {
+        if (!PlanCatalog.TryParseTier(dto.PlanTier, out var planTier))
+            return BadRequest(new { error = $"Unknown planTier: {dto.PlanTier}" });
+
+        logger.LogInformation("Admin plan change requested for org {OrgId} -> {PlanTier}", orgId, planTier);
+
+        var updated = await orgService.UpdatePlanTierAsync(orgId, planTier, cancellationToken);
+        if (updated is null)
+            return NotFound(new { error = "Organization not found" });
+
+        var entitlement = await entitlementService.GetEntitlementAsync(orgId, cancellationToken);
+        return Ok(new EntitlementDto
+        {
+            OrgId = entitlement.OrgId,
+            PlanTier = entitlement.PlanTier,
+            Limits = new EntitlementLimitsDto { MaxProperties = entitlement.MaxProperties },
+            Usage = new EntitlementUsageDto { Properties = entitlement.PropertyCount },
+            CanAddProperty = entitlement.CanAddProperty
+        });
     }
 }

--- a/Casazen.Web/Controllers/OrgsController.cs
+++ b/Casazen.Web/Controllers/OrgsController.cs
@@ -7,24 +7,33 @@ using Microsoft.AspNetCore.Mvc;
 namespace Casazen.Web.Controllers;
 
 /// <summary>
-/// Read-only org surfaces for the caller's own organization (US-004). Org management and plan
-/// switching are owned by <c>spec-saas-billing</c>; this controller only exposes entitlement.
+/// Org surfaces for the caller's organization (US-004). MVP plan catalogue and tier changes
+/// live here until <c>spec-saas-billing</c> adds Stripe Checkout for paid upgrades.
 /// </summary>
 [ApiController]
 [Route("api/orgs")]
-[Authorize]
 public class OrgsController(
     ITenantContext tenantContext,
-    IEntitlementService entitlementService) : ControllerBase
+    IEntitlementService entitlementService,
+    IOrgService orgService) : ControllerBase
 {
+    /// <summary>Returns available plan tiers and property limits.</summary>
+    [HttpGet("plans")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(IEnumerable<PlanDto>), StatusCodes.Status200OK)]
+    public ActionResult<IEnumerable<PlanDto>> GetPlans() =>
+        Ok(PlanCatalog.All.Select(p => new PlanDto
+        {
+            Tier = p.Tier.ToString(),
+            DisplayName = p.DisplayName,
+            MaxProperties = p.MaxProperties == int.MaxValue ? -1 : p.MaxProperties,
+            Description = p.Description,
+        }));
+
     /// <summary>
     /// Returns the caller org's plan entitlement: tier, limits, current usage, and whether
-    /// another property may be created (AC8). The <c>OrgId</c> is resolved from the authenticated
-    /// principal via <see cref="ITenantContext"/> and is never accepted from the client.
+    /// another property may be created (AC8).
     /// </summary>
-    /// <response code="200">Entitlement for the caller's org.</response>
-    /// <response code="401">The caller is not authenticated.</response>
-    /// <response code="404">The caller is not assigned to an org yet.</response>
     [HttpGet("me/entitlement")]
     [Authorize(Policy = "RequireContext:short-rent:property.read")]
     [ProducesResponseType(typeof(EntitlementDto), StatusCodes.Status200OK)]
@@ -38,6 +47,42 @@ public class OrgsController(
 
         var entitlement = await entitlementService.GetEntitlementAsync(orgId.Value, cancellationToken);
 
+        return Ok(new EntitlementDto
+        {
+            OrgId = entitlement.OrgId,
+            PlanTier = entitlement.PlanTier,
+            Limits = new EntitlementLimitsDto { MaxProperties = entitlement.MaxProperties },
+            Usage = new EntitlementUsageDto { Properties = entitlement.PropertyCount },
+            CanAddProperty = entitlement.CanAddProperty
+        });
+    }
+
+    /// <summary>
+    /// Updates the caller's org plan tier (MVP self-serve change before Stripe billing).
+    /// Downgrades are allowed even when usage exceeds the new limit; existing properties remain,
+    /// but new creates are blocked until usage is under the limit.
+    /// </summary>
+    [HttpPut("me/plan")]
+    [Authorize]
+    [ProducesResponseType(typeof(EntitlementDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<EntitlementDto>> UpdateMyPlan(
+        [FromBody] UpdateOrgPlanDto dto,
+        CancellationToken cancellationToken)
+    {
+        if (!PlanCatalog.TryParseTier(dto.PlanTier, out var planTier))
+            return BadRequest(new { error = $"Unknown planTier: {dto.PlanTier}" });
+
+        var orgId = tenantContext.OrgId;
+        if (orgId is null)
+            return NotFound(new { error = "No organization assigned to the current user" });
+
+        var updated = await orgService.UpdatePlanTierAsync(orgId.Value, planTier, cancellationToken);
+        if (updated is null)
+            return NotFound(new { error = "Organization not found" });
+
+        var entitlement = await entitlementService.GetEntitlementAsync(orgId.Value, cancellationToken);
         return Ok(new EntitlementDto
         {
             OrgId = entitlement.OrgId,

--- a/Casazen.Web/Controllers/UsersController.cs
+++ b/Casazen.Web/Controllers/UsersController.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
 using Casazen.Core.Services;
 using Casazen.Web.DTOs;
 using Casazen.Web.DTOs.Users;
@@ -31,10 +32,13 @@ public class UsersController(
         pageSize = Math.Min(pageSize, 100);
         logger.LogInformation("Admin: listing users page={Page} pageSize={PageSize}", page, pageSize);
         var (users, total) = await userService.GetPagedAsync(search, role, isActive, page, pageSize);
+        var userList = users.ToList();
+        var orgIds = userList.Where(u => u.OrgId.HasValue).Select(u => u.OrgId!.Value);
+        var orgMap = await orgService.GetByIdsAsync(orgIds, HttpContext.RequestAborted);
 
         return Ok(new PagedResultDto<UserSummaryDto>
         {
-            Items = users.Select(ToSummary),
+            Items = userList.Select(u => ToSummary(u, u.OrgId is Guid id && orgMap.TryGetValue(id, out var org) ? org : null)),
             TotalCount = total,
             Page = page,
             PageSize = pageSize
@@ -161,6 +165,13 @@ public class UsersController(
         if (!Enum.TryParse<RentalType>(dto.RentalType, ignoreCase: true, out var rentalType))
             return BadRequest(new { error = $"Unknown rentalType: {dto.RentalType}" });
 
+        var planTier = PlanTier.Starter;
+        if (!string.IsNullOrWhiteSpace(dto.PlanTier))
+        {
+            if (!PlanCatalog.TryParseTier(dto.PlanTier, out planTier))
+                return BadRequest(new { error = $"Unknown planTier: {dto.PlanTier}" });
+        }
+
         var sub = GetSub();
         if (sub == null)
             return Unauthorized();
@@ -176,7 +187,7 @@ public class UsersController(
                        ?? string.Empty;
 
         var (user, rolesAssigned) = await userService.CompleteOnboardingAsync(
-            sub, rentalType, email, firstName, lastName);
+            sub, rentalType, planTier, email, firstName, lastName);
 
         return Ok(new OnboardingResponseDto
         {
@@ -192,7 +203,7 @@ public class UsersController(
         ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value
         ?? User.FindFirst("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")?.Value;
 
-    private static UserSummaryDto ToSummary(User u) => new()
+    private static UserSummaryDto ToSummary(User u, Org? org = null) => new()
     {
         Id = u.Id,
         Email = u.Email,
@@ -201,7 +212,10 @@ public class UsersController(
         Role = u.Role.ToString(),
         RentalType = u.RentalType?.ToString(),
         IsActive = u.IsActive,
-        CreatedAt = u.CreatedAt
+        CreatedAt = u.CreatedAt,
+        OrgId = u.OrgId,
+        OrgName = org?.Name,
+        PlanTier = org?.PlanTier.ToString(),
     };
 
     private async Task<Org?> ResolveOrgAsync(User user) =>

--- a/Casazen.Web/DTOs/Orgs/PlanDto.cs
+++ b/Casazen.Web/DTOs/Orgs/PlanDto.cs
@@ -1,0 +1,9 @@
+namespace Casazen.Web.DTOs.Orgs;
+
+public class PlanDto
+{
+    public string Tier { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public int MaxProperties { get; set; }
+    public string Description { get; set; } = string.Empty;
+}

--- a/Casazen.Web/DTOs/Orgs/UpdateOrgPlanDto.cs
+++ b/Casazen.Web/DTOs/Orgs/UpdateOrgPlanDto.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Casazen.Web.DTOs.Orgs;
+
+public class UpdateOrgPlanDto
+{
+    [Required]
+    public string PlanTier { get; set; } = string.Empty;
+}

--- a/Casazen.Web/DTOs/Users/OnboardingRequestDto.cs
+++ b/Casazen.Web/DTOs/Users/OnboardingRequestDto.cs
@@ -6,4 +6,7 @@ public class OnboardingRequestDto
 {
     [Required]
     public string RentalType { get; set; } = string.Empty;
+
+    /// <summary>Initial org plan tier. Defaults to Starter when omitted.</summary>
+    public string? PlanTier { get; set; }
 }

--- a/Casazen.Web/DTOs/Users/UserDetailDto.cs
+++ b/Casazen.Web/DTOs/Users/UserDetailDto.cs
@@ -5,9 +5,6 @@ public class UserDetailDto : UserSummaryDto
     public string? PhoneNumber { get; set; }
     public DateTime UpdatedAt { get; set; }
 
-    /// <summary>The caller's organization id (AC9). <c>null</c> for a brand-new user pre-backfill.</summary>
-    public Guid? OrgId { get; set; }
-
     /// <summary>The caller's organization summary (AC9), or <c>null</c> when the user has no org.</summary>
     public OrgSummaryDto? Org { get; set; }
 }

--- a/Casazen.Web/DTOs/Users/UserSummaryDto.cs
+++ b/Casazen.Web/DTOs/Users/UserSummaryDto.cs
@@ -10,4 +10,7 @@ public class UserSummaryDto
     public string? RentalType { get; set; }
     public bool IsActive { get; set; }
     public DateTime CreatedAt { get; set; }
+    public Guid? OrgId { get; set; }
+    public string? OrgName { get; set; }
+    public string? PlanTier { get; set; }
 }

--- a/Sessions/specs/spec-onboarding-plg.md
+++ b/Sessions/specs/spec-onboarding-plg.md
@@ -1,0 +1,111 @@
+# Spec — Self-Serve Onboarding & Activation (PLG) (US-006)
+
+## Overview
+
+`spec-role-onboarding` covers the first-run **role choice** (short-term / long-term / both → Auth0
+roles) for an already-signed-in user. This spec extends it into a full **product-led-growth (PLG)**
+flow: a self-serve signup that **provisions a tenant `Org`** (`spec-tenant-boundary`), captures the
+**legal consents** required to launch (GDPR consent + ToS + **DPA** + **subprocessor list**), and then
+**drives the user to activation** — the two milestones that prove value: **publish a branded booking
+site** and **take a first booking**.
+
+Activation is the GTM north-star ("time-to-first-direct-booking"), so the flow includes an activation
+checklist that tracks these milestones across the new public surfaces.
+
+Phase: **1 (MVP Sellable — onboarding/PLG)** · User story: **US-006**
+Stage of entry: **Stage 01 Planning** (new macro-spec)
+
+---
+
+## User Story
+
+As a new operator, I want to sign up myself, accept the required legal terms, choose how I use CasaZen,
+get my own organization, and be guided step-by-step to publish my booking site and take my first
+booking — so that I reach value without sales hand-holding.
+
+As CasaZen, I want every new account to have an `Org`, recorded consents (GDPR/ToS/DPA + subprocessor
+acknowledgement) with versions and timestamps, and a measurable activation funnel.
+
+---
+
+## Acceptance Criteria
+
+### Backend
+
+- **AC1**: `POST /api/users/onboarding` (extends `spec-role-onboarding`) provisions an **`Org`** for the new user if none exists (`spec-tenant-boundary`: create `Org`, set `User.OrgId`, **`PlanTier` from onboarding step 2** defaulting to `Starter`). Idempotent: a user who already has an `Org` is not given a second one and the existing plan is **not** overwritten on re-run.
+
+- **AC2**: The request body adds a `consents` block: `{ tosAccepted: true, tosVersion, privacyAccepted: true, privacyVersion, dpaAccepted: true, dpaVersion, subprocessorsAcknowledged: true, subprocessorsVersion, marketingOptIn? }`. The endpoint returns `400` unless `tosAccepted && privacyAccepted && dpaAccepted && subprocessorsAcknowledged` are all true.
+
+- **AC3**: Consents are persisted to a new `ConsentRecord` entity `{ Id, UserId, OrgId, type (Tos|Privacy|Dpa|Subprocessors|Marketing), version, acceptedAt, ipAddress }` — one row per consent type, append-only (re-acceptance on version bump creates a new row; history is retained).
+
+- **AC4**: `GET /api/legal/subprocessors` (`[AllowAnonymous]`) returns the current **subprocessor list** with `version`: at minimum **Supabase (EU — data hosting)**, **Auth0 (authentication)**, **Stripe (payments)**, **SendGrid (email)**, each with purpose + region. `GET /api/legal/dpa` and `/api/legal/tos` return the current document version metadata.
+
+- **AC5**: `GET /api/onboarding/status` (authenticated) returns the activation checklist for the caller's `Org`: `{ roleChosen, orgProvisioned, consentsAccepted, propertyCreated, sitePublished, firstBookingTaken }` (each bool) + an overall `activated` flag.
+
+- **AC6**: Activation milestones are derived from real state — `propertyCreated` from the org having ≥1 `Property`; `sitePublished` when the org's branded site is enabled (`Org.IsActive` + ≥1 active property, per `spec-branded-booking-site`); `firstBookingTaken` when the org has ≥1 `Confirmed` direct `Booking` (per `spec-direct-checkout`). No manual flags that can drift from reality.
+
+- **AC7**: `PUT /api/users/onboarding` (idempotent re-run from settings, per `spec-role-onboarding`) keeps the existing `Org` and consents; only role/`rentalType` changes are applied. Admins bypass the onboarding guard (`spec-role-onboarding` AC9).
+
+### Frontend
+
+- **AC8**: The onboarding flow (extending `src/features/onboarding/onboarding-page.tsx`) becomes a short wizard: **(1) role choice** (existing cards) → **(2) legal consents** → completion. Step 2 shows checkboxes for **ToS**, **Privacy Policy**, **DPA**, and **subprocessor list** (with a link/expander listing Supabase EU, Auth0, Stripe, SendGrid), plus optional marketing opt-in. "Continua" is disabled until the four required boxes are checked.
+
+- **AC9**: On completion the FE calls the enhanced `POST /api/users/onboarding` with `rentalType` + `consents`, then refreshes the Auth0 token (`getAccessTokenSilently({ ignoreCache: true })`) and `useUserStore`/`useCurrentUser` (so the new `org` + roles are present), then routes to the dashboard.
+
+- **AC10**: An **activation checklist** widget (`src/features/onboarding/components/activation-checklist.tsx`) on the dashboard renders `GET /api/onboarding/status`: each step shows done/todo with a deep link — "Crea proprietà" → property create, "Pubblica il sito" → branded-site settings, "Prima prenotazione" → share the public booking URL. The widget hides once `activated` is true.
+
+- **AC11**: A legal subprocessor view (`src/features/legal/subprocessors-page.tsx`, public) renders `GET /api/legal/subprocessors`; linked from the onboarding consents step and the public site footer. End-user strings in Italian (e.g. "Responsabili del trattamento", "Informativa sulla privacy").
+
+- **AC12 (Regression)**: The existing `OnboardingGuard` ordering from `spec-role-onboarding` is preserved (guard after `<ProtectedRoute>`, before `AppLayerProvider`; `/onboarding` outside the guard to avoid redirect loops); demo mode (`VITE_DEMO_MODE`) still renders the flow without Auth0.
+
+---
+
+## Technical Notes
+
+### Backend
+
+| File | Action |
+|---|---|
+| `Casazen.Web/Controllers/UsersController.cs` | Modify — enhance `POST/PUT /api/users/onboarding`: provision `Org` + persist consents (AC1–AC3, AC7) |
+| `Casazen.Web/Controllers/OnboardingController.cs` | Create — `GET /api/onboarding/status` activation checklist (AC5–AC6) |
+| `Casazen.Web/Controllers/LegalController.cs` | Create — `[AllowAnonymous]` `GET /api/legal/subprocessors|dpa|tos` (AC4) |
+| `Casazen.Core/Entities/ConsentRecord.cs` | Create — append-only consent log (AC3) |
+| `Casazen.Infrastructure/Data/AppDbContext.cs` | Modify — `DbSet<ConsentRecord>` + indexes (`UserId`, `OrgId`, `type`) |
+| `Casazen.Infrastructure/Migrations/<ts>_AddConsentRecords.cs` | Create — consent table (rebased on snapshot per RF3) |
+| `Casazen.Core/Services/IOnboardingService.cs` + `Infrastructure/Services/OnboardingService.cs` | Create — provision org, record consents, compute activation status |
+| `Casazen.Infrastructure/Services/OrgService.cs` | Modify — `EnsureOrgForUserAsync` (reuse from `spec-tenant-boundary`) |
+| `Casazen.Core/Services/IUserService.cs` | Modify — onboarding takes consents payload |
+| `Casazen.Web/Extensions/ServiceCollectionExtensions.cs` | Modify — register `IOnboardingService` |
+
+### Frontend
+
+| File | Action |
+|---|---|
+| `src/features/onboarding/onboarding-page.tsx` | Modify — add legal-consents step to the wizard (AC8) |
+| `src/features/onboarding/components/consents-step.tsx` | Create — ToS/Privacy/DPA/subprocessors checkboxes (AC8) |
+| `src/features/onboarding/components/activation-checklist.tsx` | Create — dashboard activation widget (AC10) |
+| `src/features/legal/subprocessors-page.tsx` | Create — public subprocessor list (AC11) |
+| `src/api/users.api.ts` | Modify — `postOnboarding(rentalType, consents)` |
+| `src/api/legal.api.ts` | Create — `getSubprocessors()`, `getDpa()`, `getTos()` |
+| `src/queries/use-onboarding.ts` | Create — `useOnboardingStatus()`, `useCompleteOnboarding()` |
+| `src/types/onboarding.types.ts` | Create — `ConsentsPayload`, `OnboardingStatus`, `Subprocessor` |
+| `src/features/dashboard/dashboard-page.tsx` | Modify — mount activation checklist widget |
+
+---
+
+## Compliance
+
+- **GDPR consent + ToS**: required consents (Privacy + ToS) captured at signup with **version + timestamp + IP**, append-only in `ConsentRecord` (AC2–AC3); demonstrable consent per GDPR Art. 7.
+- **DPA (data processing agreement)**: the operator (`Org` = data controller) accepts a DPA with CasaZen (processor) at onboarding — the controller/processor delineation from `spec-tenant-boundary` is made contractual here (Legal C5).
+- **Subprocessor list**: explicit acknowledgement of **Supabase (EU hosting)**, **Auth0**, **Stripe**, **SendGrid** with purpose/region, exposed publicly and versioned (AC4, AC11); re-acknowledgement required on version bump.
+- **Data minimization**: onboarding stores only what is needed (role, org, consent metadata); no guest/tenant PII handled in this flow.
+
+---
+
+## Dependencies
+
+- **Requires**: `spec-role-onboarding` (role-choice flow, `OnboardingGuard`, `POST/PUT /api/users/onboarding`, `User.RentalType`); `spec-admin-backend` (Auth0 Management API client / `Auth0ManagementService`, `UsersController`, `/me`); `spec-tenant-boundary` (`Org` provisioning + `User.OrgId`).
+- **Requires (activation signals)**: `spec-branded-booking-site` (`sitePublished`) and `spec-direct-checkout` (`firstBookingTaken`) for the checklist to reflect real milestones.
+- **Blocks**: PLG GTM motion (self-serve activation funnel) and the Phase 1 exit criterion "an external PM self-onboards".
+- **Related**: `spec-saas-billing` (post-activation upgrade prompt links into billing).
+- **Does not touch**: `LayerSwitcher`, `AppLayerProvider`, lease subsystem, OTA adapters.

--- a/Sessions/specs/spec-saas-billing.md
+++ b/Sessions/specs/spec-saas-billing.md
@@ -1,0 +1,129 @@
+# Spec — SaaS Subscription Billing (Platform Account) (US-005)
+
+## Overview
+
+Today Stripe charges **guests** (booking payments); there is **no subscription billing to charge
+CasaZen's own customers**. This is a hard "sellable" gate. This spec adds **subscription billing**
+(tiers/seats) for CasaZen's customers (the `Org`s) via **Stripe Billing on the platform account** —
+distinct from the **connected-account** Stripe Connect flows in `spec-direct-checkout` (guest funds,
+operator = MoR). Here CasaZen **is** the merchant: the `Org` is a Stripe **Customer** on CasaZen's
+platform account and pays a recurring subscription mapped to its `PlanTier`.
+
+Because billing and the Connect flows **share** `WebhooksController` + `StripeWebhookJob` +
+`StripeWebhookHandler`, this spec owns the **platform-account** webhook routing (RF2): platform events
+(`customer.subscription.*`, `invoice.*`) are verified with the **platform** signing secret and routed
+separately from connected-account events.
+
+Italian tax wiring (IVA/OSS + SDI *fattura elettronica*) is a regulatory gate and is marked
+**[COUNSEL_REQUIRED]**; the **"P.IVA + SDI live" entry gate must be satisfied before the first charge**.
+
+Phase: **1 (MVP Sellable — billing)** · User story: **US-005**
+Stage of entry: **Stage 01 Planning** (new macro-spec)
+
+---
+
+## User Story
+
+As a CasaZen customer (an `Org` admin), I want to choose a plan (Starter/Pro/Scale) and pay a recurring
+subscription by card, manage my billing in a self-serve portal, and receive a tax-correct invoice, so
+that I can use CasaZen as a paid product.
+
+As CasaZen, I want subscription state to drive plan entitlement, platform-account webhooks to be routed
+and verified separately from guest-payment (Connect) webhooks, and Italian IVA/OSS + SDI e-invoicing to
+be handled correctly before the first euro is charged.
+
+---
+
+## Acceptance Criteria
+
+### Backend
+
+- **AC1**: `GET /api/billing/plans` (authenticated) returns the available tiers `{ tier, displayName, priceMonthly, currency, unitAllowance, features[] }` mapped to Stripe **Price** ids (platform account). Read-only catalogue.
+
+- **AC2**: `POST /api/billing/checkout-session` (Org admin) creates a **Stripe Billing Checkout Session** (mode `subscription`) on the **platform account** for the caller's `Org`, ensuring the `Org` has a Stripe **Customer** (`Org.StripeCustomerId`, created if missing), and returns `{ checkoutUrl }`. Selected `PlanTier` is carried in metadata `{ orgId, planTier }`.
+
+- **AC3**: `POST /api/billing/portal-session` (Org admin) creates a **Stripe Billing Customer Portal** session for `Org.StripeCustomerId` and returns `{ portalUrl }` (plan change, payment method, cancel, invoice history are delegated to the Stripe-hosted portal).
+
+- **AC4**: `GET /api/billing/subscription` (Org admin) returns the org's current `{ planTier, status (active|past_due|canceled|trialing), currentPeriodEnd, seats }`.
+
+- **AC5 (RF2 — platform-account webhook routing)**: `POST /webhooks/stripe` handles **platform-account** events only, verified with `Stripe:WebhookSecret`. On `customer.subscription.created|updated|deleted` and `invoice.paid|payment_failed`, it updates `Org.PlanTier` + subscription status and **re-syncs plan entitlement** (`IEntitlementService`). Connected-account events (`Stripe:ConnectWebhookSecret`, `spec-direct-checkout`) are **not** handled on this route. Processing stays async via `StripeWebhookJob` with a `source = platform` discriminator; handling is idempotent by Stripe event id.
+
+- **AC6**: Subscription status drives access — an `Org` whose subscription is `canceled`/`past_due` beyond grace is **downgraded** (entitlement reflects Starter/locked); reactivation on `invoice.paid` restores the tier. No data is deleted on downgrade.
+
+- **AC7 [COUNSEL_REQUIRED — IVA/OSS matrix]**: An `IVatCalculationService` resolves the correct VAT treatment per customer:
+  - **IT customer** → **IVA 22%**.
+  - **EU B2B (valid VAT id)** → **reverse charge**, with the VAT id validated via **VIES** (`IViesService`); invoice notes reverse charge.
+  - **EU B2C** → **OSS** scheme once the **€10,000** cross-border threshold is exceeded (destination-country VAT); below threshold, IT IVA.
+  - Customer country + VAT id are captured at checkout and stored on the `Org`/billing profile. The exact wiring (rates table, threshold tracking, OSS reporting export) is **[COUNSEL_REQUIRED]**.
+
+- **AC7b (OSS threshold monitoring — engineering build item, distinct from the [COUNSEL_REQUIRED] legal sign-off; DA amendment)**: a running **cross-border EU-B2C revenue counter** tracks cumulative EU-B2C sales for the calendar year. When the cumulative total crosses **€10,000**, the system **auto-switches** subsequent EU-B2C invoices to destination-country VAT (OSS) and records the switchover on `PlatformInvoice`. This counter + switchover state machine is an explicit build item (a tally + state transition), **not** deferred to counsel; counsel still signs off rates/reporting. A test asserts the **first over-threshold EU-B2C sale is invoiced at destination VAT** (not IT 22%).
+
+- **AC8 [COUNSEL_REQUIRED — SDI e-invoicing]**: Stripe invoices are **not** valid Italian *fattura elettronica*. For IT-resident customers, each paid subscription invoice is exported to a **`PlatformInvoice`** record and transmitted to **SDI** (Sistema di Interscambio) in FatturaPA XML via an e-invoicing provider; **imposta di bollo** applied where due. SDI transmission status is tracked. Wiring is **[COUNSEL_REQUIRED]**.
+
+- **AC9 (Entry gate)**: A startup/config self-check refuses to create any live charge unless the **"P.IVA + SDI live"** gate is satisfied (P.IVA configured **and** SDI e-invoicing channel configured). In non-prod (test keys) the gate is bypassed with a logged warning. This ties to the §A.11 vehicle decision (SRLS/SRL → 22% IVA + SDI; **forfettario is individuals-only and does not apply to SRLS/SRL**).
+
+### Frontend
+
+- **AC10**: `src/features/billing/plans-page.tsx` (Org admin) shows the tier cards from `GET /api/billing/plans` with a "Scegli piano" CTA; clicking calls `POST /api/billing/checkout-session` and redirects to Stripe Checkout (`checkoutUrl`). **Until Stripe is live**, operators use the MVP `PUT /api/orgs/me/plan` / plan settings page from `spec-tenant-boundary` AC11b.
+
+- **AC11**: `src/features/billing/billing-settings-page.tsx` shows the current subscription (`GET /api/billing/subscription`) with a "Gestisci abbonamento" button → `POST /api/billing/portal-session` redirect to the Stripe portal.
+
+- **AC12**: At checkout the FE collects **country** and optional **VAT id (Partita IVA)** for the billing profile (feeds AC7); Italian end-user strings (e.g. "Partita IVA", "Fatturazione").
+
+- **AC13**: Billing routes are Org-admin-only (behind `<ProtectedRoute>` + role check); a non-admin sees a "contatta l'amministratore" message. Subscription state badge (Attivo/Scaduto) is shown.
+
+---
+
+## Technical Notes
+
+### Backend
+
+| File | Action |
+|---|---|
+| `Casazen.Web/Controllers/BillingController.cs` | Create — plans, checkout-session, portal-session, subscription (AC1–AC4) |
+| `Casazen.Infrastructure/External/StripeBillingService.cs` | Create — **platform-account** Billing: ensure Customer, Checkout Session (subscription), Portal Session (kept separate from `StripeService` Connect flows) |
+| `Casazen.Core/Entities/Org.cs` | Modify — add `SubscriptionId?`, `SubscriptionStatus`, `BillingCountry`, `VatId?` (builds on `spec-tenant-boundary`) |
+| `Casazen.Core/Entities/PlatformInvoice.cs` | Create — SDI/IVA export tracking (AC8) |
+| `Casazen.Infrastructure/Data/AppDbContext.cs` | Modify — `DbSet<PlatformInvoice>` + indexes |
+| `Casazen.Infrastructure/Migrations/<ts>_AddBillingFields.cs` | Create — Org billing fields + `PlatformInvoice` (rebased on snapshot per RF3) |
+| `Casazen.Web/Controllers/WebhooksController.cs` | Modify (RF2) — `POST /webhooks/stripe` = platform events, `Stripe:WebhookSecret`; route with `source = platform` (Connect route owned by `spec-direct-checkout`) |
+| `Casazen.Web/BackgroundJobs/StripeWebhookJob.cs` | Modify (RF2) — accept webhook `source`; dispatch to platform vs connected handling |
+| `Casazen.Infrastructure/External/StripeWebhookHandler.cs` | Modify — handle `customer.subscription.*` + `invoice.*`; update `Org` tier/status; re-sync entitlement (AC5–AC6) |
+| `Casazen.Core/Services/IEntitlementService.cs` | Modify — entitlement reads subscription status (AC6) |
+| `Casazen.Infrastructure/External/VatCalculationService.cs` | Create — IVA/OSS matrix **[COUNSEL_REQUIRED]** (AC7) |
+| `Casazen.Infrastructure/External/ViesService.cs` | Create — EU VAT id validation (VIES) (AC7) |
+| `Casazen.Infrastructure/External/SdiEInvoiceService.cs` | Create — FatturaPA XML export + SDI transmission **[COUNSEL_REQUIRED]** (AC8) |
+| `Casazen.Web/Infrastructure/BillingEntryGate.cs` | Create — "P.IVA + SDI live" pre-charge guard (AC9) |
+| `Casazen.Web/Extensions/ServiceCollectionExtensions.cs` | Modify — register billing/VAT/VIES/SDI services + `Stripe:WebhookSecret` config |
+
+### Frontend
+
+| File | Action |
+|---|---|
+| `src/features/billing/plans-page.tsx` | Create — tier selection → Checkout redirect |
+| `src/features/billing/billing-settings-page.tsx` | Create — current plan + portal redirect |
+| `src/features/billing/components/plan-card.tsx` | Create — tier card |
+| `src/api/billing.api.ts` | Create — plans, checkout-session, portal-session, subscription |
+| `src/queries/use-billing.ts` | Create — `usePlans`, `useSubscription`, `useStartCheckout`, `useOpenPortal` |
+| `src/types/billing.types.ts` | Create — `PlanDto`, `SubscriptionDto` |
+| `src/routes/index.tsx` | Modify — add `/settings/billing` behind `<ProtectedRoute>` + admin check |
+
+---
+
+## Compliance
+
+- **Platform vs connected separation (RF2)**: platform-account Billing webhooks (`Stripe:WebhookSecret`) are verified and routed **separately** from connected-account Connect webhooks (`Stripe:ConnectWebhookSecret`, `spec-direct-checkout`). Each event source is verified with its **own** signing secret; the wrong secret rejects the event.
+- **IVA/OSS matrix [COUNSEL_REQUIRED]**: IT 22% / EU-B2B reverse charge (+ **VIES** validation) / EU-B2C **OSS** above €10k cross-border. Country + VAT id captured at checkout (AC7, AC12).
+- **SDI e-invoicing [COUNSEL_REQUIRED]**: Stripe invoices ≠ Italian *fattura elettronica*; IT invoices exported to **SDI** in FatturaPA XML, *imposta di bollo* where due (AC8).
+- **Entry gate**: **no live charge before "P.IVA + SDI live"** (AC9). Vehicle note: SRLS/SRL ⇒ 22% IVA + SDI mandatory; **regime forfettario applies to individuals/ditta only — never to SRLS/SRL** (draft-v3 §A.11). Final tax trade-off is the Financial Strategist's call.
+- **PCI/security**: card entry and invoice PDFs are Stripe-hosted (Checkout + Customer Portal); CasaZen stores only Stripe ids and tax metadata, never card data.
+
+---
+
+## Dependencies
+
+- **Requires**: `spec-tenant-boundary` (`Org` + `PlanTier` + `StripeCustomerId` + entitlement); existing Stripe integration + `WebhooksController`/`StripeWebhookJob`/`StripeWebhookHandler`.
+- **Requires (hard gate)**: P.IVA active + SDI e-invoicing channel live **before first charge** (Legal C2); resolve §A.11 vehicle (SRLS/SRL).
+- **Blocks**: monetization / "sellable" exit criterion of Phase 1 (an external PM pays CasaZen a subscription with a correct IVA/OSS + SDI invoice).
+- **Related (RF2)**: `spec-direct-checkout` (and Phase 1.5 `spec-ltr-recurring-rent`) — connected-account flows sharing the same webhook controller; coordinate signing-secret routing.
+- **[COUNSEL_REQUIRED]**: external tax/legal counsel must confirm the IVA/OSS rate logic, OSS threshold tracking/reporting, and SDI transmission wiring before go-live.

--- a/Sessions/specs/spec-tenant-boundary.md
+++ b/Sessions/specs/spec-tenant-boundary.md
@@ -1,0 +1,123 @@
+# Spec — Tenant Boundary (`Org` + `OrgId` + Plan Entitlement) (US-004)
+
+## Overview
+
+CasaZen has context-scoped RBAC (`AppContext`, `UserContextMembership`, `Role`, `RolePermission`,
+policy convention `RequireContext:{context}:{permission}`) but **no tenant boundary**: data is scoped
+per-`OwnerId` (Auth0 `sub`) + context, not isolated into an organization/tenant. Selling to PM teams
+and agencies requires an **`Org`** tenant key and an **`OrgId`** foreign key on the core tenant-scoped
+tables, plus **plan entitlement** (Starter/Pro/Scale).
+
+This spec introduces the `Org` entity, adds `OrgId` to `Property`, `Booking`, `LeaseContract`, and
+`Payment`, and a plan-entitlement service. It establishes a cross-cutting invariant and a strict
+migration sequence so existing data is preserved and the parallel Phase 1.5 work cannot ship un-scoped.
+
+> **Invariant (RF1)** — **every new tenant-scoped table MUST carry `OrgId` and honor plan entitlement.**
+> No tenant-scoped table (including the Phase 1.5 recurring-rent ledger) may ship without an `OrgId` FK.
+
+Phase: **1 (MVP Sellable — tenant boundary)** · User story: **US-004**
+Stage of entry: **Stage 01 Planning** (new macro-spec)
+
+---
+
+## User Story
+
+As a property-management company, I want all my properties, bookings, leases, and payments to belong
+to **my organization** so that my data is isolated from other CasaZen customers and my subscription
+plan limits apply to my org as a whole.
+
+As the platform, I want a single tenant key (`OrgId`) enforced on every tenant-scoped table and a
+plan-entitlement check, so that data isolation and tier limits are structural, not ad-hoc.
+
+---
+
+## Acceptance Criteria
+
+### Backend
+
+- **AC1**: New `Org` entity `{ Id (Guid), Name, Slug (unique), PlanTier (enum: Starter|Pro|Scale), DisplayName, LogoUrl?, ThemeColor?, ContactEmail, StripeCustomerId?, StripeConnectedAccountId?, IsActive, CreatedAt, UpdatedAt }`, registered as a `DbSet<Org>` with a unique index on `Slug`.
+
+- **AC2**: `OrgId` (`Guid`) foreign key added to `Property`, `Booking`, `LeaseContract`, and `Payment`, each with an index on `OrgId` and `OnDelete(DeleteBehavior.Restrict)` (deleting an `Org` must not cascade-wipe operational/financial history).
+
+- **AC3 (RF3 — migration sequencing, step 1)**: Migration `AddOrgIdNullable` adds `Org` table + **nullable** `OrgId` columns on the four tables. No data change yet. Applies cleanly to an existing populated DB.
+
+- **AC4 (RF3 — step 2)**: Migration `BackfillDefaultOrgs` creates **one default `Org` per distinct existing `Property.OwnerId`** (slug derived from owner; `PlanTier = Starter`), sets `User.OrgId` for that owner, and backfills `OrgId` on `Property`/`Booking`/`LeaseContract`/`Payment` by walking existing relationships (booking→property, payment→booking, lease→property). Idempotent and re-runnable; verified row-counts logged.
+
+- **AC5 (RF3 — step 3)**: Migration `MakeOrgIdRequired` sets the four `OrgId` columns **NOT NULL** and adds the FK constraints, only after AC4 backfill leaves zero NULLs. The three migrations land **in order**, **before** any Phase 1.5 migration.
+
+- **AC6 (RF3 — snapshot discipline)**: After these migrations, Phase 1.5 (and all later) migrations **rebase onto the regenerated `AppDbContextModelSnapshot.cs`** — the snapshot is **never hand-merged**. New Phase 1.5 tables carry `OrgId` from creation (enforcing RF1).
+
+- **AC7**: A tenant resolution mechanism: `ITenantContext` resolves the caller's `OrgId` from the authenticated `User` (`User.OrgId`), and an EF **global query filter** (or repository-level filter) scopes `Property`/`Booking`/`LeaseContract`/`Payment` reads to the caller's `OrgId`. Cross-org access returns empty/`404`, not another org's rows. (Anonymous public endpoints from `spec-public-booking-readmodel`/`spec-branded-booking-site` filter by explicit `orgId`, not the caller filter.)
+
+- **AC8**: Plan entitlement — `IEntitlementService.CanAddProperty(orgId)` (and a generic `GetEntitlement(orgId)`) enforces per-tier limits (e.g. Starter unit cap) sourced from a tier→limits map; `Property` creation returns `403`/`409` with a clear "plan limit reached" error when the org is over its tier limit.
+
+- **AC9**: `User` gains `OrgId` (FK to `Org`); membership of a user in an org is established at onboarding/backfill. `GET /api/users/me` returns the caller's `{ orgId, org: { id, name, slug, planTier } }` so the FE can surface the current org.
+
+- **AC10 (Regression)**: Existing authenticated endpoints keep working post-migration with backfilled data (an existing owner sees exactly their pre-migration properties/bookings/leases/payments, now under their default `Org`); no orphaned rows; `dotnet test` migration/integration suites pass against `casazen_test`.
+
+- **AC10b (Migration safety / rollback — DA amendment)**: each of the three migrations has a **tested down-migration** (`MakeOrgIdRequired` → revert to nullable; `BackfillDefaultOrgs` → documented reversible/no-op; `AddOrgIdNullable` → drop `OrgId` + `Org`). Before the `MakeOrgIdRequired` NOT-NULL flip, a **pre-flight check fails loudly if any tenant-scoped row still has a NULL `OrgId`** (e.g. direct-booking guests/bookings created without an owner): such rows are assigned to a dedicated fallback `Org` or quarantined per an explicit rule — **never silently NOT-NULL-flipped**. The three steps run as **separate deploys** (nullable → backfill → NOT NULL) so writes are never blocked mid-migration (online/zero-downtime).
+
+### Frontend
+
+- **AC11**: `src/types/user.types.ts` / `org.types.ts` add `Org` + `planTier` to the current-user model; `src/queries/use-users.ts` `useCurrentUser` surfaces `org`. The owner console header shows the current org name + plan badge with link to plan settings.
+
+- **AC11b (MVP plan management — pre-Stripe)**: Onboarding wizard step 2 lets the operator pick **Starter/Pro/Scale** (`POST /api/users/onboarding` with `planTier`). `GET /api/orgs/plans` returns the catalogue. `PUT /api/orgs/me/plan` lets the org owner change tier. Admin uses `PATCH /api/admin/orgs/{orgId}/plan`. UI: `plan-settings-page.tsx`, admin **Piano** action on users table. **Paid checkout** remains in `spec-saas-billing`.
+
+- **AC12**: When property creation is blocked by entitlement (`403`/`409` "plan limit reached"), the UI shows an Italian message (e.g. "Hai raggiunto il limite del tuo piano") with a link toward `/app/short-rent/settings/plan`.
+
+---
+
+## Technical Notes
+
+### Backend
+
+| File | Action |
+|---|---|
+| `Casazen.Core/Entities/Org.cs` | Create — tenant entity (AC1) |
+| `Casazen.Core/Entities/Enums/PlanTier.cs` | Create — `Starter|Pro|Scale` |
+| `Casazen.Core/Entities/Property.cs` | Modify — add `Guid OrgId` + nav |
+| `Casazen.Core/Entities/Booking.cs` | Modify — add `Guid OrgId` + nav |
+| `Casazen.Core/Entities/LeaseContract.cs` | Modify — add `Guid OrgId` + nav |
+| `Casazen.Core/Entities/Payment.cs` | Modify — add `Guid OrgId` + nav |
+| `Casazen.Core/Entities/User.cs` | Modify — add `Guid? OrgId` + nav (AC9) |
+| `Casazen.Infrastructure/Data/AppDbContext.cs` | Modify — `DbSet<Org>`, relationships, indexes, `Slug` unique, global query filter (AC7) |
+| `Casazen.Infrastructure/Migrations/<ts>_AddOrgIdNullable.cs` | Create — step 1 (AC3) |
+| `Casazen.Infrastructure/Migrations/<ts>_BackfillDefaultOrgs.cs` | Create — step 2 data migration (AC4) |
+| `Casazen.Infrastructure/Migrations/<ts>_MakeOrgIdRequired.cs` | Create — step 3 NOT NULL + FK (AC5) |
+| `Casazen.Infrastructure/Migrations/AppDbContextModelSnapshot.cs` | Modify — **regenerated** by EF, never hand-merged (AC6) |
+| `Casazen.Core/Services/IOrgService.cs` | Create — org CRUD + `GetPublicBySlugAsync` |
+| `Casazen.Infrastructure/Services/OrgService.cs` | Create — implementation |
+| `Casazen.Core/Services/IEntitlementService.cs` | Create — plan-limit checks (AC8) |
+| `Casazen.Infrastructure/Services/EntitlementService.cs` | Create — tier→limits map |
+| `Casazen.Web/Infrastructure/ITenantContext.cs` + `TenantContext.cs` | Create — resolve caller `OrgId` (AC7) |
+| `Casazen.Web/Controllers/PropertiesController.cs` | Modify — entitlement check on `Create` (AC8); set `OrgId` from tenant context |
+| `Casazen.Web/Controllers/MeController.cs` | Modify — return `org` in `/me` (AC9) |
+| `Casazen.Web/Extensions/ServiceCollectionExtensions.cs` | Modify — register `IOrgService`, `IEntitlementService`, `ITenantContext` |
+
+### Frontend
+
+| File | Action |
+|---|---|
+| `src/types/org.types.ts` | Create — `Org`, `PlanTier` |
+| `src/types/user.types.ts` | Modify — add `org` to current user |
+| `src/queries/use-users.ts` | Modify — surface `org` from `/me` |
+| `src/components/layout/header.tsx` | Modify — show org name + plan badge |
+| `src/features/properties/property-create-page.tsx` | Modify — handle entitlement `403`/`409` (AC12) |
+
+---
+
+## Compliance
+
+- **Tenant data isolation**: `OrgId` FK on every tenant-scoped table + tenant query filter ensure cross-customer isolation; **RF1 invariant** binds all future tenant-scoped tables (incl. the Phase 1.5 rent ledger) to carry `OrgId`.
+- **GDPR controller/processor delineation**: each `Org` is the **data controller** for its guests'/tenants' personal data; **CasaZen is the data processor**. This boundary underpins the DPA in `spec-onboarding-plg` and per-org erasure/retention scoping.
+- **Data-integrity safety**: `OnDelete(Restrict)` on org FKs prevents accidental cascade-deletion of bookings/payments/leases; the 3-step migration preserves all existing rows (AC10).
+- **Migration safety (RF3)**: nullable → backfill → NOT NULL ordering plus snapshot-rebase discipline removes the Phase 1 ↔ 1.5 merge-order ambiguity (resolves draft-v3 §D Q1).
+
+---
+
+## Dependencies
+
+- **Requires**: context-RBAC primitives (`AppContext`/`UserContextMembership`/`Role`/`RolePermission`) and EF Core migrations baseline; an applied, green migration history on `casazen_test`.
+- **Blocks**: `spec-direct-checkout` (needs `Org.StripeConnectedAccountId`), `spec-branded-booking-site` (needs `Org` slug + branding), `spec-saas-billing` (needs `Org` + `PlanTier` + `StripeCustomerId`), `spec-onboarding-plg` (provisions an `Org`), and the Phase 1.5 `spec-ltr-recurring-rent` ledger (must inherit `OrgId` via RF1).
+- **Related**: `spec-org-seats-collaboration` (Phase 2) extends `UserContextMembership`/`RequireContext` with seat RBAC on top of this `Org` boundary.
+- **Does not touch**: OTA adapters, pricing adapter, Alloggiati/tax services (their tables gain `OrgId` only transitively via `Property`/`Booking`).

--- a/docs/INFRA.md
+++ b/docs/INFRA.md
@@ -76,7 +76,7 @@ CasaZen uses **native deploys** from each provider’s GitHub app. GitHub Action
 | **Railway** | Railway GitHub integration → `casazen/backend` | Railway dashboard → each environment (`test` / `production`) |
 | **Vercel** | Vercel GitHub integration → `casazen/frontend` | Vercel dashboard → Preview / Production; `vercel.json` sets `outputDirectory: dist` |
 
-**Production FE sanity check** (Stage 05 G10/G17): `curl -sf https://casazen.vercel.app` must return HTML containing `id="root"`. If the body shows `.env` placeholders or `GEMINI_API_KEY`, the Vercel project/domain is mislinked — fix the project root and output directory in the Vercel dashboard before promoting to `main`.
+**Production FE sanity check** (Stage 05 G10/G17): `curl -sf https://casazen-app.vercel.app` must return HTML containing `id="root"`. Do **not** use `https://casazen.vercel.app` (mislinked domain — issue #187). If the body shows `.env` placeholders or `GEMINI_API_KEY`, the Vercel project/domain is mislinked — fix the project root and output directory in the Vercel dashboard before promoting to `main`.
 | **Supabase** | Hosted DB (no app deploy) | Supabase dashboard; optional secrets synced to GitHub by Supabase integration |
 
 ### What GitHub Actions still do
@@ -370,7 +370,7 @@ ASPNETCORE_URLS=http://+:8080
 PORT=8080
 ConnectionStrings__DefaultConnection=Host=db.YOUR_REF.supabase.co;Port=5432;Database=postgres;Username=postgres;Password=YOUR_PASSWORD;SearchPath=casazen_test;SSL Mode=Require;Trust Server Certificate=true
 Auth0__Domain=[your-tenant.auth0.com]
-Auth0__Audience=[https://api.casazen.app]
+Auth0__Audience=https://casazen-api
 Stripe__SecretKey=[sk_live_... or sk_test_...]
 Stripe__WebhookSecret=[whsec_...]
 Email__SendGridApiKey=[SG....]
@@ -408,12 +408,14 @@ Used only for CI health checks and PR link comments — **not** for Railway runt
 
 In Vercel dashboard → Settings → Environment Variables:
 
-| Variable | Preview | Production |
+| Variable | Preview (develop / PR) | Production (main) |
 |---|---|---|
 | `VITE_API_BASE_URL` | `https://casazen-api-test.up.railway.app/api` | `https://casazen-api.up.railway.app/api` |
-| `VITE_AUTH0_DOMAIN` | `dev-mp6wadq7j6bophl5.us.auth0.com` (your Auth0 tenant) | prod tenant when ready |
-| `VITE_AUTH0_CLIENT_ID` | `[dev client id]` | `[prod client id]` |
-| `VITE_AUTH0_AUDIENCE` | `https://casazen-api` | `https://api.casazen.app` |
+| `VITE_AUTH0_DOMAIN` | `dev-mp6wadq7j6bophl5.us.auth0.com` | same until prod Auth0 tenant is ready |
+| `VITE_AUTH0_CLIENT_ID` | `[dev client id]` | same SPA client until prod tenant is ready |
+| `VITE_AUTH0_AUDIENCE` | `https://casazen-api` | **`https://casazen-api`** (must match Railway `Auth0__Audience` on **both** environments) |
+
+> **Critical:** Preview and Production must point to **different** `VITE_API_BASE_URL` hosts (test vs prod Railway). If Production accidentally uses the test API URL, staging will look fine while production users hit the wrong backend/schema. After every `main` deploy, CI runs `prod-deploy-smoke` to catch this.
 
 ### Git branches and deploy mapping
 
@@ -501,8 +503,17 @@ Created in Stage 05 when an Epic-linked feature is released:
 - Version: v1.3.0
 - Tag: (pending)
 - BE prod: https://casazen-api.up.railway.app
-- FE prod: https://casazen.vercel.app
+- FE prod: https://casazen-app.vercel.app
 - Released: (pending)
+
+### Stage 05 Phase D checklist (mandatory)
+
+After merge `develop` → `main`:
+
+1. `.\scripts\migrate.ps1 -Target prod` — apply EF migrations to `casazen_prod` **before** relying on prod traffic
+2. `.\scripts\release-smoke.ps1` — health + auth gates + FE SPA
+3. `E2E_PROD_SMOKE=1 npm run test:e2e -- prod-deploy-smoke` (frontend repo) — authenticated prod FE + prod API
+4. Confirm GitHub Actions `verify-prod` + frontend `e2e-deploy-smoke` on `main` are green
 ```
 
 ### Bundle gate in Stage 05
@@ -522,6 +533,7 @@ Before allowing production promotion, the coordinator checks:
 |---|---|---|
 | Variable | `RAILWAY_TEST_URL` | Health check after push to `develop`; PR comment link |
 | Variable | `RAILWAY_PROD_URL` | Health check after push to `main` |
+| Variable | `STAGING_FE_URL` | Vercel develop deployment URL for staging FE smoke (frontend repo) |
 
 ### Optional
 

--- a/scripts/release-smoke.ps1
+++ b/scripts/release-smoke.ps1
@@ -1,0 +1,114 @@
+#!/usr/bin/env pwsh
+# Post-release production smoke — run after develop → main merge (Stage 05 Phase D).
+# Fails fast on health, auth-gate regressions, and missing tenant endpoints.
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$ProdApiUrl = $env:RAILWAY_PROD_URL,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ProdFeUrl = 'https://casazen-app.vercel.app',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipMigrations
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($ProdApiUrl)) {
+    $ProdApiUrl = 'https://casazen-api.up.railway.app'
+}
+
+$ProdApiUrl = $ProdApiUrl.TrimEnd('/')
+$apiBase = "$ProdApiUrl/api"
+
+function Test-HttpStatus {
+    param(
+        [string]$Url,
+        [int[]]$AllowedStatuses,
+        [string]$Label
+    )
+
+    try {
+        $response = Invoke-WebRequest -Uri $Url -Method Get -SkipHttpErrorCheck
+        $status = [int]$response.StatusCode
+    }
+    catch {
+        Write-Error "$Label failed: $_"
+        return $false
+    }
+
+    if ($AllowedStatuses -notcontains $status) {
+        Write-Error "$Label expected one of [$($AllowedStatuses -join ', ')] but got $status — $Url"
+        return $false
+    }
+
+    if ($status -eq 500) {
+        Write-Error "$Label returned 500 — likely pending EF migration on casazen_prod. Run: .\scripts\migrate.ps1 -Target prod"
+        return $false
+    }
+
+    Write-Host "OK $Label ($status)"
+    return $true
+}
+
+Write-Host "=== CasaZen production smoke ==="
+Write-Host "API: $ProdApiUrl"
+Write-Host "FE:  $ProdFeUrl"
+Write-Host ""
+
+if (-not $SkipMigrations) {
+    Write-Host "Applying EF migrations to prod schema (casazen_prod)..."
+    & "$PSScriptRoot\migrate.ps1" -Target prod
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+    Write-Host ""
+}
+
+$allOk = $true
+
+$allOk = (Test-HttpStatus -Url "$apiBase/health" -AllowedStatuses @(200) -Label 'G16 health') -and $allOk
+
+$authGatePaths = @(
+    'properties',
+    'bookings',
+    'users/me',
+    'me/contexts',
+    'orgs/me/entitlement'
+)
+
+foreach ($path in $authGatePaths) {
+    $ok = Test-HttpStatus -Url "$apiBase/$path" -AllowedStatuses @(401) -Label "auth gate /api/$path"
+    $allOk = $ok -and $allOk
+}
+
+try {
+    $feResponse = Invoke-WebRequest -Uri $ProdFeUrl -Method Get -SkipHttpErrorCheck
+    if ($feResponse.StatusCode -ne 200) {
+        Write-Error "G17 FE prod health expected 200, got $($feResponse.StatusCode) for $ProdFeUrl"
+        $allOk = $false
+    }
+    elseif ($feResponse.Content -notmatch 'id="root"') {
+        Write-Error "G17 FE prod SPA missing id=`"root`" — check Vercel Production deploy for $ProdFeUrl"
+        $allOk = $false
+    }
+    else {
+        Write-Host "OK G17 FE prod SPA (200, id=`"root`")"
+    }
+}
+catch {
+    Write-Error "G17 FE prod health failed: $_"
+    $allOk = $false
+}
+
+if (-not $allOk) {
+    Write-Host ""
+    Write-Error "Production smoke FAILED — do not mark Stage 05 Phase D complete."
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Production smoke passed."
+Write-Host "Next: run authenticated prod E2E in frontend repo:"
+Write-Host "  E2E_PROD_SMOKE=1 npm run test:e2e -- prod-deploy-smoke"


### PR DESCRIPTION
## Summary
- Adds org provisioning on onboarding with selectable `PlanTier` (Starter/Pro/Scale) and MVP APIs: `GET /api/orgs/plans`, `PUT /api/orgs/me/plan`, `PATCH /api/admin/orgs/{orgId}/plan`.
- Extends admin user list with org plan metadata for the admin UI.
- Hardens Stage 05 production gates: `scripts/release-smoke.ps1`, expanded `verify-prod` CI, corrected prod FE URL in harness/docs.

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~OrgServiceTests|FullyQualifiedName~UserServiceTests|FullyQualifiedName~TenantBoundaryIntegrationTests` (17/17 pass)
- [ ] Merge with frontend PR #TBD and validate onboarding plan step + settings page on staging
- [ ] Run `.\scripts\release-smoke.ps1` against staging/prod after deploy

Closes #202 (partial — pairs with frontend PR)