### PR TITLE
fix(#217): auto-provision Starter org for legacy users without OrgId

### DIFF
--- a/Casazen.Infrastructure/Services/UserService.cs
+++ b/Casazen.Infrastructure/Services/UserService.cs
@@ -93,7 +93,36 @@ public class UserService(
         // Upsert by sub (Auth0 sub == User.Id)
         var existing = await repository.GetBySubAsync(sub);
         if (existing != null)
+        {
+            var normalizedEmail = string.IsNullOrWhiteSpace(email) ? null : email.ToLowerInvariant();
+            var changed = false;
+
+            if (string.IsNullOrWhiteSpace(existing.Email) && normalizedEmail is not null)
+            {
+                existing.Email = normalizedEmail;
+                changed = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(existing.FirstName) && !string.IsNullOrWhiteSpace(firstName))
+            {
+                existing.FirstName = firstName;
+                changed = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(existing.LastName) && !string.IsNullOrWhiteSpace(lastName))
+            {
+                existing.LastName = lastName;
+                changed = true;
+            }
+
+            if (changed)
+            {
+                existing.UpdatedAt = DateTime.UtcNow;
+                await repository.UpdateAsync(existing);
+            }
+
             return existing;
+        }
 
         var user = new User
         {

--- a/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/PropertiesControllerTests.cs
@@ -2,10 +2,10 @@ using System.Security.Claims;
 using Casazen.Core.DTOs;
 using Casazen.Core.Entities;
 using Casazen.Core.Enums;
-using Casazen.Core.Multitenancy;
 using Casazen.Core.Services;
 using Casazen.Web.Controllers;
 using Casazen.Web.DTOs;
+using Casazen.Web.Infrastructure;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -21,7 +21,7 @@ public class PropertiesControllerTests
     private readonly Mock<IPropertyAuthorizationService> _mockAuthz;
     private readonly Mock<IPropertyDocumentService> _mockDocumentService;
     private readonly Mock<IAdminAccessAuditService> _mockAuditService;
-    private readonly Mock<ITenantContext> _mockTenantContext;
+    private readonly Mock<IOrgContextResolver> _mockOrgContextResolver;
     private readonly Mock<IEntitlementService> _mockEntitlementService;
     private readonly Mock<ILogger<PropertiesController>> _mockLogger;
     private readonly PropertiesController _controller;
@@ -33,7 +33,7 @@ public class PropertiesControllerTests
         _mockAuthz = new Mock<IPropertyAuthorizationService>();
         _mockDocumentService = new Mock<IPropertyDocumentService>();
         _mockAuditService = new Mock<IAdminAccessAuditService>();
-        _mockTenantContext = new Mock<ITenantContext>();
+        _mockOrgContextResolver = new Mock<IOrgContextResolver>();
         _mockEntitlementService = new Mock<IEntitlementService>();
         _mockLogger = new Mock<ILogger<PropertiesController>>();
         _controller = new PropertiesController(
@@ -42,13 +42,15 @@ public class PropertiesControllerTests
             _mockAuthz.Object,
             _mockDocumentService.Object,
             _mockAuditService.Object,
-            _mockTenantContext.Object,
+            _mockOrgContextResolver.Object,
             _mockEntitlementService.Object,
             _mockLogger.Object);
 
         // Defaults: caller has an org and is under the plan limit. Create-path tests that need
         // the opposite (no org / limit reached) override these per-test.
-        _mockTenantContext.SetupGet(x => x.OrgId).Returns(DefaultOrgId);
+        _mockOrgContextResolver
+            .Setup(x => x.GetOrProvisionOrgIdAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DefaultOrgId);
         _mockEntitlementService
             .Setup(x => x.CanAddPropertyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);

--- a/Casazen.Web/Controllers/ConnectController.cs
+++ b/Casazen.Web/Controllers/ConnectController.cs
@@ -1,6 +1,6 @@
-using Casazen.Core.Multitenancy;
 using Casazen.Core.Services;
 using Casazen.Web.DTOs.Connect;
+using Casazen.Web.Infrastructure;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,7 +10,7 @@ namespace Casazen.Web.Controllers;
 [Route("api/connect")]
 [Authorize(Policy = "RequireContext:short-rent:property.write")]
 public class ConnectController(
-    ITenantContext tenantContext,
+    IOrgContextResolver orgContextResolver,
     IConnectOnboardingService connectOnboardingService) : ControllerBase
 {
     [HttpPost("account")]
@@ -18,7 +18,7 @@ public class ConnectController(
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ConnectStatusDto>> CreateAccount(CancellationToken cancellationToken)
     {
-        var orgId = RequireOrgId();
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(cancellationToken);
         if (orgId is null)
             return NotFound(new { error = "No organization assigned to the current user" });
 
@@ -37,7 +37,7 @@ public class ConnectController(
         if (string.IsNullOrWhiteSpace(dto.ReturnUrl) || string.IsNullOrWhiteSpace(dto.RefreshUrl))
             return BadRequest(new { error = "returnUrl and refreshUrl are required" });
 
-        var orgId = RequireOrgId();
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(cancellationToken);
         if (orgId is null)
             return NotFound(new { error = "No organization assigned to the current user" });
 
@@ -57,15 +57,13 @@ public class ConnectController(
         [FromQuery] bool refresh = true,
         CancellationToken cancellationToken = default)
     {
-        var orgId = RequireOrgId();
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(cancellationToken);
         if (orgId is null)
             return NotFound(new { error = "No organization assigned to the current user" });
 
         var status = await connectOnboardingService.GetStatusAsync(orgId.Value, refresh, cancellationToken);
         return Ok(Map(status));
     }
-
-    private Guid? RequireOrgId() => tenantContext.OrgId;
 
     private static ConnectStatusDto Map(ConnectStatus status) => new()
     {

--- a/Casazen.Web/Controllers/PropertiesController.cs
+++ b/Casazen.Web/Controllers/PropertiesController.cs
@@ -21,7 +21,7 @@ public class PropertiesController(
     IPropertyAuthorizationService authorizationService,
     IPropertyDocumentService documentService,
     IAdminAccessAuditService adminAccessAuditService,
-    ITenantContext tenantContext,
+    IOrgContextResolver orgContextResolver,
     IEntitlementService entitlementService,
     ILogger<PropertiesController> logger) : ControllerBase
 {
@@ -90,9 +90,8 @@ public class PropertiesController(
         if (string.IsNullOrEmpty(userId))
             return Unauthorized();
 
-        // Fail-closed (AC7): OrgId is required on a Property, so a caller with no org context
-        // (e.g. a brand-new user pre-backfill) cannot create tenant-scoped rows.
-        var orgId = tenantContext.OrgId;
+        // Resolve org; auto-provision Starter org for legacy users who have roles but no OrgId (#217).
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(HttpContext.RequestAborted);
         if (orgId is null)
         {
             logger.LogWarning("Property creation blocked: user {UserId} has no org context", userId);

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -243,6 +243,7 @@ public static class ServiceCollectionExtensions
 
         // Multi-tenant Org boundary (US-004): tenant resolution + org/entitlement reads.
         services.AddScoped<ITenantContext, TenantContext>();
+        services.AddScoped<IOrgContextResolver, OrgContextResolver>();
         services.AddScoped<IOrgService, OrgService>();
         services.AddScoped<IEntitlementService, EntitlementService>();
         return services;

--- a/Casazen.Web/Infrastructure/OrgContextResolver.cs
+++ b/Casazen.Web/Infrastructure/OrgContextResolver.cs
@@ -1,0 +1,77 @@
+using System.Security.Claims;
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Multitenancy;
+using Casazen.Core.Services;
+
+namespace Casazen.Web.Infrastructure;
+
+/// <summary>
+/// Resolves the caller's organization id, auto-provisioning a Starter org when the user
+/// has roles but never completed onboarding (production backfill for #217).
+/// </summary>
+public interface IOrgContextResolver
+{
+    Task<Guid?> GetOrProvisionOrgIdAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class OrgContextResolver(
+    ITenantContext tenantContext,
+    IHttpContextAccessor httpContextAccessor,
+    IUserService userService,
+    IOrgService orgService,
+    ILogger<OrgContextResolver> logger) : IOrgContextResolver
+{
+    public async Task<Guid?> GetOrProvisionOrgIdAsync(CancellationToken cancellationToken = default)
+    {
+        if (tenantContext.OrgId is Guid cached)
+            return cached;
+
+        var sub = ResolveSub();
+        if (string.IsNullOrWhiteSpace(sub))
+            return null;
+
+        var user = await userService.GetUserAsync(sub);
+        if (user?.OrgId is Guid linked)
+            return linked;
+
+        var (email, firstName, lastName) = ResolveProfileClaims();
+        var displayName = $"{firstName} {lastName}".Trim();
+        if (string.IsNullOrWhiteSpace(displayName))
+            displayName = string.IsNullOrWhiteSpace(email) ? "La mia organizzazione" : email;
+
+        logger.LogInformation("Auto-provisioning Starter org for user {UserId}", sub);
+        var org = await orgService.EnsureOrgForUserAsync(
+            sub, email, displayName, PlanTier.Starter, cancellationToken);
+        return org.Id;
+    }
+
+    private string? ResolveSub()
+    {
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user is null)
+            return null;
+
+        return user.FindFirstValue("sub")
+            ?? user.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? user.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier");
+    }
+
+    private (string Email, string FirstName, string LastName) ResolveProfileClaims()
+    {
+        var principal = httpContextAccessor.HttpContext?.User;
+        if (principal is null)
+            return (string.Empty, string.Empty, string.Empty);
+
+        var email = principal.FindFirst("email")?.Value
+                    ?? principal.FindFirst(ClaimTypes.Email)?.Value
+                    ?? string.Empty;
+        var firstName = principal.FindFirst("given_name")?.Value
+                        ?? principal.FindFirst("name")?.Value?.Split(' ').FirstOrDefault()
+                        ?? string.Empty;
+        var lastName = principal.FindFirst("family_name")?.Value
+                       ?? principal.FindFirst("name")?.Value?.Split(' ').Skip(1).FirstOrDefault()
+                       ?? string.Empty;
+
+        return (email, firstName, lastName);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IOrgContextResolver` to auto-provision a Starter org via `EnsureOrgForUserAsync` when a user has Auth0 roles but no `OrgId` in the database
- Wire Connect and property-creation endpoints through the resolver so legacy prod users (e.g. payments page 404) get an org on first API call
- Backfill empty Email/FirstName/LastName on existing users during `GetCurrentUserAsync`

Closes #217. Supersedes stale PR #221 (branch behind develop).

## Test plan
- [x] `dotnet test` — 481 passed
- [ ] Merge to develop and release hotfix to main
- [ ] Re-test prod: `GET /api/connect/status` returns 200 for `luca.lamal@hotmail.it`
- [ ] Verify Stripe Connect onboarding flow from `/app/short-rent/settings/payments`

Made with [Cursor](https://cursor.com)