### PR TITLE
feat(payments): direct checkout Stripe Connect (#226)

### DIFF
--- a/Casazen.Core/Repositories/IBookingRepositories.cs
+++ b/Casazen.Core/Repositories/IBookingRepositories.cs
@@ -9,7 +9,8 @@ public interface IBookingRepository
     Task<IEnumerable<Booking>> GetByGuestAsync(Guid guestId);
     Task<IEnumerable<Booking>> GetAllAsync();
     Task<IEnumerable<Booking>> GetByDateRangeAsync(Guid propertyId, DateTime startDate, DateTime endDate);
-    Task<bool> IsAvailableAsync(Guid propertyId, DateTime checkIn, DateTime checkOut);
+    Task<bool> IsAvailableAsync(Guid propertyId, DateTime checkIn, DateTime checkOut, int? directPendingTtlMinutes = null);
+    Task<int> CancelExpiredPendingDirectBookingsAsync(Guid propertyId, int ttlMinutes);
     Task<Booking> AddAsync(Booking booking);
     Task<Booking> UpdateAsync(Booking booking);
     Task DeleteAsync(Guid id);

--- a/Casazen.Core/Services/DirectBookingModels.cs
+++ b/Casazen.Core/Services/DirectBookingModels.cs
@@ -1,0 +1,45 @@
+namespace Casazen.Core.Services;
+
+public record DirectBookingGuestInput(
+    string FirstName,
+    string LastName,
+    string Email,
+    string? Phone,
+    string Country);
+
+public record DirectBookingCreateInput(
+    Guid PropertyId,
+    DateTime CheckInDate,
+    DateTime CheckOutDate,
+    int NumberOfAdults,
+    int NumberOfChildren,
+    DirectBookingGuestInput Guest,
+    string ConsentVersion,
+    string ConsentIpAddress,
+    string? SpecialRequests);
+
+public record DirectBookingCreateResult(
+    Guid BookingId,
+    string ClientSecret,
+    string PublishableKey,
+    string StripeAccountId,
+    decimal Amount,
+    string Currency,
+    decimal TouristTaxAmount,
+    decimal BasePrice);
+
+public class DirectBookingException(string message, string ErrorCode) : Exception(message)
+{
+    public string ErrorCode { get; } = ErrorCode;
+}
+
+public static class DirectBookingErrorCodes
+{
+    public const string PropertyNotFound = "property_not_found";
+    public const string PaymentNotReady = "payment_not_ready";
+    public const string NotAvailable = "not_available";
+    public const string InvalidConsentVersion = "invalid_consent_version";
+    public const string TooManyGuests = "too_many_guests";
+    public const string InvalidDates = "invalid_dates";
+    public const string StripeError = "stripe_error";
+}

--- a/Casazen.Core/Services/IBookingService.cs
+++ b/Casazen.Core/Services/IBookingService.cs
@@ -11,6 +11,8 @@ public interface IBookingService
     Task<Booking> CreateBookingAsync(Booking booking);
     Task<Booking> UpdateBookingAsync(Booking booking);
     Task<bool> CancelBookingAsync(Guid bookingId);
-    Task<bool> IsPropertyAvailableAsync(Guid propertyId, DateTime checkIn, DateTime checkOut);
+    Task<bool> IsPropertyAvailableAsync(Guid propertyId, DateTime checkIn, DateTime checkOut, int? pendingDirectTtlMinutes = null);
+    Task<int> CancelExpiredPendingDirectBookingsAsync(Guid propertyId, int pendingDirectTtlMinutes);
     Task<IEnumerable<Booking>> GetCalendarAsync(Guid propertyId, DateTime startDate, DateTime endDate);
+    Task<DirectBookingCreateResult> CreateDirectBookingAsync(DirectBookingCreateInput input);
 }

--- a/Casazen.Infrastructure/External/StripeService.cs
+++ b/Casazen.Infrastructure/External/StripeService.cs
@@ -6,6 +6,11 @@ namespace Casazen.Infrastructure.External;
 public interface IStripeService
 {
     Task<PaymentIntent> CreatePaymentIntentAsync(long amount, string currency, Dictionary<string, string> metadata);
+    Task<PaymentIntent> CreateConnectedAccountPaymentIntentAsync(
+        string connectedAccountId,
+        long amountCents,
+        string currency,
+        Dictionary<string, string> metadata);
     Task<PaymentIntent> ConfirmPaymentAsync(string paymentIntentId);
     Task<Refund> RefundPaymentAsync(string paymentIntentId, long? amount = null);
 }
@@ -31,6 +36,42 @@ public class StripeService(ILogger<StripeService> logger) : IStripeService
         catch (Exception ex)
         {
             logger.LogError(ex, "Error creating payment intent");
+            throw;
+        }
+    }
+
+    public async Task<PaymentIntent> CreateConnectedAccountPaymentIntentAsync(
+        string connectedAccountId,
+        long amountCents,
+        string currency,
+        Dictionary<string, string> metadata)
+    {
+        try
+        {
+            var options = new PaymentIntentCreateOptions
+            {
+                Amount = amountCents,
+                Currency = currency,
+                Metadata = metadata,
+                ApplicationFeeAmount = 0,
+                AutomaticPaymentMethods = new PaymentIntentAutomaticPaymentMethodsOptions
+                {
+                    Enabled = true,
+                },
+            };
+
+            var requestOptions = new RequestOptions { StripeAccount = connectedAccountId };
+            var service = new PaymentIntentService();
+            var paymentIntent = await service.CreateAsync(options, requestOptions);
+            logger.LogInformation(
+                "Connected-account payment intent created: {PaymentIntentId} on {AccountId}",
+                paymentIntent.Id,
+                connectedAccountId);
+            return paymentIntent;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error creating connected-account payment intent for {AccountId}", connectedAccountId);
             throw;
         }
     }

--- a/Casazen.Infrastructure/External/StripeWebhookHandler.cs
+++ b/Casazen.Infrastructure/External/StripeWebhookHandler.cs
@@ -8,29 +8,38 @@ namespace Casazen.Infrastructure.External;
 
 public class StripeWebhookHandler(
     IPaymentRepository paymentRepository,
+    IBookingRepository bookingRepository,
     IConnectOnboardingService connectOnboardingService,
     ILogger<StripeWebhookHandler> logger)
 {
-    public async Task HandleEventAsync(Event stripeEvent)
+    private const string DirectBookingKind = "direct-booking";
+
+    public Task HandleEventAsync(Event stripeEvent) =>
+        HandleEventAsync(stripeEvent, WebhookSource.Platform);
+
+    public async Task HandleEventAsync(Event stripeEvent, WebhookSource source)
     {
         try
         {
             switch (stripeEvent.Type)
             {
                 case "payment_intent.succeeded":
-                    await HandlePaymentSucceededAsync(stripeEvent.Data.Object as PaymentIntent);
+                    await HandlePaymentSucceededAsync(stripeEvent.Data.Object as PaymentIntent, source);
                     break;
                 case "payment_intent.payment_failed":
-                    await HandlePaymentFailedAsync(stripeEvent.Data.Object as PaymentIntent);
+                case "payment_intent.canceled":
+                    await HandlePaymentFailedAsync(stripeEvent.Data.Object as PaymentIntent, source);
                     break;
                 case "charge.refunded":
-                    await HandleRefundAsync(stripeEvent.Data.Object as Charge);
+                    if (source == WebhookSource.Platform)
+                        await HandleRefundAsync(stripeEvent.Data.Object as Charge);
                     break;
                 case "account.updated":
-                    await HandleAccountUpdatedAsync(stripeEvent.Data.Object as Account);
+                    if (source == WebhookSource.Connected)
+                        await HandleAccountUpdatedAsync(stripeEvent.Data.Object as Account);
                     break;
                 default:
-                    logger.LogInformation("Unhandled Stripe event: {EventType}", stripeEvent.Type);
+                    logger.LogInformation("Unhandled Stripe event: {EventType} (source={Source})", stripeEvent.Type, source);
                     break;
             }
         }
@@ -50,51 +59,111 @@ public class StripeWebhookHandler(
         await connectOnboardingService.ApplyAccountUpdatedAsync(snapshot);
     }
 
-    private async Task HandlePaymentSucceededAsync(PaymentIntent? paymentIntent)
+    private async Task HandlePaymentSucceededAsync(PaymentIntent? paymentIntent, WebhookSource source)
     {
-        if (paymentIntent == null)
+        if (paymentIntent is null)
             return;
 
-        logger.LogInformation("Payment succeeded: {PaymentIntentId}", paymentIntent.Id);
-
-        var transactionId = paymentIntent.Id;
-        var payment = await paymentRepository.GetByTransactionIdAsync(transactionId);
-        if (payment != null)
+        if (IsDirectBookingEvent(paymentIntent, source))
         {
-            payment.Status = Core.Entities.PaymentStatus.Completed;
-            await paymentRepository.UpdateAsync(payment);
+            await HandleDirectBookingPaymentSucceededAsync(paymentIntent);
+            return;
         }
+
+        if (source != WebhookSource.Platform)
+            return;
+
+        logger.LogInformation("Platform payment succeeded: {PaymentIntentId}", paymentIntent.Id);
+        await UpdatePaymentStatusAsync(paymentIntent.Id, PaymentStatus.Completed);
     }
 
-    private async Task HandlePaymentFailedAsync(PaymentIntent? paymentIntent)
+    private async Task HandleDirectBookingPaymentSucceededAsync(PaymentIntent paymentIntent)
     {
-        if (paymentIntent == null)
+        logger.LogInformation("Direct booking payment succeeded: {PaymentIntentId}", paymentIntent.Id);
+
+        var payment = await paymentRepository.GetByTransactionIdAsync(paymentIntent.Id);
+        if (payment is null)
+        {
+            logger.LogWarning("No payment row for direct booking PI {PaymentIntentId}", paymentIntent.Id);
+            return;
+        }
+
+        if (payment.Status == PaymentStatus.Completed)
             return;
 
-        logger.LogInformation("Payment failed: {PaymentIntentId}", paymentIntent.Id);
+        payment.Status = PaymentStatus.Completed;
+        payment.ProcessedAt = DateTime.UtcNow;
+        payment.UpdatedAt = DateTime.UtcNow;
+        await paymentRepository.UpdateAsync(payment);
 
-        var transactionId = paymentIntent.Id;
-        var payment = await paymentRepository.GetByTransactionIdAsync(transactionId);
-        if (payment != null)
+        var booking = await bookingRepository.GetByIdAsync(payment.BookingId);
+        if (booking is null)
+            return;
+
+        if (booking.Status == BookingStatus.Confirmed)
+            return;
+
+        booking.Status = BookingStatus.Confirmed;
+        booking.UpdatedAt = DateTime.UtcNow;
+        await bookingRepository.UpdateAsync(booking);
+    }
+
+    private async Task HandlePaymentFailedAsync(PaymentIntent? paymentIntent, WebhookSource source)
+    {
+        if (paymentIntent is null)
+            return;
+
+        if (IsDirectBookingEvent(paymentIntent, source))
         {
-            payment.Status = Core.Entities.PaymentStatus.Failed;
-            await paymentRepository.UpdateAsync(payment);
+            logger.LogInformation("Direct booking payment failed/canceled: {PaymentIntentId}", paymentIntent.Id);
+            await UpdatePaymentStatusAsync(paymentIntent.Id, PaymentStatus.Failed);
+            return;
         }
+
+        if (source != WebhookSource.Platform)
+            return;
+
+        logger.LogInformation("Platform payment failed: {PaymentIntentId}", paymentIntent.Id);
+        await UpdatePaymentStatusAsync(paymentIntent.Id, PaymentStatus.Failed);
     }
 
     private async Task HandleRefundAsync(Charge? charge)
     {
-        if (charge == null)
+        if (charge is null)
             return;
 
         logger.LogInformation("Charge refunded: {ChargeId}", charge.Id);
-
         var transactionId = charge.PaymentIntentId;
+        if (string.IsNullOrEmpty(transactionId))
+            return;
+
         var payment = await paymentRepository.GetByTransactionIdAsync(transactionId);
-        if (payment != null)
+        if (payment is not null)
         {
-            payment.Status = Core.Entities.PaymentStatus.Refunded;
+            payment.Status = PaymentStatus.Refunded;
             await paymentRepository.UpdateAsync(payment);
         }
+    }
+
+    private static bool IsDirectBookingEvent(PaymentIntent paymentIntent, WebhookSource source)
+    {
+        if (source != WebhookSource.Connected)
+            return false;
+
+        paymentIntent.Metadata.TryGetValue("kind", out var kind);
+        return string.Equals(kind, DirectBookingKind, StringComparison.Ordinal);
+    }
+
+    private async Task UpdatePaymentStatusAsync(string transactionId, PaymentStatus status)
+    {
+        var payment = await paymentRepository.GetByTransactionIdAsync(transactionId);
+        if (payment is null)
+            return;
+
+        payment.Status = status;
+        if (status == PaymentStatus.Completed)
+            payment.ProcessedAt = DateTime.UtcNow;
+        payment.UpdatedAt = DateTime.UtcNow;
+        await paymentRepository.UpdateAsync(payment);
     }
 }

--- a/Casazen.Infrastructure/External/WebhookSource.cs
+++ b/Casazen.Infrastructure/External/WebhookSource.cs
@@ -1,0 +1,8 @@
+namespace Casazen.Infrastructure.External;
+
+/// <summary>RF2 discriminator — platform billing vs connected-account (direct checkout) webhooks.</summary>
+public enum WebhookSource
+{
+    Platform,
+    Connected,
+}

--- a/Casazen.Infrastructure/Repositories/BookingRepositories.cs
+++ b/Casazen.Infrastructure/Repositories/BookingRepositories.cs
@@ -53,20 +53,53 @@ public class BookingRepository(AppDbContext context) : IBookingRepository
             .ToListAsync();
     }
 
