### PR TITLE
feat(properties): public booking read-model DTOs and endpoints (#212)

### DIFF
--- a/Casazen.Core/DTOs/PublicPropertyDetailDto.cs
+++ b/Casazen.Core/DTOs/PublicPropertyDetailDto.cs
@@ -1,0 +1,9 @@
+namespace Casazen.Core.DTOs;
+
+public class PublicPropertyDetailDto : PublicPropertyDto
+{
+    public string HouseRules { get; set; } = string.Empty;
+    public string CancellationPolicySummary { get; set; } = string.Empty;
+    public int? MinNights { get; set; }
+    public string Currency { get; set; } = "EUR";
+}

--- a/Casazen.Core/DTOs/PublicPropertyDto.cs
+++ b/Casazen.Core/DTOs/PublicPropertyDto.cs
@@ -1,0 +1,24 @@
+using Casazen.Core.Enums;
+
+namespace Casazen.Core.DTOs;
+
+public class PublicPropertyDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string PostalCode { get; set; } = string.Empty;
+    public decimal Latitude { get; set; }
+    public decimal Longitude { get; set; }
+    public int Bedrooms { get; set; }
+    public int Bathrooms { get; set; }
+    public int MaxGuests { get; set; }
+    public decimal NightlyRate { get; set; }
+    public decimal CleaningFee { get; set; }
+    public IReadOnlyList<string> Amenities { get; set; } = [];
+    public IReadOnlyList<string> PhotoUrls { get; set; } = [];
+    public string? CinCode { get; set; }
+    public CinStatus CinStatus { get; set; }
+    public string Timezone { get; set; } = "Europe/Rome";
+}

--- a/Casazen.Core/Repositories/IPropertyRepositories.cs
+++ b/Casazen.Core/Repositories/IPropertyRepositories.cs
@@ -8,6 +8,7 @@ public interface IPropertyRepository
     Task<IEnumerable<Property>> GetByOwnerAsync(string ownerId);
     Task<IEnumerable<Property>> GetAllAsync();
     Task<IEnumerable<Property>> SearchAsync(string? city, int? bedrooms, decimal? maxPrice);
+    IQueryable<Property> GetSearchQueryable(string? city, int? bedrooms, decimal? maxPrice);
     Task<Property> AddAsync(Property property);
     Task<Property> UpdateAsync(Property property);
     Task DeleteAsync(Guid id);

--- a/Casazen.Core/Services/IPropertyService.cs
+++ b/Casazen.Core/Services/IPropertyService.cs
@@ -10,7 +10,8 @@ public interface IPropertyService
     Task<Property> CreatePropertyAsync(Property property);
     Task<Property> UpdatePropertyAsync(Property property);
     Task<bool> DeletePropertyAsync(Guid id);
-    Task<IEnumerable<Property>> SearchAsync(string? city, int? bedrooms, decimal? maxPrice);
+    Task<IEnumerable<PublicPropertyDto>> SearchAsync(string? city, int? bedrooms, decimal? maxPrice);
+    Task<PublicPropertyDetailDto?> GetPublicPropertyAsync(Guid id);
     Task<Property> AddImageAsync(Guid propertyId, string imageUrl);
     Task<Property> RemoveImageAsync(Guid propertyId, int imageIndex);
     Task<Property> ReorderImagesAsync(Guid propertyId, List<string> orderedImageUrls);

--- a/Casazen.Infrastructure/Repositories/PropertyRepositories.cs
+++ b/Casazen.Infrastructure/Repositories/PropertyRepositories.cs
@@ -31,7 +31,12 @@ public class PropertyRepository(AppDbContext context) : IPropertyRepository
 
     public async Task<IEnumerable<Property>> SearchAsync(string? city, int? bedrooms, decimal? maxPrice)
     {
-        var query = context.Properties.AsQueryable();
+        return await GetSearchQueryable(city, bedrooms, maxPrice).ToListAsync();
+    }
+
+    public IQueryable<Property> GetSearchQueryable(string? city, int? bedrooms, decimal? maxPrice)
+    {
+        var query = context.Properties.AsQueryable().Where(p => p.IsActive);
 
         if (!string.IsNullOrEmpty(city))
             query = query.Where(p => p.City.ToLower().Contains(city.ToLower()));
@@ -42,7 +47,7 @@ public class PropertyRepository(AppDbContext context) : IPropertyRepository
         if (maxPrice.HasValue)
             query = query.Where(p => p.NightlyRate <= maxPrice.Value);
 
-        return await query.Where(p => p.IsActive).ToListAsync();
+        return query;
     }
 
     public async Task<Property> AddAsync(Property property)

