### PR TITLE
fix(tenancy): auto-provision org for legacy users without OrgId (#217)

### DIFF
--- a/Casazen.Infrastructure/Services/UserService.cs
+++ b/Casazen.Infrastructure/Services/UserService.cs
@@ -93,7 +93,36 @@ public class UserService(
         // Upsert by sub (Auth0 sub == User.Id)
         var existing = await repository.GetBySubAsync(sub);
         if (existing != null)
+        {
+            var normalizedEmail = string.IsNullOrWhiteSpace(email) ? null : email.ToLowerInvariant();
+            var changed = false;
+
+            if (string.IsNullOrWhiteSpace(existing.Email) && normalizedEmail is not null)
+            {
+                existing.Email = normalizedEmail;
+                changed = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(existing.FirstName) && !string.IsNullOrWhiteSpace(firstName))
+            {
+                existing.FirstName = firstName;
+                changed = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(existing.LastName) && !string.IsNullOrWhiteSpace(lastName))
+            {
+                existing.LastName = lastName;
+                changed = true;
+            }
+
+            if (changed)
+            {
+                existing.UpdatedAt = DateTime.UtcNow;
+                await repository.UpdateAsync(existing);
+            }
+
             return existing;
+        }
 
         var user = new User
         {

--- a/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
@@ -6,6 +6,7 @@ using Casazen.Core.Multitenancy;
 using Casazen.Core.Services;
 using Casazen.Web.Controllers;
 using Casazen.Web.DTOs;
+using Casazen.Web.Infrastructure;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -21,7 +22,7 @@ public class PropertiesControllerTests
     private readonly Mock<IPropertyAuthorizationService> _mockAuthz;
     private readonly Mock<IPropertyDocumentService> _mockDocumentService;
     private readonly Mock<IAdminAccessAuditService> _mockAuditService;
-    private readonly Mock<ITenantContext> _mockTenantContext;
+    private readonly Mock<IOrgContextResolver> _mockOrgContextResolver;
     private readonly Mock<IEntitlementService> _mockEntitlementService;
     private readonly Mock<ILogger<PropertiesController>> _mockLogger;
     private readonly PropertiesController _controller;
@@ -33,7 +34,7 @@ public class PropertiesControllerTests
         _mockAuthz = new Mock<IPropertyAuthorizationService>();
         _mockDocumentService = new Mock<IPropertyDocumentService>();
         _mockAuditService = new Mock<IAdminAccessAuditService>();
-        _mockTenantContext = new Mock<ITenantContext>();
+        _mockOrgContextResolver = new Mock<IOrgContextResolver>();
         _mockEntitlementService = new Mock<IEntitlementService>();
         _mockLogger = new Mock<ILogger<PropertiesController>>();
         _controller = new PropertiesController(
@@ -42,13 +43,15 @@ public class PropertiesControllerTests
             _mockAuthz.Object,
             _mockDocumentService.Object,
             _mockAuditService.Object,
-            _mockTenantContext.Object,
+            _mockOrgContextResolver.Object,
             _mockEntitlementService.Object,
             _mockLogger.Object);
 
         // Defaults: caller has an org and is under the plan limit. Create-path tests that need
         // the opposite (no org / limit reached) override these per-test.
-        _mockTenantContext.SetupGet(x => x.OrgId).Returns(DefaultOrgId);
+        _mockOrgContextResolver
+            .Setup(x => x.GetOrProvisionOrgIdAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DefaultOrgId);
         _mockEntitlementService
             .Setup(x => x.CanAddPropertyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);

--- a/Casazen.Tests/Unit/Services/UserServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/UserServiceTests.cs
@@ -46,6 +46,22 @@ public class UserServiceTests
     }
 
     [Fact]
+    public async Task GetCurrentUserAsync_UserExistsWithEmptyEmail_BackfillsFromJwtClaims()
+    {
+        var sub = "auth0|legacy456";
+        var existing = new User { Id = sub, Email = "", FirstName = "", LastName = "" };
+        _repoMock.Setup(r => r.GetBySubAsync(sub)).ReturnsAsync(existing);
+        _repoMock.Setup(r => r.UpdateAsync(It.IsAny<User>())).Returns(Task.CompletedTask);
+
+        var result = await _service.GetCurrentUserAsync(sub, "luca@example.com", "Luca", "Rossi");
+
+        Assert.Equal("luca@example.com", result.Email);
+        Assert.Equal("Luca", result.FirstName);
+        Assert.Equal("Rossi", result.LastName);
+        _repoMock.Verify(r => r.UpdateAsync(It.Is<User>(u => u.Email == "luca@example.com")), Times.Once);
+    }
+
+    [Fact]
     public async Task GetCurrentUserAsync_UserNotExists_CreatesAndReturnsNewUser()
     {
         // Arrange

--- a/Casazen.Web/Controllers/OrgsController.cs
+++ b/Casazen.Web/Controllers/OrgsController.cs
@@ -1,6 +1,6 @@
-using Casazen.Core.Multitenancy;
 using Casazen.Core.Services;
 using Casazen.Web.DTOs.Orgs;
+using Casazen.Web.Infrastructure;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -13,7 +13,7 @@ namespace Casazen.Web.Controllers;
 [ApiController]
 [Route("api/orgs")]
 public class OrgsController(
-    ITenantContext tenantContext,
+    IOrgContextResolver orgContextResolver,
     IEntitlementService entitlementService,
     IOrgService orgService) : ControllerBase
 {
@@ -41,7 +41,7 @@ public class OrgsController(
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<EntitlementDto>> GetMyEntitlement(CancellationToken cancellationToken)
     {
-        var orgId = tenantContext.OrgId;
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(cancellationToken);
         if (orgId is null)
             return NotFound(new { error = "No organization assigned to the current user" });
 
@@ -74,7 +74,7 @@ public class OrgsController(
         if (!PlanCatalog.TryParseTier(dto.PlanTier, out var planTier))
             return BadRequest(new { error = $"Unknown planTier: {dto.PlanTier}" });
 
-        var orgId = tenantContext.OrgId;
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(cancellationToken);
         if (orgId is null)
             return NotFound(new { error = "No organization assigned to the current user" });
 

--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -2,7 +2,6 @@
 using Casazen.Core.DTOs;
 using Casazen.Core.Entities;
 using Casazen.Core.Enums;
-using Casazen.Core.Multitenancy;
 using Casazen.Core.Services;
 using Casazen.Web.DTOs;
 using Casazen.Web.Infrastructure;
@@ -21,7 +20,7 @@ public class PropertiesController(
     IPropertyAuthorizationService authorizationService,
     IPropertyDocumentService documentService,
     IAdminAccessAuditService adminAccessAuditService,
-    ITenantContext tenantContext,
+    IOrgContextResolver orgContextResolver,
     IEntitlementService entitlementService,
     ILogger<PropertiesController> logger) : ControllerBase
 {
@@ -90,9 +89,8 @@ public class PropertiesController(
         if (string.IsNullOrEmpty(userId))
             return Unauthorized();
 
-        // Fail-closed (AC7): OrgId is required on a Property, so a caller with no org context
-        // (e.g. a brand-new user pre-backfill) cannot create tenant-scoped rows.
-        var orgId = tenantContext.OrgId;
+        // Resolve org; auto-provision Starter org for legacy users who have roles but no OrgId (#217).
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(HttpContext.RequestAborted);
         if (orgId is null)
         {
             logger.LogWarning("Property creation blocked: user {UserId} has no org context", userId);

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -243,6 +243,7 @@ public static class ServiceCollectionExtensions
 
         // Multi-tenant Org boundary (US-004): tenant resolution + org/entitlement reads.
         services.AddScoped<ITenantContext, TenantContext>();
+        services.AddScoped<IOrgContextResolver, OrgContextResolver>();
         services.AddScoped<IOrgService, OrgService>();
         services.AddScoped<IEntitlementService, EntitlementService>();
         return services;

--- a/Casazen.Web/Infrastructure/OrgContextResolver.cs
+++ b/Casazen.Web/Infrastructure/OrgContextResolver.cs
@@ -1,0 +1,77 @@
+using System.Security.Claims;
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Multitenancy;
+using Casazen.Core.Services;
+
+namespace Casazen.Web.Infrastructure;
+
+/// <summary>
+/// Resolves the caller's organization id, auto-provisioning a Starter org when the user
+/// has roles but never completed onboarding (production backfill for #217).
+/// </summary>
+public interface IOrgContextResolver
+{
+    Task<Guid?> GetOrProvisionOrgIdAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class OrgContextResolver(
+    ITenantContext tenantContext,
+    IHttpContextAccessor httpContextAccessor,
+    IUserService userService,
+    IOrgService orgService,
+    ILogger<OrgContextResolver> logger) : IOrgContextResolver
+{
+    public async Task<Guid?> GetOrProvisionOrgIdAsync(CancellationToken cancellationToken = default)
+    {
+        if (tenantContext.OrgId is Guid cached)
+            return cached;
+
+        var sub = ResolveSub();
+        if (string.IsNullOrWhiteSpace(sub))
+            return null;
+
+        var user = await userService.GetUserAsync(sub);
+        if (user?.OrgId is Guid linked)
+            return linked;
+
+        var (email, firstName, lastName) = ResolveProfileClaims();
+        var displayName = $"{firstName} {lastName}".Trim();
+        if (string.IsNullOrWhiteSpace(displayName))
+            displayName = string.IsNullOrWhiteSpace(email) ? "La mia organizzazione" : email;
+
+        logger.LogInformation("Auto-provisioning Starter org for user {UserId}", sub);
+        var org = await orgService.EnsureOrgForUserAsync(
+            sub, email, displayName, PlanTier.Starter, cancellationToken);
+        return org.Id;
+    }
+
+    private string? ResolveSub()
+    {
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user is null)
+            return null;
+
+        return user.FindFirstValue("sub")
+            ?? user.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? user.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier");
+    }
+
+    private (string Email, string FirstName, string LastName) ResolveProfileClaims()
+    {
+        var principal = httpContextAccessor.HttpContext?.User;
+        if (principal is null)
+            return (string.Empty, string.Empty, string.Empty);
+
+        var email = principal.FindFirst("email")?.Value
+                    ?? principal.FindFirst(ClaimTypes.Email)?.Value
+                    ?? string.Empty;
+        var firstName = principal.FindFirst("given_name")?.Value
+                        ?? principal.FindFirst("name")?.Value?.Split(' ').FirstOrDefault()
+                        ?? string.Empty;
+        var lastName = principal.FindFirst("family_name")?.Value
+                       ?? principal.FindFirst("name")?.Value?.Split(' ').Skip(1).FirstOrDefault()
+                       ?? string.Empty;
+
+        return (email, firstName, lastName);
+    }
+}

--- a/Sessions/specs/spec-production-e2e-flow-verification.md
+++ b/Sessions/specs/spec-production-e2e-flow-verification.md
@@ -1,0 +1,95 @@
+# Spec — Production E2E Flow Verification (Chrome DevTools)
+
+## Overview
+
+Verifica manuale/automatizzata dei **flussi operativi** su produzione (`https://casazen-app.vercel.app` + `https://casazen-api.up.railway.app`), non solo smoke delle pagine.
+
+Ogni area funzionale richiede **≥ 3 scenari**: almeno 1 happy path e 2 bad path documentati con evidenza (URL, request/response, screenshot/snapshot).
+
+**Tool**: Chrome DevTools MCP (`take_snapshot`, `fill_form`, `click`, `list_network_requests`, `list_console_messages`).
+
+**Utente test**: `luca.lamal@hotmail.it` (La Malfa Luca) — credenziali in `frontend/.env.e2e`.
+
+**Sessione**: 2026-06-09.
+
+---
+
+## Matrice flussi
+
+| Area | Happy path | Bad path 1 | Bad path 2 | Stato prod |
+|------|------------|------------|------------|------------|
+| Auth login/logout | Login Auth0 → dashboard | Sessione scaduta → 401 API | — | ✅ / ⚠️ |
+| Crea proprietà | Form valido → 201 → lista | Form vuoto → validazione Zod | POST valido → 403 `no_org_context` | ❌ bloccato |
+| Modifica proprietà | Edit → PUT 200 | — | — | ⏸️ no property |
+| Upload documenti/foto | Upload PDF → 201 | File >10MB → 400 | — | ⏸️ no property |
+| Prezzo adattivo AI | `/properties/:id/pricing` toggle ON | — | — | ⏸️ no property |
+| Crea prenotazione | Form completo → 201 | Form vuoto → validazione | No property in dropdown | ⚠️ parziale |
+| Calendario prenotazioni | Vista mese con eventi | — | GET senza params → 404 loop | ❌ |
+| Cambio piano (self) | Starter → PUT 200 | No org → 404 + toast | — | ❌ |
+| Admin cambio ruolo | PUT `/users/{id}/role` 200 | — | — | ✅ |
+| Admin cambio piano | Dialog piano → PATCH org | No orgId → bottone disabilitato | — | ⚠️ |
+| Onboarding / org | POST onboarding → org creata | Utente con ruoli → redirect | Admin skip onboarding | ❌ |
+| Public booking `/book/:slug` | Landing org pubblica | Slug inesistente → 404 | Non deployato → redirect | ❌ |
+
+---
+
+## Evidenze sessione 2026-06-09
+
+### Proprietà — create (bad + blocked happy)
+
+1. **Bad — validazione client**: submit form vuoto → messaggi Zod ("Name must be at least 3 characters", ecc.). ✅
+2. **Happy attempt — dati validi**: `POST /api/properties` → **403** `{"error":"No organization context","code":"no_org_context"}`. UI: toast/errore generico "insufficient permissions", dialog resta aperto. ❌
+3. **Root cause**: `GET /api/users/me` → `orgId: null`, `org: null`, `email: ""`. Utente ha ruoli JWT (`Admin`, `PropertyOwner`, `LongTermLandlord`) ma **mai completato onboarding** che chiama `EnsureOrgForUserAsync`.
+
+### Piano — self-service
+
+1. **Happy attempt**: click "Passa a questo piano" (Starter) → `PUT /api/orgs/me/plan` → **404** `No organization assigned to the current user`. Toast: "Impossibile aggiornare il piano". ❌
+2. **Bad — entitlement**: `GET /api/orgs/me/entitlement` → 404 (coerente con assenza org).
+
+### Prenotazione — create
+
+1. **Bad — validazione**: submit vuoto → "Property is required", date/guest errors. ✅
+2. **Bad — no inventory**: dropdown proprietà vuoto (0 properties). ⏸️
+3. **Happy**: non testabile finché create property bloccato.
+
+### Calendario
+
+1. FE: `GET /api/bookings/calendar` **senza** `propertyId`, `startDate`, `endDate`.
+2. BE: endpoint richiede `propertyId` (Guid) — con Guid vuoto → `404 Property not found`.
+3. React Query ritenta → UI bloccata su "Loading calendar...". ❌
+
+### Admin — utenti
+
+1. **Happy — cambio ruolo**: dialog → PropertyOwner → `PUT /api/users/auth0|…/role` **200**, toast "Ruolo aggiornato con successo". ✅
+2. **Bad — UI dati**: tabella mostra "Admin" / email "—"; dialog "Seleziona il nuovo ruolo per ." (nome vuoto). ❌
+3. **Bad — cambio piano**: bottone "Piano" **disabled** (entrambi utenti `orgId: null`).
+
+### Onboarding / Modifica tipo
+
+1. Link profilo "Modifica tipo" → `/onboarding` → redirect immediato a `/app/admin` (utente ha ruoli). ❌
+2. `needsOnboarding()` ritorna `false` per Admin e per `roles.length > 0` — **nessun percorso UI** per creare org retroattivamente.
+
+### Public booking (issue #215)
+
+1. `https://casazen-app.vercel.app/book/test-org` → redirect `/app/choose-context`.
+2. `GET /api/public/orgs/test-org` → 404.
+3. Feature non deployata su prod FE/BE.
+
+---
+
+## Gate di uscita
+
+- [ ] Utente test può completare onboarding o backfill org
+- [ ] Create property → 201 su prod
+- [ ] Edit property + upload documento su property esistente
+- [ ] Pricing adapter accessibile da detail
+- [ ] Create booking end-to-end
+- [ ] Calendario carica senza spinner infinito
+- [ ] Cambio piano self-service funziona
+- [ ] Public booking route risponde (post-deploy #215)
+
+---
+
+## Bug aperti (GitHub)
+
+Vedi issues create nella sessione 2026-06-09 con label `e2e-verification`.


### PR DESCRIPTION
## Summary

- Auto-provision a **Starter** org when authenticated users have roles but `OrgId` is null (#217)
- Backfill empty email/name on `GET /api/users/me` from JWT claims (#219)
- Add E2E flow verification spec for production Chrome testing

## Test plan

- [x] `dotnet test` — UserServiceTests + PropertiesControllerTests (59 passed)
- [ ] Deploy to Railway test → create property as `luca.lamal@hotmail.it` returns 201
- [ ] `PUT /api/orgs/me/plan` succeeds after auto-provision
- [ ] Admin users table shows email after next login

Fixes #217