-    public async Task<bool> IsAvailableAsync(Guid propertyId, DateTime checkIn, DateTime checkOut)
+    public async Task<bool> IsAvailableAsync(
+        Guid propertyId,
+        DateTime checkIn,
+        DateTime checkOut,
+        int? directPendingTtlMinutes = null)
     {
         // Normalize to date-only to prevent time-component false conflicts (e.g. same-day turnover).
         // A checkout on Apr 5 at 10:00 and a checkin on Apr 5 at 15:00 is a valid same-day turnover.
         var checkInDate = checkIn.Date;
         var checkOutDate = checkOut.Date;
+        var pendingCutoff = directPendingTtlMinutes.HasValue
+            ? DateTime.UtcNow.AddMinutes(-directPendingTtlMinutes.Value)
+            : (DateTime?)null;
 
         var conflicting = await context.Bookings
             .AnyAsync(b => b.PropertyId == propertyId &&
                       b.CheckInDate.Date < checkOutDate &&
                       b.CheckOutDate.Date > checkInDate &&
-                      b.Status != BookingStatus.Cancelled);
+                      b.Status != BookingStatus.Cancelled &&
+                      !(pendingCutoff.HasValue &&
+                        b.Status == BookingStatus.Pending &&
+                        b.Source == BookingSource.Direct &&
+                        b.CreatedAt < pendingCutoff.Value));
 
         return !conflicting;
+    }
+
+    public async Task<int> CancelExpiredPendingDirectBookingsAsync(Guid propertyId, int ttlMinutes)
+    {
+        var cutoff = DateTime.UtcNow.AddMinutes(-ttlMinutes);
+        var expired = await context.Bookings
+            .Where(b => b.PropertyId == propertyId &&
+                        b.Status == BookingStatus.Pending &&
+                        b.Source == BookingSource.Direct &&
+                        b.CreatedAt < cutoff)
+            .ToListAsync();
+
+        foreach (var booking in expired)
+        {
+            booking.Status = BookingStatus.Cancelled;
+            booking.UpdatedAt = DateTime.UtcNow;
+        }
+
+        if (expired.Count > 0)
+            await context.SaveChangesAsync();
+
+        return expired.Count;
     }
 
     public async Task<Booking> AddAsync(Booking booking)

--- a/Casazen.Infrastructure/Services/BookingService.cs
+++ b/Casazen.Infrastructure/Services/BookingService.cs
@@ -2,11 +2,23 @@
 using Casazen.Core.Repositories;
 using Casazen.Core.Services;
 using Casazen.Core.Validation;
+using Casazen.Infrastructure.External;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Stripe;
 
 namespace Casazen.Infrastructure.Services;
 