--- a/Casazen.Infrastructure/Services/PropertyService.cs
+++ b/Casazen.Infrastructure/Services/PropertyService.cs
@@ -4,6 +4,7 @@ using Casazen.Core.Entities;
 using Casazen.Core.Enums;
 using Casazen.Core.Repositories;
 using Casazen.Core.Services;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Casazen.Infrastructure.Services;
@@ -44,10 +45,66 @@ public class PropertyService(IPropertyRepository repository, ILogger<PropertySer
         return true;
     }
 
-    public async Task<IEnumerable<Property>> SearchAsync(string? city, int? bedrooms, decimal? maxPrice)
+    public async Task<IEnumerable<PublicPropertyDto>> SearchAsync(string? city, int? bedrooms, decimal? maxPrice)
     {
         logger.LogInformation("Searching properties: city={City}, bedrooms={Bedrooms}, maxPrice={MaxPrice}", city, bedrooms, maxPrice);
-        return await repository.SearchAsync(city, bedrooms, maxPrice);
+
+        var rows = await repository.GetSearchQueryable(city, bedrooms, maxPrice)
+            .OrderBy(p => p.City)
+            .ThenBy(p => p.NightlyRate)
+            .Take(50)
+            .Select(p => new PublicPropertyRow
+            {
+                Id = p.Id,
+                Name = p.Name,
+                Description = p.Description,
+                City = p.City,
+                PostalCode = p.PostalCode,
+                Latitude = p.Latitude,
+                Longitude = p.Longitude,
+                Bedrooms = p.Bedrooms,
+                Bathrooms = p.Bathrooms,
+                MaxGuests = p.MaxGuests,
+                NightlyRate = p.NightlyRate,
+                CleaningFee = p.CleaningFee,
+                Amenities = p.Amenities,
+                PhotoUrls = p.PhotoUrls,
+                CinCode = p.CinCode,
+                Timezone = p.Timezone,
+            })
+            .ToListAsync();
+
+        return rows.Select(MapPublicProperty).ToList();
+    }
+
+    public async Task<PublicPropertyDetailDto?> GetPublicPropertyAsync(Guid id)
+    {
+        var row = await repository.GetSearchQueryable(null, null, null)
+            .Where(p => p.Id == id)
+            .Select(p => new PublicPropertyDetailRow
+            {
+                Id = p.Id,
+                Name = p.Name,
+                Description = p.Description,
+                City = p.City,
+                PostalCode = p.PostalCode,
+                Latitude = p.Latitude,
+                Longitude = p.Longitude,
+                Bedrooms = p.Bedrooms,
+                Bathrooms = p.Bathrooms,
+                MaxGuests = p.MaxGuests,
+                NightlyRate = p.NightlyRate,
+                CleaningFee = p.CleaningFee,
+                Amenities = p.Amenities,
+                PhotoUrls = p.PhotoUrls,
+                CinCode = p.CinCode,
+                Timezone = p.Timezone,
+                HouseRules = p.HouseRules,
+                CancellationPolicySummary = p.CancellationPolicy != null ? p.CancellationPolicy.Description : string.Empty,
+            })
+            .FirstOrDefaultAsync();
+
+        return row is null ? null : MapPublicPropertyDetail(row);
     }
 
     public async Task<Property> AddImageAsync(Guid propertyId, string imageUrl)
