### PR TITLE
feat(public): branded booking site org endpoints (#215)

### DIFF
--- a/Casazen.Core/DTOs/PublicOrgDto.cs
+++ b/Casazen.Core/DTOs/PublicOrgDto.cs
@@ -1,0 +1,13 @@
+namespace Casazen.Core.DTOs;
+
+/// <summary>
+/// Public branding read-model for anonymous branded booking sites (US-003 AC1).
+/// </summary>
+public class PublicOrgDto
+{
+    public string Slug { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string? LogoUrl { get; set; }
+    public string? ThemeColor { get; set; }
+    public string ContactEmail { get; set; } = string.Empty;
+}

--- a/Casazen.Core/Repositories/IPropertyRepositories.cs
+++ b/Casazen.Core/Repositories/IPropertyRepositories.cs
@@ -8,7 +8,7 @@ public interface IPropertyRepository
     Task<IEnumerable<Property>> GetByOwnerAsync(string ownerId);
     Task<IEnumerable<Property>> GetAllAsync();
     Task<IEnumerable<Property>> SearchAsync(string? city, int? bedrooms, decimal? maxPrice);
-    IQueryable<Property> GetSearchQueryable(string? city, int? bedrooms, decimal? maxPrice);
+    IQueryable<Property> GetSearchQueryable(string? city, int? bedrooms, decimal? maxPrice, Guid? orgId = null);
     Task<Property> AddAsync(Property property);
     Task<Property> UpdateAsync(Property property);
     Task DeleteAsync(Guid id);

--- a/Casazen.Core/Services/IPropertyService.cs
+++ b/Casazen.Core/Services/IPropertyService.cs
@@ -11,7 +11,9 @@ public interface IPropertyService
     Task<Property> UpdatePropertyAsync(Property property);
     Task<bool> DeletePropertyAsync(Guid id);
     Task<IEnumerable<PublicPropertyDto>> SearchAsync(string? city, int? bedrooms, decimal? maxPrice);
+    Task<IEnumerable<PublicPropertyDto>> SearchByOrgAsync(Guid orgId);
     Task<PublicPropertyDetailDto?> GetPublicPropertyAsync(Guid id);
+    Task<PublicPropertyDetailDto?> GetPublicPropertyForOrgAsync(Guid id, Guid orgId);
     Task<Property> AddImageAsync(Guid propertyId, string imageUrl);
     Task<Property> RemoveImageAsync(Guid propertyId, int imageIndex);
     Task<Property> ReorderImagesAsync(Guid propertyId, List<string> orderedImageUrls);

--- a/Casazen.Infrastructure/Repositories/PropertyRepositories.cs
+++ b/Casazen.Infrastructure/Repositories/PropertyRepositories.cs
@@ -34,9 +34,12 @@ public class PropertyRepository(AppDbContext context) : IPropertyRepository
         return await GetSearchQueryable(city, bedrooms, maxPrice).ToListAsync();
     }
 
-    public IQueryable<Property> GetSearchQueryable(string? city, int? bedrooms, decimal? maxPrice)
+    public IQueryable<Property> GetSearchQueryable(string? city, int? bedrooms, decimal? maxPrice, Guid? orgId = null)
     {
         var query = context.Properties.AsQueryable().Where(p => p.IsActive);
+
+        if (orgId.HasValue)
+            query = query.Where(p => p.OrgId == orgId.Value);
 
         if (!string.IsNullOrEmpty(city))
             query = query.Where(p => p.City.ToLower().Contains(city.ToLower()));

--- a/Casazen.Infrastructure/Services/PropertyService.cs
+++ b/Casazen.Infrastructure/Services/PropertyService.cs
@@ -77,9 +77,71 @@ public class PropertyService(IPropertyRepository repository, ILogger<PropertySer
         return rows.Select(MapPublicProperty).ToList();
     }
 
+    public async Task<IEnumerable<PublicPropertyDto>> SearchByOrgAsync(Guid orgId)
+    {
+        logger.LogInformation("Searching public properties for org {OrgId}", orgId);
+
+        var rows = await repository.GetSearchQueryable(null, null, null, orgId)
+            .OrderBy(p => p.City)
+            .ThenBy(p => p.NightlyRate)
+            .Take(50)
+            .Select(p => new PublicPropertyRow
+            {
+                Id = p.Id,
+                Name = p.Name,
+                Description = p.Description,
+                City = p.City,
+                PostalCode = p.PostalCode,
+                Latitude = p.Latitude,
+                Longitude = p.Longitude,
+                Bedrooms = p.Bedrooms,
+                Bathrooms = p.Bathrooms,
+                MaxGuests = p.MaxGuests,
+                NightlyRate = p.NightlyRate,
+                CleaningFee = p.CleaningFee,
+                Amenities = p.Amenities,
+                PhotoUrls = p.PhotoUrls,
+                CinCode = p.CinCode,
+                Timezone = p.Timezone,
+            })
+            .ToListAsync();
+
+        return rows.Select(MapPublicProperty).ToList();
+    }
+
     public async Task<PublicPropertyDetailDto?> GetPublicPropertyAsync(Guid id)
     {
         var row = await repository.GetSearchQueryable(null, null, null)
+            .Where(p => p.Id == id)
+            .Select(p => new PublicPropertyDetailRow
+            {
+                Id = p.Id,
+                Name = p.Name,
+                Description = p.Description,
+                City = p.City,
+                PostalCode = p.PostalCode,
+                Latitude = p.Latitude,
+                Longitude = p.Longitude,
+                Bedrooms = p.Bedrooms,
+                Bathrooms = p.Bathrooms,
+                MaxGuests = p.MaxGuests,
+                NightlyRate = p.NightlyRate,
+                CleaningFee = p.CleaningFee,
+                Amenities = p.Amenities,
+                PhotoUrls = p.PhotoUrls,
+                CinCode = p.CinCode,
+                Timezone = p.Timezone,
+                HouseRules = p.HouseRules,
+                CancellationPolicySummary = p.CancellationPolicy != null ? p.CancellationPolicy.Description : string.Empty,
+            })
+            .FirstOrDefaultAsync();
+
+        return row is null ? null : MapPublicPropertyDetail(row);
+    }
+
+    public async Task<PublicPropertyDetailDto?> GetPublicPropertyForOrgAsync(Guid id, Guid orgId)
+    {
+        var row = await repository.GetSearchQueryable(null, null, null, orgId)
             .Where(p => p.Id == id)
             .Select(p => new PublicPropertyDetailRow
             {

--- a/Casazen.Tests/Integration/BrandedBookingSiteIntegrationTests.cs
+++ b/Casazen.Tests/Integration/BrandedBookingSiteIntegrationTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Text.Json;
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Infrastructure.Data;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Casazen.Tests.Integration;
+
+/// <summary>
+/// US-003 (#215) branded booking site public org endpoints.
+/// </summary>
+public class BrandedBookingSiteIntegrationTests : IClassFixture<CasazenWebApplicationFactory>
+{
+    private readonly CasazenWebApplicationFactory _factory;
+    private static readonly string[] ForbiddenJsonKeys = ["ownerId", "apiKey", "planTier", "stripeCustomerId", "stripeConnectedAccountId"];
+
+    public BrandedBookingSiteIntegrationTests(CasazenWebApplicationFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task AC1_GetPublicOrg_ReturnsBrandingDto_WithoutAuth()
+    {
+        var org = await SeedOrgAsync("branded-test-org");
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/public/orgs/{org.Slug}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        AssertPublicJsonSafe(json);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal(org.Slug, root.GetProperty("slug").GetString());
+        Assert.Equal("Branded Test Org", root.GetProperty("displayName").GetString());
+        Assert.Equal("#2563eb", root.GetProperty("themeColor").GetString());
+        Assert.False(root.TryGetProperty("planTier", out _));
+    }
+
+    [Fact]
+    public async Task AC1_GetPublicOrg_Returns404_ForUnknownSlug()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/public/orgs/does-not-exist-slug");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AC2_GetOrgProperties_ReturnsOnlyOrgListings()
+    {
+        var orgA = await SeedOrgAsync($"org-a-{Guid.NewGuid():N}");
+        var orgB = await SeedOrgAsync($"org-b-{Guid.NewGuid():N}");
+        var propertyA = await SeedPropertyForOrgAsync(orgA, "Org A Villa");
+        await SeedPropertyForOrgAsync(orgB, "Org B Villa");
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/public/orgs/{orgA.Slug}/properties");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        AssertPublicJsonSafe(json);
+
+        using var doc = JsonDocument.Parse(json);
+        var ids = doc.RootElement.EnumerateArray().Select(p => p.GetProperty("id").GetGuid()).ToHashSet();
+        Assert.Single(ids);
+        Assert.Contains(propertyA.Id, ids);
+    }
+
+    [Fact]
+    public async Task AC3_GetOrgProperty_Returns404_WhenPropertyBelongsToOtherOrg()
+    {
+        var orgA = await SeedOrgAsync($"org-a-{Guid.NewGuid():N}");
+        var orgB = await SeedOrgAsync($"org-b-{Guid.NewGuid():N}");
+        var propertyB = await SeedPropertyForOrgAsync(orgB, "Other Org Property");
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/public/orgs/{orgA.Slug}/properties/{propertyB.Id}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AC3_GetOrgProperty_ReturnsDetail_ForMatchingOrg()
+    {
+        var org = await SeedOrgAsync($"org-detail-{Guid.NewGuid():N}");
+        var property = await SeedPropertyForOrgAsync(org, "Detail Villa", houseRules: "Check-in after 15:00");
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/public/orgs/{org.Slug}/properties/{property.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        AssertPublicJsonSafe(json);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal("Check-in after 15:00", doc.RootElement.GetProperty("houseRules").GetString());
+    }
+
+    private static void AssertPublicJsonSafe(string json)
+    {
+        var lower = json.ToLowerInvariant();
+        foreach (var key in ForbiddenJsonKeys)
+            Assert.DoesNotContain(key.ToLowerInvariant(), lower);
+    }
+
+    private async Task<Org> SeedOrgAsync(string slug, bool isActive = true)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var org = new Org
+        {
+            Name = "Branded Test Org",
+            Slug = slug,
+            DisplayName = "Branded Test Org",
+            LogoUrl = "https://cdn.example.com/logo.png",
+            ThemeColor = "#2563eb",
+            ContactEmail = "contact@branded.example",
+            PlanTier = PlanTier.Starter,
+            IsActive = isActive,
+        };
+        db.Orgs.Add(org);
+        await db.SaveChangesAsync();
+        return org;
+    }
+
+    private async Task<Property> SeedPropertyForOrgAsync(Org org, string name, string houseRules = "")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var ownerId = $"auth0|owner-{Guid.NewGuid():N}";
+        var property = new Property
+        {
+            OwnerId = ownerId,
+            OrgId = org.Id,
+            Name = name,
+            Description = "Branded listing description",
+            Address = $"Via Branded {Guid.NewGuid():N}",
+            City = "Rome",
+            PostalCode = "00100",
+            Latitude = 41.9028m,
+            Longitude = 12.4964m,
+            Bedrooms = 2,
+            Bathrooms = 1,
+            MaxGuests = 4,
+            NightlyRate = 150m,
+            CleaningFee = 50m,
+            DamageDeposit = 200m,
+            CinCode = "IT-12345-0123456789",
+            HouseRules = houseRules,
+            IsActive = true,
+            PhotoUrls = ["https://cdn.example.com/branded.jpg"],
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        db.Properties.Add(property);
+        await db.SaveChangesAsync();
+        return property;
+    }
+}

--- a/Casazen.Web/Controllers/PublicOrgController.cs
+++ b/Casazen.Web/Controllers/PublicOrgController.cs
@@ -1,0 +1,65 @@
+using Casazen.Core.DTOs;
+using Casazen.Core.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Casazen.Web.Controllers;
+
+[ApiController]
+[Route("api/public/orgs")]
+[AllowAnonymous]
+public class PublicOrgController(IOrgService orgService, IPropertyService propertyService) : ControllerBase
+{
+    [HttpGet("{slug}")]
+    [ProducesResponseType(typeof(PublicOrgDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<PublicOrgDto>> GetOrg(string slug, CancellationToken cancellationToken)
+    {
+        var org = await orgService.GetPublicBySlugAsync(slug, cancellationToken);
+        if (org is null)
+            return NotFound();
+
+        return Ok(new PublicOrgDto
+        {
+            Slug = org.Slug,
+            DisplayName = org.DisplayName,
+            LogoUrl = org.LogoUrl,
+            ThemeColor = org.ThemeColor,
+            ContactEmail = org.ContactEmail,
+        });
+    }
+
+    [HttpGet("{slug}/properties")]
+    [ProducesResponseType(typeof(IEnumerable<PublicPropertyDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<IEnumerable<PublicPropertyDto>>> GetProperties(
+        string slug,
+        CancellationToken cancellationToken)
+    {
+        var org = await orgService.GetPublicBySlugAsync(slug, cancellationToken);
+        if (org is null)
+            return NotFound();
+
+        var properties = await propertyService.SearchByOrgAsync(org.Id);
+        return Ok(properties);
+    }
+
+    [HttpGet("{slug}/properties/{propertyId:guid}")]
+    [ProducesResponseType(typeof(PublicPropertyDetailDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<PublicPropertyDetailDto>> GetProperty(
+        string slug,
+        Guid propertyId,
+        CancellationToken cancellationToken)
+    {
+        var org = await orgService.GetPublicBySlugAsync(slug, cancellationToken);
+        if (org is null)
+            return NotFound();
+
+        var property = await propertyService.GetPublicPropertyForOrgAsync(propertyId, org.Id);
+        if (property is null)
+            return NotFound();
+
+        return Ok(property);
+    }
+}

--- a/Sessions/pipeline-spec-branded-booking-site/issue-body.md
+++ b/Sessions/pipeline-spec-branded-booking-site/issue-body.md
@@ -1,0 +1,18 @@
+## User Story
+
+As a prospective guest, I want to visit an operator's branded CasaZen booking site, browse listings, and view property details without logging in.
+
+As an operator, I want my public booking site to carry my brand (name, logo, colors).
+
+## Acceptance Criteria
+
+See `Sessions/specs/spec-branded-booking-site.md` (AC1–AC11).
+
+Checkout payment flow deferred to `spec-direct-checkout`; route shell included.
+
+## Technical Notes
+
+- Backend: `PublicOrgController`, `PublicOrgDto`, org-scoped property list/detail
+- Frontend: `/book/:orgSlug` public route tree, `PublicBookingShell`, GDPR cookie banner
+- No EF migration required
+- Depends on: spec-public-booking-readmodel (#212), spec-tenant-boundary (#202)


### PR DESCRIPTION
## Summary
- PublicOrgController: GET /api/public/orgs/{slug}, /properties, /properties/{id}
- Org-scoped public property search with cross-org 404

## Test plan
- [x] dotnet test (468 passed)
- [x] BrandedBookingSiteIntegrationTests 5/5

Made with [Cursor](https://cursor.com)