-public class BookingService(IBookingRepository repository, ILogger<BookingService> logger) : IBookingService
+public class BookingService(
+    IBookingRepository repository,
+    IPropertyRepository propertyRepository,
+    IOrgService orgService,
+    IGuestService guestService,
+    ITaxCalculationService taxCalculationService,
+    IStripeService stripeService,
+    IPaymentRepository paymentRepository,
+    IConfiguration configuration,
+    ILogger<BookingService> logger) : IBookingService
 {
     public async Task<Booking?> GetBookingAsync(Guid id)
     {
@@ -30,7 +42,6 @@ public class BookingService(IBookingRepository repository, ILogger<BookingServic
 
     public async Task<Booking> CreateBookingAsync(Booking booking)
     {
-        // Validate booking data
         var validationResult = BookingValidator.ValidateBooking(booking);
         if (!validationResult.IsValid)
         {
@@ -38,7 +49,6 @@ public class BookingService(IBookingRepository repository, ILogger<BookingServic
             throw new InvalidOperationException($"Booking validation failed: {validationResult.ErrorMessage}");
         }
 
-        // Check property availability
         var isAvailable = await repository.IsAvailableAsync(
             booking.PropertyId, booking.CheckInDate, booking.CheckOutDate);
 
@@ -54,14 +64,161 @@ public class BookingService(IBookingRepository repository, ILogger<BookingServic
         return await repository.AddAsync(booking);
     }
 
+    public async Task<DirectBookingCreateResult> CreateDirectBookingAsync(DirectBookingCreateInput input)
+    {
+        var allowedConsentVersion = configuration["DirectBooking:ConsentVersion"] ?? "2026-06-direct-checkout-v1";
+        if (!string.Equals(input.ConsentVersion, allowedConsentVersion, StringComparison.Ordinal))
+        {
+            throw new DirectBookingException(
+                "Invalid consent version",
+                DirectBookingErrorCodes.InvalidConsentVersion);
+        }
+
+        var property = await propertyRepository.GetByIdAsync(input.PropertyId);
+        if (property is null || !property.IsActive)
+        {
+            throw new DirectBookingException("Property not found", DirectBookingErrorCodes.PropertyNotFound);
+        }
+
+        var org = await orgService.GetByIdAsync(property.OrgId);
+        if (org is null ||
+            string.IsNullOrWhiteSpace(org.StripeConnectedAccountId) ||
+            !org.ConnectChargesEnabled)
+        {
+            throw new DirectBookingException(
+                "Complete Stripe onboarding before accepting guest payments",
+                DirectBookingErrorCodes.PaymentNotReady);
+        }
+
+        var totalGuests = input.NumberOfAdults + input.NumberOfChildren;
+        if (totalGuests > property.MaxGuests)
+        {
+            throw new DirectBookingException(
+                $"This property allows a maximum of {property.MaxGuests} guests.",
+                DirectBookingErrorCodes.TooManyGuests);
+        }
+
+        var checkIn = DateTime.SpecifyKind(input.CheckInDate.Date, DateTimeKind.Utc);
+        var checkOut = DateTime.SpecifyKind(input.CheckOutDate.Date, DateTimeKind.Utc);
+        if (checkOut <= checkIn)
+        {
+            throw new DirectBookingException(
+                "Check-out date must be after check-in date",
+                DirectBookingErrorCodes.InvalidDates);
+        }
+
+        var pendingTtlMinutes = configuration.GetValue("DirectBooking:PendingTtlMinutes", 15);
+        await repository.CancelExpiredPendingDirectBookingsAsync(input.PropertyId, pendingTtlMinutes);
+
+        var isAvailable = await repository.IsAvailableAsync(
+            input.PropertyId, checkIn, checkOut, pendingTtlMinutes);
+        if (!isAvailable)
+        {
+            throw new DirectBookingException(
+                "Property not available for selected dates",
+                DirectBookingErrorCodes.NotAvailable);
+        }
+
+        var guest = await UpsertGuestWithConsentAsync(input.Guest, input.ConsentVersion, input.ConsentIpAddress);
+
+        var nights = (checkOut - checkIn).Days;
+        var basePrice = property.NightlyRate * nights + property.CleaningFee;
+        var touristTaxAmount = await taxCalculationService.CalculateTouristTaxAsync(
+            input.PropertyId, checkIn, checkOut, totalGuests);
+        var totalPrice = basePrice + touristTaxAmount;
+        var currency = "EUR";
+
+        var booking = new Booking
+        {
+            PropertyId = input.PropertyId,
+            OrgId = property.OrgId,
+            GuestId = guest.Id,
+            CheckInDate = checkIn,
+            CheckOutDate = checkOut,
+            NumberOfAdults = input.NumberOfAdults,
+            NumberOfChildren = input.NumberOfChildren,
+            NumberOfGuests = totalGuests,
+            SpecialRequests = input.SpecialRequests ?? string.Empty,
+            Status = BookingStatus.Pending,
+            Source = BookingSource.Direct,
+            BasePrice = basePrice,
+            TouristTax = touristTaxAmount,
+            TouristTaxAmount = touristTaxAmount,
+            TotalPrice = totalPrice,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        var validationResult = BookingValidator.ValidateBooking(booking);
+        if (!validationResult.IsValid)
+        {
+            throw new DirectBookingException(
+                validationResult.ErrorMessage ?? "Booking validation failed",
+                DirectBookingErrorCodes.InvalidDates);
+        }
+
+        var createdBooking = await repository.AddAsync(booking);
+
+        var amountCents = (long)Math.Round(totalPrice * 100m, MidpointRounding.AwayFromZero);
+        var metadata = new Dictionary<string, string>
+        {
+            ["bookingId"] = createdBooking.Id.ToString(),
+            ["propertyId"] = input.PropertyId.ToString(),
+            ["orgId"] = property.OrgId.ToString(),
+            ["kind"] = "direct-booking",
+        };
+
+        PaymentIntent paymentIntent;
+        try
+        {
+            paymentIntent = await stripeService.CreateConnectedAccountPaymentIntentAsync(
+                org.StripeConnectedAccountId!,
+                amountCents,
+                currency.ToLowerInvariant(),
+                metadata);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Stripe PaymentIntent creation failed for booking {BookingId}", createdBooking.Id);
+            createdBooking.Status = BookingStatus.Cancelled;
+            createdBooking.UpdatedAt = DateTime.UtcNow;
+            await repository.UpdateAsync(createdBooking);
+            throw new DirectBookingException("Payment initialization failed", DirectBookingErrorCodes.StripeError);
+        }
+
+        var payment = new Payment
+        {
+            BookingId = createdBooking.Id,
+            OrgId = property.OrgId,
+            Amount = totalPrice,
+            Status = PaymentStatus.Pending,
+            Method = Core.Entities.PaymentMethod.CreditCard,
+            TransactionId = paymentIntent.Id,
+            StripePaymentIntentId = paymentIntent.Id,
+            Description = "Direct checkout",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        await paymentRepository.AddAsync(payment);
+
+        var publishableKey = configuration["Stripe:PublishableKey"] ?? string.Empty;
+        return new DirectBookingCreateResult(
+            createdBooking.Id,
+            paymentIntent.ClientSecret ?? string.Empty,
+            publishableKey,
+            org.StripeConnectedAccountId!,
+            totalPrice,
+            currency,
+            touristTaxAmount,
+            basePrice);
+    }
+
     public async Task<Booking> UpdateBookingAsync(Booking booking)
     {
-        // Get existing booking for validation
         var existingBooking = await repository.GetByIdAsync(booking.Id);
         if (existingBooking == null)
             throw new KeyNotFoundException($"Booking {booking.Id} not found");
 
-        // Validate update
         var validationResult = BookingValidator.ValidateBookingUpdate(existingBooking, booking);
         if (!validationResult.IsValid)
         {
@@ -69,7 +226,6 @@ public class BookingService(IBookingRepository repository, ILogger<BookingServic
             throw new InvalidOperationException($"Booking update validation failed: {validationResult.ErrorMessage}");
         }
 
-        // Validate basic booking data
         var bookingValidation = BookingValidator.ValidateBooking(booking);
         if (!bookingValidation.IsValid)
         {
@@ -93,13 +249,93 @@ public class BookingService(IBookingRepository repository, ILogger<BookingServic
         return true;
     }
 
-    public async Task<bool> IsPropertyAvailableAsync(Guid propertyId, DateTime checkIn, DateTime checkOut)
+    public async Task<bool> IsPropertyAvailableAsync(
+        Guid propertyId,
+        DateTime checkIn,
+        DateTime checkOut,
+        int? pendingDirectTtlMinutes = null)
     {
-        return await repository.IsAvailableAsync(propertyId, checkIn, checkOut);
+        return await repository.IsAvailableAsync(propertyId, checkIn, checkOut, pendingDirectTtlMinutes);
+    }
+
+    public async Task<int> CancelExpiredPendingDirectBookingsAsync(Guid propertyId, int pendingDirectTtlMinutes)
+    {
+        return await repository.CancelExpiredPendingDirectBookingsAsync(propertyId, pendingDirectTtlMinutes);
     }
 
     public async Task<IEnumerable<Booking>> GetCalendarAsync(Guid propertyId, DateTime startDate, DateTime endDate)
     {
         return await repository.GetByDateRangeAsync(propertyId, startDate, endDate);
+    }
+
+    private async Task<Guest> UpsertGuestWithConsentAsync(
+        DirectBookingGuestInput guestInput,
+        string consentVersion,
+        string consentIpAddress)
+    {
+        var now = DateTime.UtcNow;
+        var retentionUntil = now.AddYears(7);
+        var existing = await guestService.GetGuestByEmailAsync(guestInput.Email);
+
+        if (existing is not null)
+        {
+            existing.FirstName = guestInput.FirstName;
+            existing.LastName = guestInput.LastName;
+            existing.PhoneNumber = guestInput.Phone ?? string.Empty;
+            existing.Country = guestInput.Country;
+            existing.DataProcessingConsentDate = now;
+            existing.ConsentIpAddress = consentIpAddress.Length > 50
+                ? consentIpAddress[..50]
+                : consentIpAddress;
+            existing.ConsentVersion = consentVersion;
+            existing.ConsentDate = now;
+            existing.DataRetentionUntil = retentionUntil;
+            existing.DataProcessingPurpose = "Direct Booking Checkout";
+            existing.UpdatedAt = now;
+            return await guestService.UpdateGuestAsync(existing);
+        }
+
+        var guest = new Guest
+        {
+            FirstName = guestInput.FirstName,
+            LastName = guestInput.LastName,
+            Email = guestInput.Email,
+            PhoneNumber = guestInput.Phone ?? string.Empty,
+            Country = guestInput.Country,
+            DataProcessingConsentDate = now,
+            ConsentIpAddress = consentIpAddress.Length > 50 ? consentIpAddress[..50] : consentIpAddress,
+            ConsentVersion = consentVersion,
+            ConsentDate = now,
+            DataRetentionUntil = retentionUntil,
+            DataProcessingPurpose = "Direct Booking Checkout",
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        try
+        {
+            return await guestService.CreateGuestAsync(guest);
+        }
+        catch (InvalidOperationException)
+        {
+            var raced = await guestService.GetGuestByEmailAsync(guestInput.Email);
+            if (raced is null)
+                throw;
+
+            raced.FirstName = guestInput.FirstName;
+            raced.LastName = guestInput.LastName;
+            raced.PhoneNumber = guestInput.Phone ?? string.Empty;
+            raced.Country = guestInput.Country;
+            raced.DataProcessingConsentDate = now;
+            raced.ConsentIpAddress = consentIpAddress.Length > 50
+                ? consentIpAddress[..50]
+                : consentIpAddress;
+            raced.ConsentVersion = consentVersion;
+            raced.ConsentDate = now;
+            raced.DataRetentionUntil = retentionUntil;
+            raced.DataProcessingPurpose = "Direct Booking Checkout";
+            raced.UpdatedAt = now;
+            return await guestService.UpdateGuestAsync(raced);
+        }
     }
 }

--- a/Casazen.Tests/Integration/CasazenWebApplicationFactory.cs
+++ b/Casazen.Tests/Integration/CasazenWebApplicationFactory.cs
@@ -3,6 +3,7 @@ using Casazen.Core.Entities;
 using Casazen.Core.Entities.Enums;
 using Casazen.Core.Services;
 using Casazen.Infrastructure.Data;
+using Casazen.Infrastructure.External;
 using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
@@ -37,6 +38,9 @@ public class CasazenWebApplicationFactory : WebApplicationFactory<Program>
                 ["ConnectionStrings:DefaultConnection"] = string.Empty,
                 ["Auth0:Domain"] = "test.auth0.com",
                 ["Auth0:Audience"] = "https://test-api.casazen.app",
+                ["Stripe:PublishableKey"] = "pk_test_integration",
+                ["DirectBooking:ConsentVersion"] = "2026-06-direct-checkout-v1",
+                ["DirectBooking:PendingTtlMinutes"] = "15",
             });
         });
 
@@ -66,6 +70,9 @@ public class CasazenWebApplicationFactory : WebApplicationFactory<Program>
 
             RemoveService<IStripeConnectGateway>(services);
             services.AddSingleton<IStripeConnectGateway, FakeStripeConnectGateway>();
+
+            RemoveService<IStripeService>(services);
+            services.AddSingleton<IStripeService, FakeStripeService>();
         });
     }
 

--- a/Casazen.Tests/Integration/DirectCheckoutIntegrationTests.cs
+++ b/Casazen.Tests/Integration/DirectCheckoutIntegrationTests.cs
@@ -1,0 +1,308 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using PlanTierEnum = Casazen.Core.Entities.Enums.PlanTier;
+using Casazen.Infrastructure.Data;
+using Casazen.Infrastructure.External;
+using Microsoft.Extensions.DependencyInjection;
+using Stripe;
+using Xunit;
+
+namespace Casazen.Tests.Integration;
+
+public class DirectCheckoutIntegrationTests : IClassFixture<CasazenWebApplicationFactory>
+{
+    private const string ConsentVersion = "2026-06-direct-checkout-v1";
+    private readonly CasazenWebApplicationFactory _factory;
+
+    public DirectCheckoutIntegrationTests(CasazenWebApplicationFactory factory)
+    {
+        _factory = factory;
+        FakeStripeService.Reset();
+    }
+
+    [Fact]
+    public async Task AC1_MissingConsent_Returns400()
+    {
+        var property = await SeedConnectReadyPropertyAsync();
+        var client = _factory.CreateClient();
+
+        var payload = BuildPayload(property.Id, consent: false);
+        var response = await PostDirectBookingAsync(client, payload);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AC1_InvalidDates_Returns400()
+    {
+        var property = await SeedConnectReadyPropertyAsync();
+        var client = _factory.CreateClient();
+
+        var payload = BuildPayload(
+            property.Id,
+            checkIn: DateTime.UtcNow.Date.AddDays(10),
+            checkOut: DateTime.UtcNow.Date.AddDays(5));
+        var response = await PostDirectBookingAsync(client, payload);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AC3_OperatorNotOnboarded_Returns409()
+    {
+        var property = await SeedPropertyWithoutConnectAsync();
+        var client = _factory.CreateClient();
+
+        var response = await PostDirectBookingAsync(client, BuildPayload(property.Id));
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Complete Stripe onboarding", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SuccessfulBooking_ReturnsClientSecretAndPublishableContext()
+    {
+        var property = await SeedConnectReadyPropertyAsync();
+        var client = _factory.CreateClient();
+
+        var response = await PostDirectBookingAsync(client, BuildPayload(property.Id));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("clientSecret").GetString()));
+        Assert.Equal("pi_test_secret_direct", root.GetProperty("clientSecret").GetString());
+        Assert.True(root.GetProperty("bookingId").GetGuid() != Guid.Empty);
+
+        var ctx = root.GetProperty("connectedAccountPublishableContext");
+        Assert.Equal("pk_test_integration", ctx.GetProperty("publishableKey").GetString());
+        Assert.Equal("acct_test_connect_ready", ctx.GetProperty("stripeAccountId").GetString());
+        Assert.True(root.GetProperty("amount").GetDecimal() > 0);
+    }
+
+    [Fact]
+    public async Task Webhook_ConfirmsDirectBooking()
+    {
+        var property = await SeedConnectReadyPropertyAsync();
+        var client = _factory.CreateClient();
+        var response = await PostDirectBookingAsync(client, BuildPayload(property.Id));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var bookingId = doc.RootElement.GetProperty("bookingId").GetGuid();
+        var paymentIntentId = FakeStripeService.LastPaymentIntentId!;
+
+        using var scope = _factory.Services.CreateScope();
+        var handler = scope.ServiceProvider.GetRequiredService<StripeWebhookHandler>();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var paymentIntent = new PaymentIntent
+        {
+            Id = paymentIntentId,
+            Amount = 65000,
+            Metadata = new Dictionary<string, string>
+            {
+                ["kind"] = "direct-booking",
+                ["bookingId"] = bookingId.ToString(),
+            },
+        };
+
+        var stripeEvent = new Event
+        {
+            Type = "payment_intent.succeeded",
+            Data = new EventData { Object = paymentIntent },
+        };
+
+        await handler.HandleEventAsync(stripeEvent, WebhookSource.Connected);
+
+        var booking = await db.Bookings.FindAsync(bookingId);
+        Assert.NotNull(booking);
+        Assert.Equal(BookingStatus.Confirmed, booking!.Status);
+
+        var payment = db.Payments.Single(p => p.BookingId == bookingId);
+        Assert.Equal(PaymentStatus.Completed, payment.Status);
+        Assert.Equal(paymentIntentId, payment.TransactionId);
+    }
+
+    private static object BuildPayload(
+        Guid propertyId,
+        bool consent = true,
+        DateTime? checkIn = null,
+        DateTime? checkOut = null)
+    {
+        var inDate = checkIn ?? DateTime.UtcNow.Date.AddDays(30);
+        var outDate = checkOut ?? inDate.AddDays(4);
+        return new
+        {
+            propertyId,
+            checkInDate = inDate.ToString("yyyy-MM-dd"),
+            checkOutDate = outDate.ToString("yyyy-MM-dd"),
+            numberOfAdults = 2,
+            numberOfChildren = 0,
+            guest = new
+            {
+                firstName = "Mario",
+                lastName = "Rossi",
+                email = $"mario.{Guid.NewGuid():N}@example.com",
+                phone = "+393331234567",
+                country = "IT",
+            },
+            consent = new
+            {
+                dataProcessing = consent,
+                consentVersion = ConsentVersion,
+            },
+        };
+    }
+
+    private static async Task<HttpResponseMessage> PostDirectBookingAsync(HttpClient client, object payload)
+    {
+        var json = JsonSerializer.Serialize(payload);
+        return await client.PostAsync(
+            "/api/public/bookings",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+    }
+
+    private async Task<Property> SeedConnectReadyPropertyAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var org = new Org
+        {
+            Name = "Direct Checkout Org",
+            Slug = $"direct-{Guid.NewGuid():N}",
+            DisplayName = "Direct Checkout Org",
+            ContactEmail = "checkout@example.com",
+            PlanTier = PlanTierEnum.Starter,
+            IsActive = true,
+            StripeConnectedAccountId = "acct_test_connect_ready",
+            ConnectChargesEnabled = true,
+        };
+        db.Orgs.Add(org);
+
+        var property = new Property
+        {
+            OwnerId = $"auth0|owner-{Guid.NewGuid():N}",
+            OrgId = org.Id,
+            Name = "Direct Checkout Villa",
+            Description = "Integration test property",
+            Address = $"Via Direct {Guid.NewGuid():N}",
+            City = "Rome",
+            PostalCode = "00100",
+            Latitude = 41.9028m,
+            Longitude = 12.4964m,
+            Bedrooms = 2,
+            Bathrooms = 1,
+            MaxGuests = 4,
+            NightlyRate = 150m,
+            CleaningFee = 50m,
+            DamageDeposit = 200m,
+            CinCode = "IT-12345-0123456789",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Properties.Add(property);
+        await db.SaveChangesAsync();
+        return property;
+    }
+
+    private async Task<Property> SeedPropertyWithoutConnectAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var org = new Org
+        {
+            Name = "No Connect Org",
+            Slug = $"no-connect-{Guid.NewGuid():N}",
+            DisplayName = "No Connect Org",
+            ContactEmail = "noconnect@example.com",
+            PlanTier = PlanTierEnum.Starter,
+            IsActive = true,
+        };
+        db.Orgs.Add(org);
+
+        var property = new Property
+        {
+            OwnerId = $"auth0|owner-{Guid.NewGuid():N}",
+            OrgId = org.Id,
+            Name = "No Connect Villa",
+            Description = "Integration test property",
+            Address = $"Via NoConnect {Guid.NewGuid():N}",
+            City = "Rome",
+            PostalCode = "00100",
+            Latitude = 41.9028m,
+            Longitude = 12.4964m,
+            Bedrooms = 2,
+            Bathrooms = 1,
+            MaxGuests = 4,
+            NightlyRate = 150m,
+            CleaningFee = 50m,
+            DamageDeposit = 200m,
+            CinCode = "IT-12345-0123456789",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Properties.Add(property);
+        await db.SaveChangesAsync();
+        return property;
+    }
+}
+
+internal sealed class FakeStripeService : IStripeService
+{
+    public static string? LastPaymentIntentId { get; private set; }
+    public static string LastClientSecret { get; private set; } = "pi_test_secret_direct";
+
+    public static void Reset()
+    {
+        LastPaymentIntentId = null;
+        LastClientSecret = "pi_test_secret_direct";
+    }
+
+    public Task<PaymentIntent> CreatePaymentIntentAsync(
+        long amount,
+        string currency,
+        Dictionary<string, string> metadata)
+    {
+        LastPaymentIntentId = $"pi_test_{Guid.NewGuid():N}";
+        return Task.FromResult(new PaymentIntent
+        {
+            Id = LastPaymentIntentId,
+            ClientSecret = LastClientSecret,
+            Amount = amount,
+            Currency = currency,
+        });
+    }
+
+    public Task<PaymentIntent> CreateConnectedAccountPaymentIntentAsync(
+        string connectedAccountId,
+        long amountCents,
+        string currency,
+        Dictionary<string, string> metadata)
+    {
+        LastPaymentIntentId = $"pi_test_{Guid.NewGuid():N}";
+        return Task.FromResult(new PaymentIntent
+        {
+            Id = LastPaymentIntentId,
+            ClientSecret = LastClientSecret,
+            Amount = amountCents,
+            Currency = currency,
+            Metadata = metadata,
+        });
+    }
+
+    public Task<PaymentIntent> ConfirmPaymentAsync(string paymentIntentId) =>
+        Task.FromResult(new PaymentIntent { Id = paymentIntentId });
+
+    public Task<Refund> RefundPaymentAsync(string paymentIntentId, long? amount = null) =>
+        Task.FromResult(new Refund { Id = "re_test", PaymentIntentId = paymentIntentId });
+}

--- a/Casazen.Tests/Unit/Services/BookingServiceTests.cs
+++ b/Casazen.Tests/Unit/Services/BookingServiceTests.cs
@@ -1,7 +1,9 @@
 ﻿using Casazen.Core.Entities;
 using Casazen.Core.Repositories;
 using Casazen.Core.Services;
+using Casazen.Infrastructure.External;
 using Casazen.Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -16,15 +18,30 @@ public class BookingServiceTests
     public BookingServiceTests()
     {
         _mockRepository = new Mock<IBookingRepository>();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DirectBooking:ConsentVersion"] = "2026-06-direct-checkout-v1",
+                ["DirectBooking:PendingTtlMinutes"] = "15",
+                ["Stripe:PublishableKey"] = "pk_test",
+            })
+            .Build();
+
         _service = new BookingService(
             _mockRepository.Object,
+            new Mock<IPropertyRepository>().Object,
+            new Mock<IOrgService>().Object,
+            new Mock<IGuestService>().Object,
+            new Mock<ITaxCalculationService>().Object,
+            new Mock<IStripeService>().Object,
+            new Mock<IPaymentRepository>().Object,
+            configuration,
             new Mock<ILogger<BookingService>>().Object);
     }
 
     [Fact]
     public async Task CreateBookingAsync_WithValidBooking_ReturnsCreatedBooking()
     {
-        // Arrange
         var booking = new Booking
         {
             PropertyId = Guid.NewGuid(),
@@ -32,53 +49,45 @@ public class BookingServiceTests
             CheckInDate = DateTime.UtcNow.AddDays(1),
             CheckOutDate = DateTime.UtcNow.AddDays(5),
             TotalPrice = 500m,
-            NumberOfGuests = 2
+            NumberOfGuests = 2,
         };
         _mockRepository.Setup(x => x.AddAsync(It.IsAny<Booking>())).ReturnsAsync(booking);
         _mockRepository.Setup(x => x.IsAvailableAsync(
-            It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<int?>()))
             .ReturnsAsync(true);
 
-        // Act
         var result = await _service.CreateBookingAsync(booking);
 
-        // Assert
         Assert.NotNull(result);
         Assert.Equal(booking.PropertyId, result.PropertyId);
         _mockRepository.Verify(x => x.AddAsync(It.IsAny<Booking>()), Times.Once);
         _mockRepository.Verify(x => x.IsAvailableAsync(
-            booking.PropertyId, booking.CheckInDate, booking.CheckOutDate), Times.Once);
+            booking.PropertyId, booking.CheckInDate, booking.CheckOutDate, null), Times.Once);
     }
 
     [Fact]
     public async Task IsPropertyAvailableAsync_WithAvailableProperty_ReturnsTrue()
     {
-        // Arrange
         var propertyId = Guid.NewGuid();
         var checkIn = DateTime.Now.AddDays(10);
         var checkOut = DateTime.Now.AddDays(15);
-        _mockRepository.Setup(x => x.IsAvailableAsync(propertyId, checkIn, checkOut)).ReturnsAsync(true);
+        _mockRepository.Setup(x => x.IsAvailableAsync(propertyId, checkIn, checkOut, null)).ReturnsAsync(true);
 
-        // Act
         var result = await _service.IsPropertyAvailableAsync(propertyId, checkIn, checkOut);
 
-        // Assert
         Assert.True(result);
     }
 
     [Fact]
     public async Task CancelBookingAsync_WithValidBooking_CancelsBooking()
     {
-        // Arrange
         var bookingId = Guid.NewGuid();
         var booking = new Booking { Id = bookingId, Status = BookingStatus.Confirmed };
         _mockRepository.Setup(x => x.GetByIdAsync(bookingId)).ReturnsAsync(booking);
         _mockRepository.Setup(x => x.UpdateAsync(It.IsAny<Booking>())).ReturnsAsync(booking);
 
-        // Act
         var result = await _service.CancelBookingAsync(bookingId);
 
-        // Assert
         Assert.True(result);
         _mockRepository.Verify(x => x.UpdateAsync(It.Is<Booking>(b => b.Status == BookingStatus.Cancelled)), Times.Once);
     }

--- a/Casazen.Web/BackgroundJobs/StripeWebhookJob.cs
+++ b/Casazen.Web/BackgroundJobs/StripeWebhookJob.cs
@@ -24,24 +24,32 @@ public class StripeWebhookJob
     /// <param name="eventId">Stripe event ID</param>
     /// <param name="eventType">Stripe event type (e.g., "payment_intent.succeeded")</param>
     /// <param name="eventJson">JSON representation of the Stripe event</param>
-    public async Task ProcessEventAsync(string eventId, string eventType, string eventJson)
+    /// <param name="source">Webhook ingress source (platform vs connected account).</param>
+    public async Task ProcessEventAsync(string eventId, string eventType, string eventJson, WebhookSource source)
     {
         try
         {
-            _logger.LogInformation("Processing Stripe webhook event {EventId} of type {EventType}", eventId, eventType);
+            _logger.LogInformation(
+                "Processing Stripe webhook event {EventId} of type {EventType} from {Source}",
+                eventId,
+                eventType,
+                source);
 
-            // Deserialize the Stripe event
             var stripeEvent = Event.FromJson(eventJson);
-
-            // Process the event through the webhook handler
-            await _webhookHandler.HandleEventAsync(stripeEvent);
+            await _webhookHandler.HandleEventAsync(stripeEvent, source);
 
             _logger.LogInformation("Successfully processed Stripe webhook event {EventId}", eventId);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error processing Stripe webhook event {EventId}", eventId);
-            throw; // Re-throw to let Hangfire handle retry logic
+            throw;
         }
     }
+
+    /// <summary>
+    /// Backward-compatible overload for callers that do not pass a webhook source.
+    /// </summary>
+    public Task ProcessEventAsync(string eventId, string eventType, string eventJson) =>
+        ProcessEventAsync(eventId, eventType, eventJson, WebhookSource.Platform);
 }