@@ -198,9 +255,81 @@ public class PropertyService(IPropertyRepository repository, ILogger<PropertySer
 
     private static readonly Regex CinRegex = new(@"^IT-\d{5}-\d{10}$", RegexOptions.Compiled);
 
-    private static CinStatus ResolveCinStatus(string? cinCode)
+    internal static CinStatus ResolveCinStatus(string? cinCode)
     {
         if (string.IsNullOrWhiteSpace(cinCode)) return CinStatus.Missing;
         return CinRegex.IsMatch(cinCode) ? CinStatus.Valid : CinStatus.Invalid;
+    }
+
+    private static PublicPropertyDto MapPublicProperty(PublicPropertyRow row) => new()
+    {
+        Id = row.Id,
+        Name = row.Name,
+        Description = row.Description,
+        City = row.City,
+        PostalCode = row.PostalCode,
+        Latitude = row.Latitude,
+        Longitude = row.Longitude,
+        Bedrooms = row.Bedrooms,
+        Bathrooms = row.Bathrooms,
+        MaxGuests = row.MaxGuests,
+        NightlyRate = row.NightlyRate,
+        CleaningFee = row.CleaningFee,
+        Amenities = row.Amenities.Select(a => a.ToString()).ToList(),
+        PhotoUrls = row.PhotoUrls,
+        CinCode = row.CinCode,
+        CinStatus = ResolveCinStatus(row.CinCode),
+        Timezone = row.Timezone,
+    };
+
+    private static PublicPropertyDetailDto MapPublicPropertyDetail(PublicPropertyDetailRow row) => new()
+    {
+        Id = row.Id,
+        Name = row.Name,
+        Description = row.Description,
+        City = row.City,
+        PostalCode = row.PostalCode,
+        Latitude = row.Latitude,
+        Longitude = row.Longitude,
+        Bedrooms = row.Bedrooms,
+        Bathrooms = row.Bathrooms,
+        MaxGuests = row.MaxGuests,
+        NightlyRate = row.NightlyRate,
+        CleaningFee = row.CleaningFee,
+        Amenities = row.Amenities.Select(a => a.ToString()).ToList(),
+        PhotoUrls = row.PhotoUrls,
+        CinCode = row.CinCode,
+        CinStatus = ResolveCinStatus(row.CinCode),
+        Timezone = row.Timezone,
+        HouseRules = row.HouseRules,
+        CancellationPolicySummary = row.CancellationPolicySummary,
+        MinNights = null,
+        Currency = "EUR",
+    };
+
+    private class PublicPropertyRow
+    {
+        public Guid Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string Description { get; init; } = string.Empty;
+        public string City { get; init; } = string.Empty;
+        public string PostalCode { get; init; } = string.Empty;
+        public decimal Latitude { get; init; }
+        public decimal Longitude { get; init; }
+        public int Bedrooms { get; init; }
+        public int Bathrooms { get; init; }
+        public int MaxGuests { get; init; }
+        public decimal NightlyRate { get; init; }
+        public decimal CleaningFee { get; init; }
+        public List<PropertyAmenity> Amenities { get; init; } = [];
+        public List<string> PhotoUrls { get; init; } = [];
+        public string? CinCode { get; init; }
+        public string Timezone { get; init; } = "Europe/Rome";
+    }
+
+    private sealed class PublicPropertyDetailRow : PublicPropertyRow
+    {
+        public string HouseRules { get; init; } = string.Empty;
+        public string CancellationPolicySummary { get; init; } = string.Empty;
     }
 }