--- a/Casazen.Web/Controllers/PublicBookingsController.cs
+++ b/Casazen.Web/Controllers/PublicBookingsController.cs
@@ -1,0 +1,97 @@
+using Casazen.Core.Services;
+using Casazen.Web.DTOs;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace Casazen.Web.Controllers;
+
+[ApiController]
+[Route("api/public/bookings")]
+[AllowAnonymous]
+public class PublicBookingsController(
+    IBookingService bookingService,
+    ILogger<PublicBookingsController> logger) : ControllerBase
+{
+    [HttpPost]
+    [EnableRateLimiting("PublicBookingCreate")]
+    public async Task<ActionResult<DirectBookingResponse>> CreateDirectBooking(
+        [FromBody] CreateDirectBookingRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        if (request.Consent is null || !request.Consent.DataProcessing)
+        {
+            return BadRequest(new
+            {
+                error = "Consent required",
+                message = "Data processing consent is required to complete booking.",
+            });
+        }
+
+        var consentIp = HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+        var guest = request.Guest;
+
+        try
+        {
+            var result = await bookingService.CreateDirectBookingAsync(new DirectBookingCreateInput(
+                request.PropertyId,
+                request.CheckInDate,
+                request.CheckOutDate,
+                request.NumberOfAdults,
+                request.NumberOfChildren,
+                new DirectBookingGuestInput(
+                    guest.FirstName,
+                    guest.LastName,
+                    guest.Email,
+                    guest.Phone,
+                    guest.Country),
+                request.Consent.ConsentVersion,
+                consentIp,
+                request.SpecialRequests));
+
+            return Ok(new DirectBookingResponse
+            {
+                BookingId = result.BookingId,
+                ClientSecret = result.ClientSecret,
+                ConnectedAccountPublishableContext = new ConnectedAccountPublishableContext
+                {
+                    PublishableKey = result.PublishableKey,
+                    StripeAccountId = result.StripeAccountId,
+                },
+                Amount = result.Amount,
+                Currency = result.Currency,
+                TouristTaxAmount = result.TouristTaxAmount,
+                BasePrice = result.BasePrice,
+            });
+        }
+        catch (DirectBookingException ex)
+        {
+            logger.LogWarning(ex, "Direct booking rejected: {ErrorCode}", ex.ErrorCode);
+            return ex.ErrorCode switch
+            {
+                DirectBookingErrorCodes.PropertyNotFound => NotFound(new { error = "Property not found" }),
+                DirectBookingErrorCodes.PaymentNotReady => Conflict(new
+                {
+                    error = "Complete Stripe onboarding before accepting guest payments",
+                }),
+                DirectBookingErrorCodes.NotAvailable => Conflict(new
+                {
+                    error = "Property not available for selected dates",
+                }),
+                DirectBookingErrorCodes.TooManyGuests or DirectBookingErrorCodes.InvalidDates
+                    or DirectBookingErrorCodes.InvalidConsentVersion => BadRequest(new
+                    {
+                        error = ex.ErrorCode,
+                        message = ex.Message,
+                    }),
+                DirectBookingErrorCodes.StripeError => StatusCode(500, new
+                {
+                    error = "Payment initialization failed",
+                }),
+                _ => BadRequest(new { error = ex.Message }),
+            };
+        }
+    }
+}

--- a/Casazen.Web/Controllers/WebhooksController.cs
+++ b/Casazen.Web/Controllers/WebhooksController.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using Casazen.Core.Services;
+using Casazen.Infrastructure.External;
 using Casazen.Web.BackgroundJobs;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
@@ -68,7 +69,7 @@ public class WebhooksController : ControllerBase
             // Queue the event for background processing
             // This allows us to respond within 3 seconds while processing happens asynchronously
             _backgroundJobClient.Enqueue<StripeWebhookJob>(job =>
-                job.ProcessEventAsync(stripeEvent.Id, stripeEvent.Type, json));
+                job.ProcessEventAsync(stripeEvent.Id, stripeEvent.Type, json, WebhookSource.Platform));
 
             _logger.LogInformation("Queued Stripe webhook event {EventId} for background processing", stripeEvent.Id);
 
@@ -118,7 +119,7 @@ public class WebhooksController : ControllerBase
                 stripeEvent.Id);
 
             _backgroundJobClient.Enqueue<StripeWebhookJob>(job =>
-                job.ProcessEventAsync(stripeEvent.Id, stripeEvent.Type, json));
+                job.ProcessEventAsync(stripeEvent.Id, stripeEvent.Type, json, WebhookSource.Connected));
 
             return Ok();
         }