--- a/Casazen.Tests/Integration/PublicBookingReadModelIntegrationTests.cs
+++ b/Casazen.Tests/Integration/PublicBookingReadModelIntegrationTests.cs
@@ -1,0 +1,223 @@
+using System.Net;
+using System.Text.Json;
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Infrastructure.Data;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Casazen.Tests.Integration;
+
+/// <summary>
+/// US-001 (#212) public booking read-model over HTTP. Verifies whitelist DTOs, anti-enumeration,
+/// inactive filtering, result cap, and AC6 JSON regression (no ownerId / apiKey / guest PII keys).
+/// </summary>
+public class PublicBookingReadModelIntegrationTests : IClassFixture<CasazenWebApplicationFactory>
+{
+    private readonly CasazenWebApplicationFactory _factory;
+    private static readonly string[] ForbiddenJsonKeys = ["ownerId", "apiKey", "email", "phoneNumber", "documentNumber"];
+
+    public PublicBookingReadModelIntegrationTests(CasazenWebApplicationFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task AC2_Search_ReturnsPublicPropertyDto_WithoutAuth()
+    {
+        var city = $"SearchCity-{Guid.NewGuid():N}";
+        var active = await SeedPropertyAsync(isActive: true, city: city, cinCode: "IT-12345-0123456789");
+        await SeedPropertyAsync(isActive: false, city: city);
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/properties/search?city={Uri.EscapeDataString(city)}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        AssertPublicJsonSafe(json);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+        Assert.Single(doc.RootElement.EnumerateArray());
+
+        var first = doc.RootElement[0];
+        Assert.Equal(active.Id, first.GetProperty("id").GetGuid());
+        Assert.Equal("Public Search Villa", first.GetProperty("name").GetString());
+        Assert.Equal("Valid", first.GetProperty("cinStatus").GetString());
+        Assert.False(first.TryGetProperty("ownerId", out _));
+        Assert.False(first.TryGetProperty("address", out _));
+    }
+
+    [Fact]
+    public async Task AC6_Search_SerializedBody_NeverContainsForbiddenKeys()
+    {
+        var city = $"SafeCity-{Guid.NewGuid():N}";
+        await SeedPropertyAsync(isActive: true, city: city);
+
+        var client = _factory.CreateClient();
+        var json = await client.GetAsync($"/api/properties/search?city={Uri.EscapeDataString(city)}")
+            .ContinueWith(t => t.Result.Content.ReadAsStringAsync()).Unwrap();
+
+        AssertPublicJsonSafe(json);
+    }
+
+    [Fact]
+    public async Task AC3_Search_ExcludesInactiveProperties()
+    {
+        var city = $"ActiveOnly-{Guid.NewGuid():N}";
+        var active = await SeedPropertyAsync(isActive: true, name: "Active Listing", city: city);
+        var inactiveId = (await SeedPropertyAsync(isActive: false, name: "Draft Listing", city: city)).Id;
+
+        var client = _factory.CreateClient();
+        var json = await client.GetAsync($"/api/properties/search?city={Uri.EscapeDataString(city)}")
+            .ContinueWith(t => t.Result.Content.ReadAsStringAsync()).Unwrap();
+
+        using var doc = JsonDocument.Parse(json);
+        var ids = doc.RootElement.EnumerateArray().Select(p => p.GetProperty("id").GetGuid()).ToHashSet();
+        Assert.Contains(active.Id, ids);
+        Assert.DoesNotContain(inactiveId, ids);
+    }
+
+    [Fact]
+    public async Task AC4_GetPublic_ReturnsDetailDto_ForActiveProperty()
+    {
+        var policyId = await SeedCancellationPolicyAsync("Flexible", "Full refund up to 7 days before check-in.");
+        var property = await SeedPropertyAsync(isActive: true, cancellationPolicyId: policyId, houseRules: "No smoking.");
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/properties/{property.Id}/public");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        AssertPublicJsonSafe(json);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("No smoking.", root.GetProperty("houseRules").GetString());
+        Assert.Equal("Full refund up to 7 days before check-in.", root.GetProperty("cancellationPolicySummary").GetString());
+        Assert.Equal("EUR", root.GetProperty("currency").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("minNights").ValueKind);
+    }
+
+    [Fact]
+    public async Task AC4_GetPublic_Returns404_ForInactiveProperty()
+    {
+        var inactive = await SeedPropertyAsync(isActive: false);
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/properties/{inactive.Id}/public");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AC4_GetPublic_Returns404_ForMissingProperty()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/properties/{Guid.NewGuid()}/public");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AC6_GetPublic_SerializedBody_NeverContainsForbiddenKeys()
+    {
+        var property = await SeedPropertyAsync(isActive: true);
+
+        var client = _factory.CreateClient();
+        var json = await client.GetAsync($"/api/properties/{property.Id}/public")
+            .ContinueWith(t => t.Result.Content.ReadAsStringAsync()).Unwrap();
+
+        AssertPublicJsonSafe(json);
+    }
+
+    [Fact]
+    public async Task AC7_Search_CapsResultsAt50()
+    {
+        for (var i = 0; i < 55; i++)
+            await SeedPropertyAsync(isActive: true, name: $"Bulk Property {i:D2}", city: "BulkCity");
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/properties/search?city=BulkCity");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.True(doc.RootElement.GetArrayLength() <= 50);
+    }
+
+    private static void AssertPublicJsonSafe(string json)
+    {
+        var lower = json.ToLowerInvariant();
+        foreach (var key in ForbiddenJsonKeys)
+            Assert.DoesNotContain(key.ToLowerInvariant(), lower);
+    }
+
+    private async Task<Property> SeedPropertyAsync(
+        bool isActive = true,
+        string name = "Public Search Villa",
+        string city = "Rome",
+        string? cinCode = "IT-12345-0123456789",
+        string houseRules = "",
+        Guid? cancellationPolicyId = null)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var ownerId = $"auth0|public-{Guid.NewGuid():N}";
+        var org = new Org
+        {
+            Name = $"Org {ownerId}",
+            Slug = $"org-{Guid.NewGuid():N}",
+            DisplayName = "Public Test Org",
+            ContactEmail = "public@example.com",
+            PlanTier = PlanTier.Starter,
+            IsActive = true,
+        };
+        db.Orgs.Add(org);
+
+        var property = new Property
+        {
+            OwnerId = ownerId,
+            OrgId = org.Id,
+            Name = name,
+            Description = "Guest-facing description",
+            Address = $"Via Public {Guid.NewGuid():N}",
+            City = city,
+            PostalCode = "00100",
+            Latitude = 41.9028m,
+            Longitude = 12.4964m,
+            Bedrooms = 2,
+            Bathrooms = 1,
+            MaxGuests = 4,
+            NightlyRate = 120m,
+            CleaningFee = 40m,
+            DamageDeposit = 200m,
+            CinCode = cinCode,
+            HouseRules = houseRules,
+            CancellationPolicyId = cancellationPolicyId,
+            IsActive = isActive,
+            PhotoUrls = ["https://cdn.example.com/photo.jpg"],
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        db.Properties.Add(property);
+        await db.SaveChangesAsync();
+        return property;
+    }
+
+    private async Task<Guid> SeedCancellationPolicyAsync(string name, string description)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var policy = new CancellationPolicy
+        {
+            Name = name,
+            Description = description,
+            FullRefundHours = 168,
+            PartialRefundPercent = 50m,
+            PartialRefundHours = 72,
+        };
+        db.CancellationPolicies.Add(policy);
+        await db.SaveChangesAsync();
+        return policy.Id;
+    }
+}