--- a/Casazen.Web/DTOs/CreateDirectBookingRequest.cs
+++ b/Casazen.Web/DTOs/CreateDirectBookingRequest.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Casazen.Web.DTOs;
+
+public class CreateDirectBookingGuestRequest
+{
+    [Required(ErrorMessage = "First name is required")]
+    [MaxLength(100)]
+    public string FirstName { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Last name is required")]
+    [MaxLength(100)]
+    public string LastName { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Email is required")]
+    [EmailAddress(ErrorMessage = "Invalid email address")]
+    [MaxLength(255)]
+    public string Email { get; set; } = string.Empty;
+
+    [MaxLength(20)]
+    public string? Phone { get; set; }
+
+    [Required(ErrorMessage = "Country is required")]
+    [MaxLength(100)]
+    public string Country { get; set; } = string.Empty;
+}
+
+public class CreateDirectBookingConsentRequest
+{
+    [Required]
+    public bool DataProcessing { get; set; }
+
+    [Required(ErrorMessage = "Consent version is required")]
+    [MaxLength(100)]
+    public string ConsentVersion { get; set; } = string.Empty;
+}
+
+public class CreateDirectBookingRequest
+{
+    [Required(ErrorMessage = "Property is required")]
+    public Guid PropertyId { get; set; }
+
+    [Required(ErrorMessage = "Check-in date is required")]
+    public DateTime CheckInDate { get; set; }
+
+    [Required(ErrorMessage = "Check-out date is required")]
+    public DateTime CheckOutDate { get; set; }
+
+    [Range(1, 100, ErrorMessage = "Number of adults must be at least 1")]
+    public int NumberOfAdults { get; set; }
+
+    [Range(0, 100, ErrorMessage = "Number of children cannot be negative")]
+    public int NumberOfChildren { get; set; }
+
+    [Required(ErrorMessage = "Guest information is required")]
+    public CreateDirectBookingGuestRequest Guest { get; set; } = null!;
+
+    [Required(ErrorMessage = "Consent is required")]
+    public CreateDirectBookingConsentRequest Consent { get; set; } = null!;
+
+    [MaxLength(1000)]
+    public string? SpecialRequests { get; set; }
+}

--- a/Casazen.Web/DTOs/DirectBookingResponse.cs
+++ b/Casazen.Web/DTOs/DirectBookingResponse.cs
@@ -1,0 +1,18 @@
+namespace Casazen.Web.DTOs;
+
+public class ConnectedAccountPublishableContext
+{
+    public string PublishableKey { get; set; } = string.Empty;
+    public string StripeAccountId { get; set; } = string.Empty;
+}
+
+public class DirectBookingResponse
+{
+    public Guid BookingId { get; set; }
+    public string ClientSecret { get; set; } = string.Empty;
+    public ConnectedAccountPublishableContext ConnectedAccountPublishableContext { get; set; } = null!;
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = "EUR";
+    public decimal TouristTaxAmount { get; set; }
+    public decimal BasePrice { get; set; }
+}

--- a/Casazen.Web/Program.cs
+++ b/Casazen.Web/Program.cs
@@ -14,7 +14,9 @@ using Casazen.Web.Infrastructure;
 using Casazen.Web.Middleware;
 using Hangfire;
 using Hangfire.PostgreSql;
+using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using SendGrid.Extensions.DependencyInjection;
@@ -74,6 +76,7 @@ builder.Services.AddScoped<ITouristTaxService, TouristTaxService>();
 builder.Services.AddScoped<IOtaManager, OtaManager>();
 builder.Services.AddScoped<ISendGridService, SendGridService>();
 builder.Services.AddScoped<IImageStorageService, LocalImageStorageService>();
+builder.Services.AddScoped<IStripeService, StripeService>();
 builder.Services.AddScoped<StripeWebhookHandler>();
 builder.Services.AddScoped<IStripeConnectGateway, StripeConnectGateway>();
 builder.Services.AddScoped<IConnectOnboardingService, ConnectOnboardingService>();
@@ -100,6 +103,17 @@ builder.Services.AddCasazenAuthorization();
 
 // CORS
 builder.Services.AddCasazenCors(builder.Configuration);
+
+builder.Services.AddRateLimiter(options =>
+{
+    options.AddFixedWindowLimiter("PublicBookingCreate", limiter =>
+    {
+        limiter.Window = TimeSpan.FromMinutes(1);
+        limiter.PermitLimit = builder.Configuration.GetValue("DirectBooking:RateLimitPermitLimit", 10);
+        limiter.QueueLimit = 0;
+    });
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+});
 
 // Background Jobs
 builder.Services.AddScoped<OtaSyncJob>();
@@ -218,6 +232,7 @@ app.UseErrorHandling();
 // Authentication & Authorization (must be in this order)
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseRateLimiter();
 
 // Hangfire Dashboard and recurring jobs (only when Hangfire is configured)
 if (!string.IsNullOrEmpty(connectionString))

--- a/Casazen.Web/appsettings.json
+++ b/Casazen.Web/appsettings.json
@@ -14,7 +14,13 @@
   "Stripe": {
     "PublishableKey": "pk_test_YOUR_KEY",
     "SecretKey": "sk_test_YOUR_KEY",
-    "WebhookSecret": "whsec_YOUR_SECRET"
+    "WebhookSecret": "whsec_YOUR_SECRET",
+    "ConnectWebhookSecret": "whsec_YOUR_CONNECT_SECRET"
+  },
+  "DirectBooking": {
+    "PendingTtlMinutes": 15,
+    "ConsentVersion": "2026-06-direct-checkout-v1",
+    "RateLimitPermitLimit": 10
   },
   "Email": {
     "SendGridApiKey": "SG.YOUR_KEY",

--- a/Sessions/design-226.md
+++ b/Sessions/design-226.md
@@ -1,0 +1,421 @@
+# Design — Issue #226 Direct Checkout (Stripe Connect, Operator = Merchant of Record)
+
+> **Stage 02 — Design** · Spec: `Sessions/specs/spec-direct-checkout.md` (US-002) · Phase 1 (MVP Sellable — direct booking)
+> **Architecture**: AD-5 (operator = merchant of record, CasaZen never holds guest funds), RF2 (platform vs connected-account webhook routing), C3 (charge-gating via `ConnectChargesEnabled`)
+> **Stack**: .NET 10 · EF Core · PostgreSQL (Supabase) · Stripe Connect Express · layered `Casazen.Core` / `Casazen.Infrastructure` / `Casazen.Web` · React 19 SPA (`casazen/frontend`)
+> **Specialist synthesis**: `api-designer` (API Contract + Migration Plan) · `frontend-designer` (Frontend Flow + ProtectedRoute) · `security-by-design` (Security Notes + GDPR Scope).
+
+Anonymous guests book and pay on the branded public surface (`/book/:orgSlug/...`). Funds settle to the operator's Stripe **connected account** via a direct-charge `PaymentIntent` (`application_fee_amount = 0`). CasaZen confirms the booking asynchronously on connected-account `payment_intent.succeeded` (RF2). Tourist tax is computed server-side from `TouristTaxRate`; Alloggiati Web remains on operator check-in only (`BookingsController.CheckIn` → `AlloggiatiWebReportJob`).
+
+**Grounding note (verified against source):** Public read-model lives in `PublicOrgController` (`GET /api/public/orgs/{slug}/properties/{propertyId}` → `PropertyService.GetPublicPropertyForOrgAsync`, `IsActive` filter in `PropertyRepository.GetSearchQueryable`). Connect onboarding (#224) populated `Org.StripeConnectedAccountId` + `ConnectChargesEnabled` via `ConnectOnboardingService` / `POST /webhooks/stripe/connect`. Current `StripeService.CreatePaymentIntentAsync` creates PI on the **platform** account only — #226 adds a connected-account overload. `StripeWebhookHandler.HandlePaymentSucceededAsync` today only **updates** an existing `Payment` row by `TransactionId`; it does not confirm bookings — #226 extends this for `metadata.kind = "direct-booking"` on the Connect route. Frontend checkout shell is `CheckoutPlaceholderPage` at `/book/:orgSlug/property/:propertyId/checkout` (to be replaced). `axios.ts` already skips auth for `/public/orgs` — extend for `/public/bookings`.
+
+**Branch for Stage 03:** `feature/226-direct-checkout`
+
+---
+
+## API Contract
+
+**Conventions** — JSON camelCase; amounts in API responses are **decimal EUR** for display; Stripe `PaymentIntent.Amount` is **integer cents** (server converts). `propertyId`, dates, and guest fields come from the client; **prices, org id, connected account id, and publishable key context are server-derived**. No JWT on public booking endpoints.
+
+### A. Public direct booking endpoint (AC1–AC3, AC6, AC8, AC9)
+
+| # | Method | Path | Request schema | Response schema | Auth requirement (decision) |
+|---|---|---|---|---|---|
+| 1 | `POST` | `/api/public/bookings` | `CreateDirectBookingRequest` — see below | `200 DirectBookingResponse` — see below | **`[AllowAnonymous]` — explicit public justification:** anonymous guest checkout on branded booking site; abuse mitigated by per-IP rate limit (AC9) and server-side validation. No `OrgId` / `ownerId` accepted from client. |
+
+#### `CreateDirectBookingRequest` (#1 request)
+
+```json
+{
+  "propertyId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "checkInDate": "2026-07-01",
+  "checkOutDate": "2026-07-05",
+  "numberOfAdults": 2,
+  "numberOfChildren": 0,
+  "guest": {
+    "firstName": "Mario",
+    "lastName": "Rossi",
+    "email": "mario.rossi@example.com",
+    "phone": "+393331234567",
+    "country": "IT"
+  },
+  "consent": {
+    "dataProcessing": true,
+    "consentVersion": "2026-06-direct-checkout-v1"
+  },
+  "specialRequests": "Arrivo tardivo"
+}
+```
+
+| Field | Type | Validation |
+|---|---|---|
+| `propertyId` | `Guid` | Required; property must exist and `IsActive == true` |
+| `checkInDate` / `checkOutDate` | `date` (ISO) | Required; normalized to UTC date; `checkOut > checkIn` |
+| `numberOfAdults` | `int` | Required; `>= 1` |
+| `numberOfChildren` | `int` | Required; `>= 0`; `numberOfAdults + numberOfChildren <= property.MaxGuests` |
+| `guest.firstName` / `lastName` | `string` | Required, max 100 |
+| `guest.email` | `string` | Required, valid email |
+| `guest.phone` | `string` | Optional, max 20 |
+| `guest.country` | `string` | Required, max 100 |
+| `consent.dataProcessing` | `bool` | Must be `true` |
+| `consent.consentVersion` | `string` | Required; must match server-allowed version constant |
+| `specialRequests` | `string?` | Optional, max 1000 |
+
+#### `DirectBookingResponse` (#1 response — AC3, AC8)
+
+```json
+{
+  "bookingId": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+  "clientSecret": "pi_xxx_secret_xxx",
+  "connectedAccountPublishableContext": {
+    "publishableKey": "pk_test_...",
+    "stripeAccountId": "acct_xxx"
+  },
+  "amount": 520.00,
+  "currency": "EUR",
+  "touristTaxAmount": 8.00,
+  "basePrice": 512.00
+}
+```
+
+| Field | Type | Source |
+|---|---|---|
+| `bookingId` | `Guid` | New `Booking.Id` (`Status = Pending`, `Source = Direct`) |
+| `clientSecret` | `string` | Stripe `PaymentIntent.ClientSecret` on connected account |
+| `connectedAccountPublishableContext.publishableKey` | `string` | `IConfiguration["Stripe:PublishableKey"]` (platform publishable key — used with `stripeAccount` option) |
+| `connectedAccountPublishableContext.stripeAccountId` | `string` | `Org.StripeConnectedAccountId` (non-secret connected account id for Stripe.js) |
+| `amount` | `decimal` | `TotalPrice` (= charged PI amount in EUR) |
+| `currency` | `string` | Property/public read-model currency (default `"EUR"`) |
+| `touristTaxAmount` | `decimal` | Server-computed tourist tax (AC6) |
+| `basePrice` | `decimal` | `nightlyRate × nights + cleaningFee` (display-only breakdown; optional but recommended for AC13 FE) |
+
+**Explicitly omitted from response (AC8):** `ownerId`, `OrgId`, Stripe secret key, other guests' data, operator PII.
+
+#### Error responses (#1)
+
+| HTTP | Condition | Body (example) |
+|---|---|---|
+| `400` | Validation failure, missing consent, invalid dates, too many guests | `{ "error": "...", "message": "..." }` |
+| `404` | Property not found or `IsActive == false` | Empty / `{ "error": "Property not found" }` (anti-enumeration — same for inactive) |
+| `409` | Dates unavailable (`IBookingService.IsPropertyAvailableAsync` false) | `{ "error": "Property not available for selected dates" }` |
+| `409` | Operator not payment-ready: missing `StripeConnectedAccountId` or `ConnectChargesEnabled == false` (#224 AC5 gate) | `{ "error": "Complete Stripe onboarding before accepting guest payments" }` |
+| `429` | Per-IP rate limit exceeded (AC9) | `{ "error": "Too many requests" }` + `Retry-After` header |
+| `500` | Stripe PI creation failure | Generic error (no Stripe secret leakage) |
+
+#### Server-side processing sequence (#1 — AC2, AC3)
+
+1. **Resolve property** — `IPropertyRepository.GetByIdAsync(propertyId)` (existing filter: `IsActive`); load `Org` via `property.OrgId`. `404` if null.
+2. **Charge gate** — `Org.StripeConnectedAccountId` not null **and** `Org.ConnectChargesEnabled == true`; else `409`.
+3. **Availability** — `IBookingService.IsPropertyAvailableAsync` with **Pending TTL filter** (AC9): treat `Pending` + `Source = Direct` bookings older than `DirectBooking:PendingTtlMinutes` (default **15**) as non-blocking; optionally cancel them in the same transaction. `409` if still conflicting.
+4. **Guest upsert** — match `Guest` by email (`IGuestService.GetGuestByEmailAsync`); create or update with consent fields + request IP (`HttpContext.Connection.RemoteIpAddress`).
+5. **Amounts (server-only, AC2, AC6)** — `nights = (checkOut - checkIn).Days`; `basePrice = property.NightlyRate * nights + property.CleaningFee`; `touristTaxAmount = ITouristTaxService.CalculateTouristTaxAsync(property.City, numberOfAdults, numberOfChildren, checkIn, checkOut)` (uses `TouristTaxRate.RatePerPersonPerNight`, `MaxNights`, adults-only taxation per `TouristTaxService`); `totalPrice = basePrice + touristTaxAmount`. Set `Booking.NumberOfAdults`, `NumberOfChildren`, `NumberOfGuests`, `TouristTaxAmount`, `TouristTax` (mirror for existing reports), `OrgId`.
+6. **Persist booking** — `Status = Pending`, `Source = Direct` via new `IBookingService.CreateDirectBookingAsync`.
+7. **PaymentIntent (connected account, AC3)** — `IStripeService.CreateConnectedAccountPaymentIntentAsync(connectedAccountId, amountCents, currency, metadata)`:
+   - `RequestOptions.StripeAccount = Org.StripeConnectedAccountId`
+   - `ApplicationFeeAmount = 0` (no CasaZen fee; operator = MoR)
+   - `AutomaticPaymentMethods.Enabled = true` (PSD2/SCA)
+   - `Metadata`: `{ bookingId, propertyId, orgId, kind: "direct-booking" }`
+8. **Payment row (optional traceability)** — insert `Payment` with `Status = Pending`, `StripePaymentIntentId`, `TransactionId = paymentIntent.Id`, `Amount = totalPrice`, `OrgId`, `BookingId`.
+9. **Return** `DirectBookingResponse`.
+
+**Rate limiting (AC9):** Register ASP.NET Core fixed-window limiter policy `PublicBookingCreate` in `Program.cs` / `ServiceCollectionExtensions` — e.g. **10 requests / minute / IP** on `PublicBookingsController` via `[EnableRateLimiting("PublicBookingCreate")]`. Distinct from OTA `OtaRateLimiter` singleton.
+
+### B. Connect webhook endpoint — extended event handling (AC4–AC5, RF2)
+
+| # | Method | Path | Request schema | Response schema | Auth requirement (decision) |
+|---|---|---|---|---|---|
+| 2 | `POST` | `/webhooks/stripe/connect` | Raw Stripe event JSON; header `Stripe-Signature` required; connected-account events include non-null `event.Account` / `Stripe-Account` context | `200` empty body (ack ≤3s). `400` invalid signature. `500` if `Stripe:ConnectWebhookSecret` missing. | **`[AllowAnonymous]` — explicit public justification:** inbound Stripe Connect webhook; HMAC via `EventUtility.ConstructEvent` + `Stripe:ConnectWebhookSecret`. Already implemented in `WebhooksController.StripeConnectWebhook` (#224); **#226 extends handled event types only.** |
+
+**Ingress separation (RF2) — unchanged from #224, now includes payment events:**
+
+| Route | Secret | Events handled after #226 |
+|---|---|---|
+| `POST /webhooks/stripe` | `Stripe:WebhookSecret` | Platform billing only (`customer.subscription.*`, `invoice.*` — `spec-saas-billing`). **Must not** confirm direct bookings. |
+| `POST /webhooks/stripe/connect` | `Stripe:ConnectWebhookSecret` | `account.updated` (#224); **`payment_intent.succeeded`**, **`payment_intent.payment_failed`**, **`payment_intent.canceled`** (#226 direct checkout) |
+
+**Stripe Dashboard action:** Add `payment_intent.succeeded`, `payment_intent.payment_failed`, `payment_intent.canceled` to the Connect webhook endpoint (same URL `{API_BASE}/webhooks/stripe/connect`).
+
+#### Handled Connect events (#226)
+
+| Event type | Handler | Side effect | Idempotency |
+|---|---|---|---|
+| `payment_intent.succeeded` | `StripeWebhookHandler.HandleDirectBookingPaymentSucceededAsync` | Read `metadata.kind == "direct-booking"` + `bookingId`; load `Booking`; if already `Confirmed`, no-op; else `Pending → Confirmed`; upsert `Payment` (`StripePaymentIntentId`, `Status = Completed`, `ProcessedAt = UtcNow`) | By `PaymentIntent.Id` via `IPaymentRepository.GetByTransactionIdAsync` |
+| `payment_intent.payment_failed` | `StripeWebhookHandler.HandleDirectBookingPaymentFailedAsync` | Record/update `Payment` `Status = Failed`; booking stays `Pending` (or `Cancelled` if past Pending TTL — see AC5) | Same PI id |
+| `payment_intent.canceled` | Same as failed | Same | Same PI id |
+| `account.updated` | Existing `HandleAccountUpdatedAsync` → `ConnectOnboardingService.ApplyAccountUpdatedAsync` | Unchanged (#224) | Last-write-wins on org flags |
+
+**Processing model:** `WebhooksController.StripeConnectWebhook` verifies signature → enqueues `StripeWebhookJob.ProcessEventAsync(eventId, eventType, json, WebhookSource.Connected)` (add `source` discriminator parameter). Handler **ignores** `payment_intent.*` where `metadata.kind != "direct-booking"` (log + no-op). Platform route passes `WebhookSource.Platform`; handler skips direct-booking branches on platform source.
+
+**Alloggiati (AC7):** No webhook side effects for police reporting. Confirmed direct bookings follow existing `POST /api/bookings/{id}/check-in` → `BackgroundJob.Enqueue<AlloggiatiWebReportJob>` in `BookingsController` (operator-authenticated, unchanged).
+
+### C. Existing public read endpoints (consumer — no contract change)
+
+| # | Method | Path | Used by checkout for |
+|---|---|---|---|
+| 3 | `GET` | `/api/public/orgs/{slug}` | Org branding shell (`PublicOrgController`) |
+| 4 | `GET` | `/api/public/orgs/{slug}/properties/{propertyId}` | Property detail + rates (`PublicPropertyDetailDto`) for price preview (AC13) |
+
+Both remain **`[AllowAnonymous]`** per #212.
+
+### D. Service / layer map
+
+| Layer | Type | Responsibility |
+|---|---|---|
+| `PublicBookingsController` | Web | `[AllowAnonymous] POST /api/public/bookings`; rate limit; IP capture for consent |
+| `CreateDirectBookingRequest` / `DirectBookingResponse` | Web DTOs | Request/response contracts |
+| `IBookingService.CreateDirectBookingAsync` | Application | Guest upsert orchestration, amount computation, availability + TTL, PI creation |
+| `BookingService` | Infrastructure | Implementation; delegates tax to `ITouristTaxService`, Stripe to `IStripeService` |
+| `IStripeService` | Infrastructure | New `CreateConnectedAccountPaymentIntentAsync(...)` overload on `StripeService` |
+| `StripeWebhookHandler` | Infrastructure | Direct-booking payment event branches; booking confirmation |
+| `StripeWebhookJob` | Web (Hangfire) | Async processing; optional `WebhookSource` enum |
+| `WebhooksController` | Web | Existing Connect ingress (#224); pass `source` to job |
+| `IBookingRepository.IsAvailableAsync` | Infrastructure | Extend query to exclude expired `Pending` direct holds (AC9) |
+| `ExpirePendingDirectBookingsJob` (new, optional) | Web (Hangfire) | Recurring job marks expired `Pending`/`Direct` → `Cancelled` (AC5 cleanup) |
+
+**Config keys:**
+
+| Key | Purpose |
+|---|---|
+| `Stripe:SecretKey` | Platform API key — used with `StripeAccount` request option for connected PI create |
+| `Stripe:PublishableKey` | Returned in `connectedAccountPublishableContext` for Stripe.js |
+| `Stripe:ConnectWebhookSecret` | HMAC for `/webhooks/stripe/connect` |
+| `Stripe:WebhookSecret` | Platform route only (unchanged) |
+| `DirectBooking:PendingTtlMinutes` | Pending hold TTL (default `15`) |
+| `DirectBooking:ConsentVersion` | Allowed `consent.consentVersion` value |
+| `DirectBooking:RateLimitPermitLimit` | Default `10` per minute per IP |
+
+---
+
+## Frontend Flow
+
+Repo `casazen/frontend` (React 19, feature-slice, TanStack Query, Auth0). Issue #226 replaces the checkout placeholder with a **two-step anonymous checkout** (guest + consent → Stripe Elements payment). All user-facing strings are **Italian**.
+
+### Route changes & guard status
+
+| Route | Status in #226 | Guard |
+|---|---|---|
+| `/book/:orgSlug` | Unchanged — `OrgLandingPage` | **Public** — no `<ProtectedRoute>` |
+| `/book/:orgSlug/property/:propertyId` | Unchanged — `PublicPropertyPage` (date selection → navigates to checkout with query params) | **Public** |
+| `/book/:orgSlug/property/:propertyId/checkout` | **Modify** — replace `CheckoutPlaceholderPage` with `CheckoutPage` (AC10–AC14) | **Public** — no `<ProtectedRoute>` |
+| `/book/:orgSlug/property/:propertyId/checkout/confirmation` | **New** — `CheckoutConfirmationPage` (AC12 success state) | **Public** |
+| `/app/short-rent/settings/payments` | Unchanged (#224) — operator Connect onboarding | **`<ProtectedRoute>`** + `ContextRouteGuard` (`property.write`) |
+
+> **Gate G5:** All new/modified checkout routes under `/book/:orgSlug/...` are **public** (no `<ProtectedRoute>`). The only authenticated surface touched indirectly is operator check-in / Alloggiati (existing `BookingsController`, out of scope for guest FE).
+
+### Component breakdown
+
+| Component / file | Type | Responsibility |
+|---|---|---|
+| `src/features/public-booking/checkout-page.tsx` | create (replaces placeholder) | Step 1: guest form, GDPR consent, `PriceBreakdown`; Step 2: Stripe `Elements` + `PaymentElement`; calls `useCreateDirectBooking` then `confirmPayment` |
+| `src/features/public-booking/checkout-confirmation-page.tsx` | create | Success screen with booking reference (`bookingId`), dates, amount (AC12) |
+| `src/features/public-booking/components/price-breakdown.tsx` | create | Lines: nightly × nights, cleaning fee, **Tassa di soggiorno** (AC13) |
+| `src/features/public-booking/components/consent-checkbox.tsx` | create | Mandatory GDPR gate — "Acconsento al trattamento dei dati" (AC13) |
+| `src/features/public-booking/components/stripe-payment-form.tsx` | create | `@stripe/react-stripe-js` wrapper; `loadStripe(publishableKey, { stripeAccount })` from API response |
+| `src/api/public-booking.api.ts` | create | `createDirectBooking(payload)` → `POST /api/public/bookings` |
+| `src/queries/use-public-booking.ts` | create | `useCreateDirectBooking()` mutation (no auth header) |
+| `src/types/booking.types.ts` | modify | `CreateDirectBookingRequest`, `DirectBookingResponse`, `ConnectedAccountPublishableContext` |
+| `src/lib/axios.ts` | modify | Add `/public/bookings` to public endpoint skip list (AC11) |
+| `src/routes/index.tsx` | modify | Swap `CheckoutPlaceholderPage` → `CheckoutPage`; add confirmation child route |
+| `package.json` | modify | Add `@stripe/stripe-js`, `@stripe/react-stripe-js` (AC14) |
+
+### Checkout UX flow (AC10–AC14)
+
+```
+Guest → PublicPropertyPage (select dates)
+  → navigate /book/{slug}/property/{id}/checkout?checkIn=&checkOut=
+
+CheckoutPage Step 1 — guest + consent
+  → PriceBreakdown (client preview from PublicPropertyDetailDto; server amounts authoritative after submit)
+  → ConsentCheckbox required
+  → Submit disabled until consent checked
+
+CheckoutPage Step 2 — payment
+  → useCreateDirectBooking.mutateAsync(payload)
+  → POST /api/public/bookings (no Authorization header)
+  → initialize Stripe: loadStripe(response.connectedAccountPublishableContext.publishableKey,
+                              { stripeAccount: response.connectedAccountPublishableContext.stripeAccountId })
+  → Elements + PaymentElement with clientSecret
+  → stripe.confirmPayment({ elements, confirmParams: { return_url: confirmationUrl } })
+  → SCA/3DS handled by Stripe.js (AC12)
+
+Success → /book/{slug}/property/{id}/checkout/confirmation?bookingId={id}
+Failure → inline Italian error on payment step + retry (same bookingId / new PI policy: allow retry via re-submit or dedicated "Riprova pagamento" calling create again if PI expired)
+```
+
+**Operator not onboarded:** If API returns `409`, show destructive alert linking to operator-facing copy (guest-safe message: "Pagamenti non ancora disponibili per questa struttura") — mirrors #224 checkout-gate banner on operator settings, not guest actionable.
+
+**Date params:** Read `checkIn` / `checkOut` from URL search params (set by `PublicPropertyPage` navigation); validate present before enabling submit.
+
+### Data flow diagram
+
+```mermaid
+sequenceDiagram
+  participant Guest as Guest (FE)
+  participant API as PublicBookingsController
+  participant Svc as BookingService
+  participant Stripe as Stripe Connect
+  participant WH as WebhooksController
+  participant Job as StripeWebhookJob
+  participant H as StripeWebhookHandler
+
+  Guest->>API: POST /api/public/bookings
+  API->>Svc: CreateDirectBookingAsync
+  Svc->>Svc: Upsert Guest + Pending Booking + tax
+  Svc->>Stripe: PaymentIntent.create (StripeAccount=acct_xxx, fee=0)
+  API-->>Guest: DirectBookingResponse (clientSecret, publishable context)
+
+  Guest->>Stripe: Stripe.js confirmPayment (SCA)
+  Stripe-->>Guest: redirect / confirmation
+
+  Stripe->>WH: POST /webhooks/stripe/connect (payment_intent.succeeded)
+  WH->>Job: Enqueue ProcessEventAsync (source=Connected)
+  Job->>H: HandleDirectBookingPaymentSucceededAsync
+  H->>H: Pending → Confirmed + Payment Completed (idempotent)
+```
+
+---
+
+## Security Notes
+
+### Threat model (STRIDE)
+
+| Threat | Vector | Mitigation |
+|---|---|---|
+| **Price manipulation** | Guest tampers with amounts in request | Server computes all prices (AC2); client prices ignored; PI amount matches server `TotalPrice` |
+| **Booking for unavailable dates** | Race / hold bypass | DB availability check; `Pending` direct holds block inventory until TTL (AC9) |
+| **Pay before operator onboarded** | Guest checks out when Connect inactive | `ConnectChargesEnabled` + `StripeConnectedAccountId` gate → `409` (#224 AC5) |
+| **Cross-tenant payment routing** | Attacker supplies another org's property | `OrgId` derived from `Property.OrgId`; connected account from property's org only |
+| **PII exfiltration** | Public API returns internal ids | Response whitelist (AC8): no `ownerId`, org secrets, other guests |
+| **Card data exposure** | PAN through CasaZen servers | Stripe Elements + `automatic_payment_methods`; PCI scope stays with Stripe (AC14) |
+| **Webhook spoofing** | Fake `payment_intent.succeeded` | `Stripe:ConnectWebhookSecret` HMAC on `/webhooks/stripe/connect` only; wrong route rejects signature |
+| **Webhook replay** | Duplicate event confirms twice | Idempotent by `PaymentIntent.Id` + skip if booking already `Confirmed` |
+| **Abuse / scraping** | Mass booking creation | Per-IP rate limit on `POST /api/public/bookings` (AC9) |
+| **Consent bypass** | Submit without GDPR consent | Server rejects `consent.dataProcessing != true` → `400` |
+| **Secret leakage** | API returns Stripe secret key | Only `clientSecret` (intended for client) + publishable key; never `Stripe:SecretKey` |
+
+### Webhook secrets (RF2)
+
+| Route | Secret | Verification | #226 events |
+|---|---|---|---|
+| `/webhooks/stripe` | `Stripe:WebhookSecret` | Platform billing — **not** direct checkout | No booking confirmation |
+| `/webhooks/stripe/connect` | `Stripe:ConnectWebhookSecret` | Connect account events | `payment_intent.*` (direct booking) + `account.updated` |
+
+Connected-account events arrive with non-null `event.Account`. Handler must **require** `metadata.kind == "direct-booking"` before mutating bookings. Platform-account `payment_intent.succeeded` events must not confirm direct bookings even if metadata were tampered — ingress separation prevents verified delivery on wrong secret.
+
+### PII / funds flow
+
+| Data | Where collected | CasaZen storage | Notes |
+|---|---|---|---|
+| Guest name, email, phone, country | Public checkout form | `Guest` entity | Upsert by email; consent metadata |
+| Card / payment method | Stripe.js only | **None** | Operator connected account is MoR |
+| PaymentIntent id | Stripe API | `Payment.StripePaymentIntentId`, `TransactionId` | Non-secret reference |
+| Consent IP | Server | `Guest.ConsentIpAddress` | From `HttpContext` |
+| Operator payout / KYC | Stripe Connect (#224) | Account id + flags only on `Org` | Not guest checkout scope |
+
+**Merchant of record:** Operator receives funds directly (`application_fee_amount = 0`); CasaZen never holds or settles guest funds (AD-5 / C3).
+
+### Auth decisions summary
+
+| Surface | Principal | Policy |
+|---|---|---|
+| `POST /api/public/bookings` | Anonymous guest | `[AllowAnonymous]` + rate limit + validation |
+| `GET /api/public/orgs/*` | Anonymous | `[AllowAnonymous]` (existing) |
+| `POST /webhooks/stripe/connect` | Stripe (HMAC) | `[AllowAnonymous]` + `Stripe:ConnectWebhookSecret` |
+| `POST /api/bookings/{id}/check-in` | Operator JWT | Existing `PropertyOwner` + `booking.write` (Alloggiati enqueue) |
+
+---
+
+## Migration Plan
+
+**N/A — no schema changes**
+
+All required fields already exist:
+
+| Entity | Existing fields used |
+|---|---|
+| `Booking` | `Source`, `Status`, `BasePrice`, `TouristTax` / `TouristTaxAmount`, `NumberOfAdults`, `NumberOfChildren`, `OrgId`, `CreatedAt` |
+| `Guest` | Consent fields (`DataProcessingConsentDate`, `ConsentIpAddress`, `ConsentVersion`, `DataRetentionUntil`, …) |
+| `Payment` | `StripePaymentIntentId`, `TransactionId`, `Status`, `ProcessedAt`, `OrgId` |
+| `Org` | `StripeConnectedAccountId`, `ConnectChargesEnabled` (#224) |
+
+**Behavioral / config-only changes:**
+
+| Area | Change |
+|---|---|
+| `BookingRepository.IsAvailableAsync` | Exclude expired `Pending` + `Direct` holds (AC9) — query-only |
+| `Program.cs` / `ServiceCollectionExtensions` | ASP.NET rate limiter policy `PublicBookingCreate` |
+| `appsettings.json` | `DirectBooking:PendingTtlMinutes`, `DirectBooking:ConsentVersion`, rate limit tuning |
+| Stripe Dashboard | Subscribe `payment_intent.*` on Connect webhook endpoint |
+| Railway / env | Confirm `Stripe:PublishableKey`, `Stripe:ConnectWebhookSecret` set |
+
+**Optional follow-up (non-blocking):** composite index on `Bookings (PropertyId, Status, Source, CreatedAt)` if availability queries regress under load — not required for MVP.
+
+**Deploy sequence:**
+
+1. Deploy backend with new controller + webhook handler branches (no EF migration).
+2. Update Stripe Connect webhook event subscriptions.
+3. Deploy frontend with Stripe.js dependencies + checkout pages.
+4. Smoke: anonymous checkout on staging with Connect test account; verify `payment_intent.succeeded` confirms booking via Hangfire.
+
+---
+
+## GDPR Scope
+
+**Regulatory driver:** Guest PII collected at anonymous checkout; lawful basis = **contract performance** (booking) + **consent** (GDPR Art. 6(1)(b)/(a)).
+
+**Consent capture (AC2, AC13) — written to `Guest` on upsert:**
+
+| Field | Value | Purpose |
+|---|---|---|
+| `DataProcessingConsentDate` | `DateTime.UtcNow` | Proof of consent timestamp |
+| `ConsentIpAddress` | Client IP (max 50) | Audit trail |
+| `ConsentVersion` | From request (validated against `DirectBooking:ConsentVersion`) | Versioned privacy notice |
+| `DataRetentionUntil` | Default `UtcNow + 7 years` (existing entity default) | Retention policy |
+| `ConsentDate` | Same as processing consent | Align with existing GDPR columns |
+| `DataProcessingPurpose` | `"Direct Booking Checkout"` | Purpose limitation |
+
+**PII collected at checkout:**
+
+| Field | Personal data? | Storage |
+|---|---|---|
+| `FirstName`, `LastName` | Yes | `Guest` |
+| `Email` | Yes | `Guest` (lookup key) |
+| `PhoneNumber` | Yes | `Guest` |
+| `Country` | Low sensitivity | `Guest` |
+
+**Data minimization (AC8):** `DirectBookingResponse` exposes only booking id, payment client secret, publishable Stripe context, and amounts — never operator Auth0 `sub`, full guest records of other users, or Stripe secret keys.
+
+**Special requests:** Optional free text stored on `Booking.SpecialRequests` — may contain personal preferences; covered by same consent.
+
+**Alloggiati / police data:** **Not** collected at checkout (AC7). Additional guest document fields remain for operator check-in workflow / `AlloggiatiWebReportJob`.
+
+**Data subject rights:** Guest erasure flows via existing `GdprService` / guest management (operator context). Direct checkout does not create Auth0 users.
+
+**Cross-border:** Payment processing under Stripe DPA on operator connected account; CasaZen acts as processor for booking/guest data stored in Supabase EU.
+
+---
+
+## Open Questions
+
+All resolved.
+
+1. **`ITaxCalculationService` vs `ITouristTaxService` for adult/child split?**
+   **Resolved:** Use `ITouristTaxService.CalculateTouristTaxAsync(city, numberOfAdults, numberOfChildren, ...)` — already implements DB-driven `TouristTaxRate` with adults-only taxation (AC6). `BookingsController` legacy path uses `ITaxCalculationService`; direct booking uses the tourist-tax service aligned with spec.
+
+2. **Pending TTL duration?**
+   **Resolved:** Config `DirectBooking:PendingTtlMinutes` default **15**. Availability query ignores expired pending direct holds; optional `ExpirePendingDirectBookingsJob` cancels stale rows.
+
+3. **`connectedAccountPublishableContext` shape?**
+   **Resolved:** `{ publishableKey, stripeAccountId }` — platform publishable key + connected account id for `loadStripe(key, { stripeAccount })` per Stripe Connect direct-charge docs.
+
+4. **Create `Payment` row at booking time or only on webhook?**
+   **Resolved:** Create `Pending` payment at PI creation; webhook sets `Completed` / `Failed` idempotently (simplifies failure tracking AC5).
+
+5. **`StripeWebhookJob` source discriminator?**
+   **Resolved:** Add `WebhookSource` enum (`Platform`, `Connected`) parameter; Connect route passes `Connected`. Handler processes direct-booking payment branches only when `source == Connected` **and** `metadata.kind == "direct-booking"`.
+
+6. **Replace placeholder vs new route?**
+   **Resolved:** Replace `CheckoutPlaceholderPage` in-place at existing `/checkout` route; add `/checkout/confirmation` child route for AC12 success UX.
+
+7. **Tourist tax FE preview before API call?**
+   **Resolved:** Step 1 shows **estimated** breakdown from `PublicPropertyDetailDto` rates; authoritative `touristTaxAmount` returned only in `DirectBookingResponse` after server calculation (display updated before payment step).

--- a/Sessions/pipeline-spec-direct-checkout/issue-body.md
+++ b/Sessions/pipeline-spec-direct-checkout/issue-body.md
@@ -1,0 +1,81 @@
+## User Story
+
+As an anonymous guest, I want to select dates for a published property, enter my details and consent, and pay securely so that my booking is confirmed instantly — paying the **operator** directly with no booking commission added by CasaZen.
+
+As an operator, I want guest payments to land in **my** Stripe account (I am the merchant of record), with tourist tax computed at checkout and the Italian police report (Alloggiati Web) filed on check-in, so I stay compliant without manual steps.
+
+**Spec**: `Sessions/specs/spec-direct-checkout.md` · Phase 1 MVP · Depends on #212 (read-model), #202 (tenant-boundary), #224 (connect-onboarding), #215 (branded booking site)
+
+---
+
+## Acceptance Criteria
+
+### Backend
+
+- **AC1**: New `POST /api/public/bookings` (`[AllowAnonymous]`) accepts `CreateDirectBookingRequest` with propertyId, dates, guest details, consent. Validates availability (`409` if unavailable); property must be `IsActive` (`404`); requires `consent.dataProcessing == true` (`400`).
+
+- **AC2**: On valid request: upsert `Guest` (match by email; consent fields), create `Booking` with `Source = Direct`, `Status = Pending`, compute amounts server-side (nightly rate × nights + cleaning fee + tourist tax via `ITaxCalculationService`). Client prices ignored.
+
+- **AC3**: Create Stripe Connect `PaymentIntent` on operator's connected account; return `DirectBookingResponse { bookingId, clientSecret, connectedAccountPublishableContext, amount, currency, touristTaxAmount }`. `application_fee_amount = 0`. `409` if no `StripeConnectedAccountId`.
+
+- **AC4 (RF2)**: Connected-account `payment_intent.succeeded` webhook (Connect signing secret) transitions booking `Pending → Confirmed`, writes `Payment` idempotently. Platform webhook not used here.
+
+- **AC5**: `payment_intent.payment_failed` / `canceled` leaves booking Pending or marks Cancelled after expiry; no Alloggiati side effects.
+
+- **AC6**: Tourist tax at checkout from `TouristTaxRate` (DB-driven, never hardcoded).
+
+- **AC7**: Alloggiati Web on check-in only (existing `AlloggiatiWebReportJob` path unchanged).
+
+- **AC8**: Public response data-minimized — no ownerId, no secret keys, no other guests' data.
+
+- **AC9**: Rate-limiting per-IP on `POST /api/public/bookings`; Pending booking TTL releases inventory.
+
+### Frontend
+
+- **AC10**: Public checkout flow (no Auth0): date/guest step → Stripe Elements payment step for operator connected account.
+
+- **AC11**: `createDirectBooking()` → `POST /api/public/bookings`; `useCreateDirectBooking()` without auth header.
+
+- **AC12**: `confirmPayment` with SCA/3DS; success shows confirmation; failure shows inline error + retry.
+
+- **AC13**: Mandatory GDPR consent checkbox + price breakdown (nightly, cleaning, tourist tax) in Italian before payment.
+
+- **AC14**: No card data through CasaZen — Stripe Elements only; publishable key from API response.
+
+---
+
+## Technical Notes
+
+### Backend impact
+- New `PublicBookingsController` — `[AllowAnonymous] POST /api/public/bookings`
+- Modify `StripeService` — connected-account PaymentIntent overload (`RequestOptions.StripeAccount`, `application_fee_amount = 0`)
+- Modify `BookingService` — `CreateDirectBookingAsync`, Pending TTL helper
+- Modify `WebhooksController` / `StripeWebhookHandler` / `StripeWebhookJob` — RF2 connected-account `payment_intent.*` events
+- Rate limiter registration for public booking endpoint
+- **No EF migration expected** unless new fields needed for Pending TTL (reuse existing Booking/Guest/Payment entities)
+
+### Frontend impact
+- New checkout page, price breakdown, consent checkbox under `src/features/public-booking/`
+- Add `@stripe/stripe-js`, `@stripe/react-stripe-js`
+- Modify `axios.ts` to skip auth for `/public/bookings`
+
+### Background jobs
+- `StripeWebhookJob` — async processing of connected-account payment events
+- `AlloggiatiWebReportJob` — unchanged; triggered on check-in only
+
+### OTA impact
+- None — direct booking is separate from OTA adapters
+
+### Compliance
+- Stripe Connect operator = MoR (C3 gate): `application_fee_amount = 0`, funds settle to operator
+- PSD2/SCA via Stripe.js `automatic_payment_methods`
+- Tourist tax from DB `TouristTaxRate` at checkout
+- GDPR consent captured on guest upsert
+- Alloggiati Web on check-in (D.L. 286/1998 Art. 7), never inline at checkout
+
+---
+
+## Dependencies
+
+- Requires: #212 (public read-model), #202 (tenant-boundary), #224 (connect-onboarding), #215 (branded booking site checkout surface)
+- Blocks: full branded-site publish gate with live payments

--- a/Sessions/pipeline-spec-direct-checkout/state.md
+++ b/Sessions/pipeline-spec-direct-checkout/state.md
@@ -1,0 +1,37 @@
+# Pipeline: Direct Checkout (Stripe Connect, Operator = MoR) (US-002)
+
+## Status
+- status: running
+- current_stage: 01-planning
+- started: 2026-06-10T12:00:00Z
+- last_updated: 2026-06-10T12:00:00Z
+
+## Input
+- description: Public direct booking + Stripe Connect checkout for anonymous guests — PaymentIntent on operator connected account, application_fee_amount=0, tourist tax at checkout, connected-account webhook confirmation, Stripe.js Elements FE flow.
+- type: feat
+- priority: critical
+- spec_file: Sessions/specs/spec-direct-checkout.md
+
+## Artifacts
+- issue: (pending)
+- branch: (pending)
+- design_spec: (pending)
+- pr_backend: (pending)
+- pr_backend_url: (pending)
+- pr_frontend: (pending)
+- pr_frontend_url: (pending)
+- release_report: (pending)
+- tag: (pending)
+- release_url: (pending)
+- ops_report: (pending)
+
+## Stage History
+
+| Stage | Status | Iterations | Gates | Artifact |
+|---|---|---|---|---|
+| 01-planning | (pending) | - | - | - |
+| 02-design | (pending) | - | - | - |
+| 03-development | (pending) | - | - | - |
+| 04-review | (pending) | - | - | - |
+| 05-release | (pending) | - | - | - |
+| 06-operations | (pending) | - | - | - |


### PR DESCRIPTION
## Summary
- Add `POST /api/public/bookings` for anonymous direct checkout (Stripe Connect, operator = MoR)
- Connected-account PaymentIntent with `application_fee_amount = 0`, pending TTL, rate limiting
- RF2 webhook handling for `payment_intent.*` on `/webhooks/stripe/connect`
- Integration tests for consent validation, connect gate, and webhook confirmation

## Frontend PR
https://github.com/casazen/frontend/pull/TBD

## Test Plan
- [x] `dotnet test` (481 pass)
- [x] `DirectCheckoutIntegrationTests` (AC1/AC3/webhook)
- [ ] Staging smoke after merge

Closes #226