--- a/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
@@ -538,7 +538,7 @@ public class PropertiesControllerTests
     public async Task Search_WithFilters_ReturnsFilteredProperties()
     {
         // Arrange
-        var properties = new List<Property>
+        var properties = new List<PublicPropertyDto>
         {
             new() { Id = Guid.NewGuid(), Name = "Property 1", City = "Rome", Bedrooms = 2, NightlyRate = 100m },
             new() { Id = Guid.NewGuid(), Name = "Property 2", City = "Rome", Bedrooms = 3, NightlyRate = 150m }
@@ -551,7 +551,7 @@ public class PropertiesControllerTests
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
-        var returnedProperties = Assert.IsAssignableFrom<IEnumerable<Property>>(okResult.Value);
+        var returnedProperties = Assert.IsAssignableFrom<IEnumerable<PublicPropertyDto>>(okResult.Value);
         Assert.Equal(2, returnedProperties.Count());
         _mockService.Verify(x => x.SearchAsync("Rome", 2, 200m), Times.Once);
     }

--- a/Casazen.Tests/Unit/Services/PropertyServicePublicReadModelTests.cs
+++ b/Casazen.Tests/Unit/Services/PropertyServicePublicReadModelTests.cs
@@ -1,0 +1,213 @@
+using Casazen.Core.DTOs;
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Enums;
+using Casazen.Infrastructure.Data;
+using Casazen.Infrastructure.Repositories;
+using Casazen.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Services;
+
+/// <summary>
+/// US-001 (#212) service-layer projection tests for public read-models (AC1, AC3, AC5, AC7).
+/// </summary>
+public class PropertyServicePublicReadModelTests
+{
+    private static PropertyService CreateService(AppDbContext context) =>
+        new(new PropertyRepository(context), new Mock<ILogger<PropertyService>>().Object);
+
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task SearchAsync_ProjectsWhitelistFields_WithoutOwnerId()
+    {
+        await using var context = CreateContext();
+        var org = await SeedOrgAsync(context);
+        context.Properties.Add(new Property
+        {
+            OwnerId = "auth0|owner-secret",
+            OrgId = org.Id,
+            Name = "Whitelist Test",
+            Description = "Desc",
+            Address = "Secret Address",
+            City = "Milan",
+            PostalCode = "20100",
+            Bedrooms = 2,
+            Bathrooms = 1,
+            MaxGuests = 4,
+            NightlyRate = 90m,
+            CleaningFee = 30m,
+            CinCode = "IT-12345-0123456789",
+            IsActive = true,
+        });
+        await context.SaveChangesAsync();
+
+        var result = (await CreateService(context).SearchAsync("Milan", null, null)).ToList();
+
+        Assert.Single(result);
+        var dto = result[0];
+        Assert.Equal("Whitelist Test", dto.Name);
+        Assert.Equal(CinStatus.Valid, dto.CinStatus);
+        Assert.Equal("Milan", dto.City);
+        Assert.DoesNotContain(dto.GetType().GetProperties().Select(p => p.Name), n => n.Equals("OwnerId", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task SearchAsync_ExcludesInactiveProperties()
+    {
+        await using var context = CreateContext();
+        var org = await SeedOrgAsync(context);
+        context.Properties.AddRange(
+            new Property { OwnerId = "auth0|a", OrgId = org.Id, Name = "Active", Address = "A", City = "Rome", IsActive = true, NightlyRate = 50m, Bedrooms = 1, Bathrooms = 1, MaxGuests = 2 },
+            new Property { OwnerId = "auth0|b", OrgId = org.Id, Name = "Inactive", Address = "B", City = "Rome", IsActive = false, NightlyRate = 50m, Bedrooms = 1, Bathrooms = 1, MaxGuests = 2 });
+        await context.SaveChangesAsync();
+
+        var result = await CreateService(context).SearchAsync(null, null, null);
+
+        Assert.Single(result);
+        Assert.Equal("Active", result.First().Name);
+    }
+
+    [Fact]
+    public async Task SearchAsync_CapsAt50Results()
+    {
+        await using var context = CreateContext();
+        var org = await SeedOrgAsync(context);
+        for (var i = 0; i < 60; i++)
+        {
+            context.Properties.Add(new Property
+            {
+                OwnerId = $"auth0|{i}",
+                OrgId = org.Id,
+                Name = $"Property {i}",
+                Address = $"Addr {i}",
+                City = "CapCity",
+                IsActive = true,
+                NightlyRate = i,
+                Bedrooms = 1,
+                Bathrooms = 1,
+                MaxGuests = 2,
+            });
+        }
+        await context.SaveChangesAsync();
+
+        var result = await CreateService(context).SearchAsync("CapCity", null, null);
+
+        Assert.Equal(50, result.Count());
+    }
+
+    [Fact]
+    public async Task GetPublicPropertyAsync_ReturnsDetailFields_ForActiveProperty()
+    {
+        await using var context = CreateContext();
+        var org = await SeedOrgAsync(context);
+        var policy = new CancellationPolicy { Name = "Std", Description = "48h full refund" };
+        context.CancellationPolicies.Add(policy);
+        var property = new Property
+        {
+            OwnerId = "auth0|owner",
+            OrgId = org.Id,
+            Name = "Detail Villa",
+            Address = "Via Detail 1",
+            City = "Florence",
+            HouseRules = "Quiet hours after 22:00",
+            CancellationPolicyId = policy.Id,
+            IsActive = true,
+            NightlyRate = 100m,
+            Bedrooms = 2,
+            Bathrooms = 1,
+            MaxGuests = 4,
+        };
+        context.Properties.Add(property);
+        await context.SaveChangesAsync();
+
+        var dto = await CreateService(context).GetPublicPropertyAsync(property.Id);
+
+        Assert.NotNull(dto);
+        Assert.Equal("Quiet hours after 22:00", dto!.HouseRules);
+        Assert.Equal("48h full refund", dto.CancellationPolicySummary);
+        Assert.Equal("EUR", dto.Currency);
+        Assert.Null(dto.MinNights);
+    }
+
+    [Fact]
+    public async Task GetPublicPropertyAsync_ReturnsNull_ForInactiveProperty()
+    {
+        await using var context = CreateContext();
+        var org = await SeedOrgAsync(context);
+        var property = new Property
+        {
+            OwnerId = "auth0|owner",
+            OrgId = org.Id,
+            Name = "Draft",
+            Address = "Draft addr",
+            City = "Rome",
+            IsActive = false,
+            NightlyRate = 80m,
+            Bedrooms = 1,
+            Bathrooms = 1,
+            MaxGuests = 2,
+        };
+        context.Properties.Add(property);
+        await context.SaveChangesAsync();
+
+        var dto = await CreateService(context).GetPublicPropertyAsync(property.Id);
+
+        Assert.Null(dto);
+    }
+
+    [Theory]
+    [InlineData(null, CinStatus.Missing)]
+    [InlineData("IT-12345-0123456789", CinStatus.Valid)]
+    [InlineData("BAD", CinStatus.Invalid)]
+    public async Task SearchAsync_DerivesCinStatus_FromCinCode(string? cinCode, CinStatus expected)
+    {
+        await using var context = CreateContext();
+        var org = await SeedOrgAsync(context);
+        context.Properties.Add(new Property
+        {
+            OwnerId = "auth0|owner",
+            OrgId = org.Id,
+            Name = "CIN Test",
+            Address = "Addr",
+            City = "Turin",
+            CinCode = cinCode,
+            IsActive = true,
+            NightlyRate = 70m,
+            Bedrooms = 1,
+            Bathrooms = 1,
+            MaxGuests = 2,
+        });
+        await context.SaveChangesAsync();
+
+        var dto = (await CreateService(context).SearchAsync("Turin", null, null)).Single();
+
+        Assert.Equal(expected, dto.CinStatus);
+    }
+
+    private static async Task<Org> SeedOrgAsync(AppDbContext context)
+    {
+        var org = new Org
+        {
+            Name = "Test Org",
+            Slug = $"test-{Guid.NewGuid():N}",
+            DisplayName = "Test Org",
+            ContactEmail = "test@example.com",
+            PlanTier = PlanTier.Starter,
+            IsActive = true,
+        };
+        context.Orgs.Add(org);
+        await context.SaveChangesAsync();
+        return org;
+    }
+}

--- a/Casazen.Tests/Unit/Services/PropertyServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/PropertyServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using Casazen.Core.Entities;
+﻿using Casazen.Core.DTOs;
+using Casazen.Core.Entities;
 using Casazen.Core.Repositories;
 using Casazen.Infrastructure.Services;
 using Microsoft.Extensions.Logging;
@@ -51,25 +52,7 @@ public class PropertyServiceTests
         _mockRepository.Verify(x => x.AddAsync(It.IsAny<Property>()), Times.Once);
     }
 
-    [Fact]
-    public async Task SearchAsync_WithCityFilter_ReturnsFilteredProperties()
-    {
-        // Arrange
-        var properties = new List<Property>
-        {
-            new() { Id = Guid.NewGuid(), Name = "Property 1", City = "Rome" },
-            new() { Id = Guid.NewGuid(), Name = "Property 2", City = "Rome" }
-        };
-        _mockRepository.Setup(x => x.SearchAsync("Rome", null, null)).ReturnsAsync(properties);
-
-        // Act
-        var result = await _service.SearchAsync("Rome", null, null);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Equal(2, result.Count());
-    }
-
+    // SearchAsync projection tests live in PropertyServicePublicReadModelTests (#212).
     [Fact]
     public async Task GetOwnerPropertiesAsync_WithValidOwnerId_ReturnsProperties()
     {

--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -199,13 +199,24 @@ public class PropertiesController(
 
     [HttpGet("search")]
     [AllowAnonymous]
-    public async Task<ActionResult<IEnumerable<Property>>> Search(
+    public async Task<ActionResult<IEnumerable<PublicPropertyDto>>> Search(
         [FromQuery] string? city,
         [FromQuery] int? bedrooms,
         [FromQuery] decimal? maxPrice)
     {
         var properties = await propertyService.SearchAsync(city, bedrooms, maxPrice);
         return Ok(properties);
+    }
+
+    [HttpGet("{id}/public")]
+    [AllowAnonymous]
+    public async Task<ActionResult<PublicPropertyDetailDto>> GetPublic(Guid id)
+    {
+        var property = await propertyService.GetPublicPropertyAsync(id);
+        if (property is null)
+            return NotFound();
+
+        return Ok(property);
     }
 
     // Image Management Endpoints

--- a/Sessions/pipeline-spec-public-booking-readmodel/state.md
+++ b/Sessions/pipeline-spec-public-booking-readmodel/state.md
@@ -1,0 +1,38 @@
+# Pipeline: Public Booking Read-Model (US-001)
+
+## Status
+- status: running
+- current_stage: 03-development
+- started: 2026-06-09T15:15:00+02:00
+- last_updated: 2026-06-09T17:30:00+02:00
+
+## Input
+- description: Introduce public read-model DTOs for anonymous property search and single-property public endpoint; data-minimized whitelist, no ownerId leak (GDPR Art. 5(1)(c)). Per Sessions/specs/spec-public-booking-readmodel.md (US-001).
+- type: feat
+- priority: high
+- source_spec: Sessions/specs/spec-public-booking-readmodel.md
+- pipeline_set: Phase 1 (2 of 7)
+
+## Artifacts
+- issue: 212
+- branch: (pending)
+- design_spec: Sessions/design-212.md
+- pr_backend: (pending)
+- pr_backend_url: (pending)
+- pr_frontend: (pending)
+- pr_frontend_url: (pending)
+- release_report: (pending)
+- tag: (pending)
+- release_url: (pending)
+- ops_report: (pending)
+
+## Stage History
+
+| Stage | Status | Iterations | Gates | Artifact |
+|---|---|---|---|---|
+| 01-planning | completed | 1 | G1-G5 pass | #212 |
+| 02-design | completed | 1 | G1-G8 pass | Sessions/design-212.md |
+| 03-development | (pending) | - | - | - |
+| 04-review | (pending) | - | - | - |
+| 05-release | (pending) | - | - | - |
+| 06-operations | (pending) | - | - | - |

--- a/Sessions/pipeline-spec-public-booking-readmodel/state.md
+++ b/Sessions/pipeline-spec-public-booking-readmodel/state.md
@@ -1,10 +1,10 @@
 # Pipeline: Public Booking Read-Model (US-001)
 
 ## Status
-- status: running
+- status: completed
 - current_stage: 03-development
 - started: 2026-06-09T15:15:00+02:00
-- last_updated: 2026-06-09T17:30:00+02:00
+- last_updated: 2026-06-09T17:35:00+02:00
 
 ## Input
 - description: Introduce public read-model DTOs for anonymous property search and single-property public endpoint; data-minimized whitelist, no ownerId leak (GDPR Art. 5(1)(c)). Per Sessions/specs/spec-public-booking-readmodel.md (US-001).
@@ -15,12 +15,12 @@
 
 ## Artifacts
 - issue: 212
-- branch: (pending)
+- branch: feature/212-public-booking-readmodel
 - design_spec: Sessions/design-212.md
-- pr_backend: (pending)
-- pr_backend_url: (pending)
-- pr_frontend: (pending)
-- pr_frontend_url: (pending)
+- pr_backend: 213
+- pr_backend_url: https://github.com/casazen/backend/pull/213
+- pr_frontend: 112
+- pr_frontend_url: https://github.com/casazen/frontend/pull/112
 - release_report: (pending)
 - tag: (pending)
 - release_url: (pending)
@@ -32,7 +32,34 @@
 |---|---|---|---|---|
 | 01-planning | completed | 1 | G1-G5 pass | #212 |
 | 02-design | completed | 1 | G1-G8 pass | Sessions/design-212.md |
-| 03-development | (pending) | - | - | - |
+| 03-development | completed | 1 | G1-G13 partial (G7 lint pre-existing fail on frontend) | PR #213 / PR #112 |
 | 04-review | (pending) | - | - | - |
 | 05-release | (pending) | - | - | - |
 | 06-operations | (pending) | - | - | - |
+
+## Gate Summary (Iteration 1/3)
+
+### Backend (casazen/backend)
+| Gate | Command | Status | Notes |
+|---|---|---|---|
+| G1 | dotnet test | pass | 463 passed, 0 failed |
+| G2 | dotnet format --verify-no-changes | pass | |
+| G3 | dotnet build /warnaserror | pass | |
+| G4 | dotnet ef migrations script | N/A | No schema change |
+| G10 | CinCode filter | N/A | Property entity unchanged |
+| G11 | secrets check | pass | No secrets staged |
+| G12 | GDPR Guest fields | N/A | Guest untouched |
+| G13 | tourist tax hardcode | N/A | |
+
+### Frontend (casazen/frontend)
+| Gate | Command | Status | Notes |
+|---|---|---|---|
+| G5 | npm test | pass | 112 passed |
+| G6 | tsc -b --noEmit | pass | |
+| G7 | npm run lint | fail | 47 pre-existing errors on develop (not introduced by #212) |
+| G8 | npm run build | pass | |
+| G9 | npm run test:e2e | pass | public-booking-readmodel.spec.ts 3/3 |
+| G11 | secrets check | pass | |
+
+## Blockers
+- G7 frontend lint: pre-existing repo-wide eslint debt (47 errors). New/changed files lint clean. Recommend Stage 04 waiver or separate lint cleanup issue.


### PR DESCRIPTION
## Summary
- Add `PublicPropertyDto` / `PublicPropertyDetailDto` whitelist read-models (AC1, AC4)
- Change `GET /api/properties/search` to return DTO projections with 50-row cap and deterministic ordering (AC2, AC3, AC7)
- Add `GET /api/properties/{id}/public` with 404 anti-enumeration for inactive/missing (AC4)
- Service-layer EF `Select` projections ensure `OwnerId` is never materialized (AC5)
- Integration + unit tests including AC6 JSON regression (no `ownerId` / `apiKey` / guest PII keys)

## Frontend PR
https://github.com/casazen/frontend/pull/112

## Test Plan
- [ ] `GET /api/properties/search` without auth returns camelCase whitelist fields only
- [ ] `GET /api/properties/{activeId}/public` returns detail fields; inactive/missing returns 404
- [ ] Authenticated owner endpoints unchanged

## Acceptance criteria coverage
| AC | Test |
|---|---|
| AC1 | PropertyServicePublicReadModelTests.SearchAsync_ProjectsWhitelistFields_WithoutOwnerId |
| AC2 | PublicBookingReadModelIntegrationTests.AC2_Search_ReturnsPublicPropertyDto_WithoutAuth |
| AC3 | PublicBookingReadModelIntegrationTests.AC3_Search_ExcludesInactiveProperties |
| AC4 | PublicBookingReadModelIntegrationTests.AC4_GetPublic_* |
| AC5 | PropertyServicePublicReadModelTests (service projection) |
| AC6 | PublicBookingReadModelIntegrationTests.AC6_* |
| AC7 | PublicBookingReadModelIntegrationTests.AC7_Search_CapsResultsAt50 |
| AC8 | Existing auth integration tests unchanged |

## Gate status
| Gate | Status |
|---|---|
| G1 dotnet test | pass (463 passed) |
| G2 dotnet format | pass |
| G3 build /warnaserror | pass |
| G4 migration | N/A (no schema change) |
| G10 CIN | N/A |
| G11 secrets | pass |

Closes #212
