### PR TITLE
fix: Stripe Connect onboarding + booking DTO responses (#252)

### DIFF
--- a/Casazen.Core/Services/Auth0UserProfile.cs
+++ b/Casazen.Core/Services/Auth0UserProfile.cs
@@ -1,0 +1,3 @@
+namespace Casazen.Core.Services;
+
+public record Auth0UserProfile(string Email, string FirstName, string LastName);

--- a/Casazen.Core/Services/IAuth0ManagementService.cs
+++ b/Casazen.Core/Services/IAuth0ManagementService.cs
@@ -10,4 +10,9 @@ public interface IAuth0ManagementService
     /// Replaces onboarding-related roles (PropertyOwner, LongTermLandlord) while preserving others (e.g. Admin).
     /// </summary>
     Task AssignOnboardingRolesAsync(string userId, IReadOnlyList<UserRole> roles);
+
+    /// <summary>
+    /// Fetches email and name from Auth0. Returns null when Management API is not configured.
+    /// </summary>
+    Task<Auth0UserProfile?> GetUserProfileAsync(string userId);
 }

--- a/Casazen.Core/Services/IUserService.cs
+++ b/Casazen.Core/Services/IUserService.cs
@@ -20,6 +20,11 @@ public interface IUserService
     Task<(IEnumerable<User> Users, int TotalCount)> GetPagedAsync(
         string? search, string? role, bool? isActive, int page, int pageSize);
 
+    /// <summary>
+    /// Backfills missing email/name from Auth0 Management API for admin user listings.
+    /// </summary>
+    Task EnrichUsersFromAuth0Async(IList<User> users);
+
     Task ChangeRoleAsync(string id, UserRole newRole, string adminSub);
 
     /// <summary>

--- a/Casazen.Infrastructure/External/StripeConnectGateway.cs
+++ b/Casazen.Infrastructure/External/StripeConnectGateway.cs
@@ -1,3 +1,4 @@
+using Casazen.Core.Exceptions;
 using Casazen.Core.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -12,10 +13,12 @@ public class StripeConnectGateway(IConfiguration configuration, ILogger<StripeCo
     {
         EnsureApiKey();
 
+        var country = configuration["Stripe:ConnectDefaultCountry"] ?? "IT";
+
         var options = new AccountCreateOptions
         {
             Type = "express",
-            Email = email,
+            Country = country,
             Capabilities = new AccountCapabilitiesOptions
             {
                 CardPayments = new AccountCapabilitiesCardPaymentsOptions { Requested = true },
@@ -23,10 +26,23 @@ public class StripeConnectGateway(IConfiguration configuration, ILogger<StripeCo
             },
         };
 
-        var service = new AccountService();
-        var account = await service.CreateAsync(options, cancellationToken: cancellationToken);
-        logger.LogInformation("Stripe Express account created: {AccountId}", account.Id);
-        return account.Id;
+        if (!string.IsNullOrWhiteSpace(email))
+            options.Email = email.Trim();
+
+        try
+        {
+            var service = new AccountService();
+            var account = await service.CreateAsync(options, cancellationToken: cancellationToken);
+            logger.LogInformation("Stripe Express account created: {AccountId}", account.Id);
+            return account.Id;
+        }
+        catch (StripeException ex)
+        {
+            logger.LogError(ex, "Stripe Connect account creation failed");
+            throw new PaymentProcessingException(
+                ex.StripeError?.Message ?? "Stripe Connect account creation failed. Verify platform API keys and Connect settings.",
+                ex);
+        }
     }
 
     public async Task<ConnectAccountSnapshot> GetAccountAsync(
@@ -35,9 +51,19 @@ public class StripeConnectGateway(IConfiguration configuration, ILogger<StripeCo
     {
         EnsureApiKey();
 
-        var service = new AccountService();
-        var account = await service.GetAsync(connectedAccountId, cancellationToken: cancellationToken);
-        return MapAccount(account);
+        try
+        {
+            var service = new AccountService();
+            var account = await service.GetAsync(connectedAccountId, cancellationToken: cancellationToken);
+            return MapAccount(account);
+        }
+        catch (StripeException ex)
+        {
+            logger.LogError(ex, "Stripe Connect account lookup failed for {AccountId}", connectedAccountId);
+            throw new PaymentProcessingException(
+                ex.StripeError?.Message ?? "Unable to load Stripe Connect account status.",
+                ex);
+        }
     }
 
     public async Task<string> CreateAccountOnboardingLinkAsync(
@@ -56,16 +82,36 @@ public class StripeConnectGateway(IConfiguration configuration, ILogger<StripeCo
             Type = "account_onboarding",
         };
 
-        var service = new AccountLinkService();
-        var link = await service.CreateAsync(options, cancellationToken: cancellationToken);
-        return link.Url;
+        try
+        {
+            var service = new AccountLinkService();
+            var link = await service.CreateAsync(options, cancellationToken: cancellationToken);
+            return link.Url;
+        }
+        catch (StripeException ex)
+        {
+            logger.LogError(ex, "Stripe Connect onboarding link creation failed for {AccountId}", connectedAccountId);
+            throw new PaymentProcessingException(
+                ex.StripeError?.Message ?? "Unable to create Stripe onboarding link.",
+                ex);
+        }
     }
 
     private void EnsureApiKey()
     {
         var secretKey = configuration["Stripe:SecretKey"];
         if (string.IsNullOrWhiteSpace(secretKey))
-            throw new InvalidOperationException("Stripe:SecretKey is not configured");
+        {
+            throw new PaymentProcessingException(
+                "Stripe is not configured on the API server. Set Stripe__SecretKey in Railway.");
+        }
+
+        if (secretKey.Contains("...", StringComparison.Ordinal) ||
+            secretKey is "sk_test_" or "sk_live_")
+        {
+            throw new PaymentProcessingException(
+                "Stripe API key is a placeholder. Configure a valid sk_test_ or sk_live_ key on the API server.");
+        }
 
         StripeConfiguration.ApiKey = secretKey;
     }

--- a/Casazen.Infrastructure/Services/Auth0ManagementService.cs
+++ b/Casazen.Infrastructure/Services/Auth0ManagementService.cs
@@ -173,4 +173,33 @@ public class Auth0ManagementService(
                 "Auth0ManagementService: Failed to sync onboarding roles for user {UserId}", userId);
         }
     }
+
+    /// <inheritdoc />
+    public async Task<Auth0UserProfile?> GetUserProfileAsync(string userId)
+    {
+        var token = configuration["Auth0:ManagementApiToken"];
+        var domain = configuration["Auth0:ManagementApiDomain"]
+                     ?? configuration["Auth0:Domain"];
+
+        if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(domain))
+            return null;
+
+        try
+        {
+            var client = new ManagementApiClient(token, new Uri($"https://{domain}/api/v2"));
+            var auth0User = await client.Users.GetAsync(userId);
+            if (auth0User is null)
+                return null;
+
+            return new Auth0UserProfile(
+                auth0User.Email ?? string.Empty,
+                auth0User.FirstName ?? string.Empty,
+                auth0User.LastName ?? string.Empty);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Auth0ManagementService: Failed to fetch profile for user {UserId}", userId);
+            return null;
+        }
+    }
 }

--- a/Casazen.Infrastructure/Services/ConnectOnboardingService.cs
+++ b/Casazen.Infrastructure/Services/ConnectOnboardingService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Casazen.Core.Entities;
+using Casazen.Core.Exceptions;
 using Casazen.Core.Services;
 using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
@@ -35,15 +36,45 @@ public class ConnectOnboardingService(
             ?? throw new InvalidOperationException($"Org {orgId} not found");
 
         if (!string.IsNullOrWhiteSpace(org.StripeConnectedAccountId))
-            return await GetStatusAsync(orgId, refreshFromStripe: true, cancellationToken);
+        {
+            try
+            {
+                return await GetStatusAsync(orgId, refreshFromStripe: true, cancellationToken);
+            }
+            catch (PaymentProcessingException ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Stale Stripe connected account {AccountId} for org {OrgId}; recreating",
+                    org.StripeConnectedAccountId,
+                    orgId);
+                org.StripeConnectedAccountId = null;
+                org.ConnectChargesEnabled = false;
+                org.ConnectPayoutsEnabled = false;
+                org.ConnectDetailsSubmitted = false;
+                org.ConnectRequirementsDueJson = null;
+                org.UpdatedAt = DateTime.UtcNow;
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
 
-        var accountId = await stripeConnectGateway.CreateExpressAccountAsync(org.ContactEmail, cancellationToken);
+        var connectEmail = await ResolveConnectEmailAsync(org, cancellationToken);
+        var accountId = await stripeConnectGateway.CreateExpressAccountAsync(connectEmail, cancellationToken);
         org.StripeConnectedAccountId = accountId;
         org.UpdatedAt = DateTime.UtcNow;
         await dbContext.SaveChangesAsync(cancellationToken);
 
         logger.LogInformation("Created Stripe Connect account {AccountId} for org {OrgId}", accountId, orgId);
-        return await GetStatusAsync(orgId, refreshFromStripe: true, cancellationToken);
+
+        try
+        {
+            return await GetStatusAsync(orgId, refreshFromStripe: true, cancellationToken);
+        }
+        catch (PaymentProcessingException ex)
+        {
+            logger.LogWarning(ex, "Stripe account {AccountId} created but refresh failed for org {OrgId}", accountId, orgId);
+            return MapStatus(org);
+        }
     }
 
     public async Task<string> CreateOnboardingLinkAsync(
@@ -76,6 +107,19 @@ public class ConnectOnboardingService(
         }
 
         await PersistSnapshotAsync(org, snapshot, cancellationToken);
+    }
+
+    private async Task<string> ResolveConnectEmailAsync(Org org, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(org.ContactEmail))
+            return org.ContactEmail.Trim();
+
+        var userEmail = await dbContext.Users.AsNoTracking()
+            .Where(u => u.OrgId == org.Id && u.Email != null && u.Email != string.Empty)
+            .Select(u => u.Email)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return userEmail?.Trim() ?? string.Empty;
     }
 
     private async Task PersistSnapshotAsync(Org org, ConnectAccountSnapshot snapshot, CancellationToken cancellationToken)

--- a/Casazen.Infrastructure/Services/UserService.cs
+++ b/Casazen.Infrastructure/Services/UserService.cs
@@ -149,6 +149,50 @@ public class UserService(
     }
 
     /// <inheritdoc />
+    public async Task EnrichUsersFromAuth0Async(IList<User> users)
+    {
+        foreach (var user in users)
+        {
+            if (!string.IsNullOrWhiteSpace(user.Email) &&
+                !string.IsNullOrWhiteSpace(user.FirstName) &&
+                !string.IsNullOrWhiteSpace(user.LastName))
+            {
+                continue;
+            }
+
+            var profile = await auth0Management.GetUserProfileAsync(user.Id);
+            if (profile is null)
+                continue;
+
+            var changed = false;
+
+            if (string.IsNullOrWhiteSpace(user.Email) && !string.IsNullOrWhiteSpace(profile.Email))
+            {
+                user.Email = profile.Email.ToLowerInvariant();
+                changed = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(user.FirstName) && !string.IsNullOrWhiteSpace(profile.FirstName))
+            {
+                user.FirstName = profile.FirstName;
+                changed = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(user.LastName) && !string.IsNullOrWhiteSpace(profile.LastName))
+            {
+                user.LastName = profile.LastName;
+                changed = true;
+            }
+
+            if (changed)
+            {
+                user.UpdatedAt = DateTime.UtcNow;
+                await repository.UpdateAsync(user);
+            }
+        }
+    }
+
+    /// <inheritdoc />
     public async Task ChangeRoleAsync(string id, UserRole newRole, string adminSub)
     {
         var user = await repository.GetByIdAsync(id)

--- a/Casazen.Tests/Unit/Controllers/BookingsControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/BookingsControllerTests.cs
@@ -105,16 +105,30 @@ public class BookingsControllerTests
             .ReturnsAsync(12m);
         _mockBookingService.Setup(b => b.CreateBookingAsync(It.IsAny<Booking>()))
             .ReturnsAsync((Booking b) => { b.Id = Guid.NewGuid(); return b; });
+        _mockBookingService.Setup(b => b.GetBookingAsync(It.IsAny<Guid>()))
+            .ReturnsAsync((Guid id) => new Booking
+            {
+                Id = id,
+                PropertyId = PropertyId,
+                OrgId = OrgId,
+                GuestId = guest.Id,
+                Guest = guest,
+                Property = MakeProperty(),
+                NumberOfGuests = 2,
+                BasePrice = 450m,
+                TouristTax = 12m,
+                TotalPrice = 462m,
+                Status = BookingStatus.Pending,
+                Source = BookingSource.Direct,
+            });
 
         var result = await _controller.Create(MakeRequest());
 
         var created = Assert.IsType<CreatedAtActionResult>(result.Result);
-        var booking = Assert.IsType<Booking>(created.Value);
+        var booking = Assert.IsType<BookingResponseDto>(created.Value);
         Assert.Equal(PropertyId, booking.PropertyId);
-        Assert.Equal(OrgId, booking.OrgId);
-        Assert.Equal(guest.Id, booking.GuestId);
-        Assert.Equal(450m, booking.BasePrice); // 4 nights * 100 + 50 cleaning
         Assert.Equal(462m, booking.TotalPrice);
+        Assert.Equal("mario.rossi@example.com", booking.Guest.Email);
     }
 
     [Fact]

--- a/Casazen.Tests/Unit/Infrastructure/BookingMapperTests.cs
+++ b/Casazen.Tests/Unit/Infrastructure/BookingMapperTests.cs
@@ -1,0 +1,52 @@
+using Casazen.Core.Entities;
+using Casazen.Web.Infrastructure;
+using Xunit;
+
+namespace Casazen.Tests.Unit.Infrastructure;
+
+public class BookingMapperTests
+{
+    [Fact]
+    public void ToResponse_MapsGuestPhoneWithoutPropertyBookingsCycle()
+    {
+        var propertyId = Guid.NewGuid();
+        var booking = new Booking
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId,
+            Property = new Property
+            {
+                Id = propertyId,
+                Name = "Casa Test",
+                Bookings = new List<Booking>(),
+            },
+            Guest = new Guest
+            {
+                FirstName = "Mario",
+                LastName = "Rossi",
+                Email = "mario@example.com",
+                PhoneNumber = "+393331234567",
+                Country = "IT",
+            },
+            CheckInDate = new DateTime(2026, 7, 15, 0, 0, 0, DateTimeKind.Utc),
+            CheckOutDate = new DateTime(2026, 7, 18, 0, 0, 0, DateTimeKind.Utc),
+            NumberOfGuests = 2,
+            TotalPrice = 360m,
+            BasePrice = 330m,
+            TouristTax = 30m,
+            Status = BookingStatus.Pending,
+            Source = BookingSource.Direct,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        var dto = BookingMapper.ToResponse(booking);
+
+        Assert.Equal(booking.Id, dto.Id);
+        Assert.Equal("Casa Test", dto.PropertyName);
+        Assert.Equal("Mario", dto.Guest.FirstName);
+        Assert.Equal("+393331234567", dto.Guest.Phone);
+        Assert.Equal("Pending", dto.Status);
+        Assert.Equal("EUR", dto.Currency);
+    }
+}

--- a/Casazen.Web/Controllers/BookingController.cs
+++ b/Casazen.Web/Controllers/BookingController.cs
@@ -5,6 +5,7 @@ using Casazen.Core.Utilities;
 using Casazen.Web.BackgroundJobs;
 using Casazen.Web.DTOs;
 using Casazen.Web.DTOs.Alloggiati;
+using Casazen.Web.Infrastructure;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -26,7 +27,7 @@ public class BookingsController(
     ILogger<BookingsController> logger) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<Booking>>> GetAll([FromQuery] Guid? propertyId)
+    public async Task<ActionResult<IEnumerable<BookingResponseDto>>> GetAll([FromQuery] Guid? propertyId)
     {
         IEnumerable<Booking> bookings;
 
@@ -35,19 +36,19 @@ public class BookingsController(
         else
             bookings = await bookingService.GetAllBookingsAsync();
 
-        return Ok(bookings);
+        return Ok(bookings.Select(BookingMapper.ToResponse));
     }
 
     [HttpGet("{id}")]
-    public async Task<ActionResult<Booking>> GetById(Guid id)
+    public async Task<ActionResult<BookingResponseDto>> GetById(Guid id)
     {
         var booking = await bookingService.GetBookingAsync(id);
-        return booking == null ? NotFound() : Ok(booking);
+        return booking == null ? NotFound() : Ok(BookingMapper.ToResponse(booking));
     }
 
     [HttpPost]
     [Authorize(Policy = "RequireContext:short-rent:booking.write")]
-    public async Task<ActionResult<Booking>> Create([FromBody] CreateBookingRequest request)
+    public async Task<ActionResult<BookingResponseDto>> Create([FromBody] CreateBookingRequest request)
     {
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
@@ -116,8 +117,10 @@ public class BookingsController(
         try
         {
             var created = await bookingService.CreateBookingAsync(booking);
+            var loaded = await bookingService.GetBookingAsync(created.Id);
+            var response = loaded is null ? BookingMapper.ToResponse(created) : BookingMapper.ToResponse(loaded);
             logger.LogInformation("Booking created: {BookingId}, tourist tax: {Tax} EUR", created.Id, created.TouristTax);
-            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, response);
         }
         catch (InvalidOperationException ex)
         {
@@ -238,7 +241,8 @@ public class BookingsController(
             job => job.ReportGuestAsync(booking.GuestId, booking.Id));
 
         logger.LogInformation("Check-in completed for booking {BookingId}, queued Alloggiati Web report", id);
-        return Ok(booking);
+        var updated = await bookingService.GetBookingAsync(id);
+        return Ok(updated is null ? BookingMapper.ToResponse(booking) : BookingMapper.ToResponse(updated));
     }
 
     [HttpPost("{id}/check-out")]
@@ -271,7 +275,8 @@ public class BookingsController(
 
         booking.Status = BookingStatus.CheckedOut;
         await bookingService.UpdateBookingAsync(booking);
-        return Ok(booking);
+        var updated = await bookingService.GetBookingAsync(id);
+        return Ok(updated is null ? BookingMapper.ToResponse(booking) : BookingMapper.ToResponse(updated));
     }
 
     [HttpGet("{id}/alloggiati-status")]

--- a/Casazen.Web/Controllers/UsersController.cs
+++ b/Casazen.Web/Controllers/UsersController.cs
@@ -33,6 +33,7 @@ public class UsersController(
         logger.LogInformation("Admin: listing users page={Page} pageSize={PageSize}", page, pageSize);
         var (users, total) = await userService.GetPagedAsync(search, role, isActive, page, pageSize);
         var userList = users.ToList();
+        await userService.EnrichUsersFromAuth0Async(userList);
         var orgIds = userList.Where(u => u.OrgId.HasValue).Select(u => u.OrgId!.Value);
         var orgMap = await orgService.GetByIdsAsync(orgIds, HttpContext.RequestAborted);
 

--- a/Casazen.Web/DTOs/BookingResponseDto.cs
+++ b/Casazen.Web/DTOs/BookingResponseDto.cs
@@ -1,0 +1,30 @@
+namespace Casazen.Web.DTOs;
+
+public class BookingResponseDto
+{
+    public Guid Id { get; set; }
+    public Guid PropertyId { get; set; }
+    public string? PropertyName { get; set; }
+    public DateTime CheckInDate { get; set; }
+    public DateTime CheckOutDate { get; set; }
+    public int NumberOfGuests { get; set; }
+    public decimal TotalPrice { get; set; }
+    public decimal BasePrice { get; set; }
+    public decimal TouristTax { get; set; }
+    public string Currency { get; set; } = "EUR";
+    public string Status { get; set; } = string.Empty;
+    public string Source { get; set; } = string.Empty;
+    public string SpecialRequests { get; set; } = string.Empty;
+    public BookingGuestDto Guest { get; set; } = new();
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+
+public class BookingGuestDto
+{
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Country { get; set; } = string.Empty;
+}

--- a/Casazen.Web/Infrastructure/BookingMapper.cs
+++ b/Casazen.Web/Infrastructure/BookingMapper.cs
@@ -1,0 +1,35 @@
+using Casazen.Core.Entities;
+using Casazen.Web.DTOs;
+
+namespace Casazen.Web.Infrastructure;
+
+public static class BookingMapper
+{
+    public static BookingResponseDto ToResponse(Booking booking) => new()
+    {
+        Id = booking.Id,
+        PropertyId = booking.PropertyId,
+        PropertyName = booking.Property?.Name,
+        CheckInDate = booking.CheckInDate,
+        CheckOutDate = booking.CheckOutDate,
+        NumberOfGuests = booking.NumberOfGuests,
+        TotalPrice = booking.TotalPrice,
+        BasePrice = booking.BasePrice,
+        TouristTax = booking.TouristTax,
+        Status = booking.Status.ToString(),
+        Source = booking.Source.ToString(),
+        SpecialRequests = booking.SpecialRequests,
+        Guest = booking.Guest is null
+            ? new BookingGuestDto()
+            : new BookingGuestDto
+            {
+                FirstName = booking.Guest.FirstName,
+                LastName = booking.Guest.LastName,
+                Email = booking.Guest.Email,
+                Phone = booking.Guest.PhoneNumber,
+                Country = booking.Guest.Country,
+            },
+        CreatedAt = booking.CreatedAt,
+        UpdatedAt = booking.UpdatedAt,
+    };
+}

--- a/Casazen.Web/Middleware/ErrorHandlingMiddleware.cs
+++ b/Casazen.Web/Middleware/ErrorHandlingMiddleware.cs
@@ -74,7 +74,7 @@ public class ErrorHandlingMiddleware(RequestDelegate next, ILogger<ErrorHandling
             {
                 Type = "https://casazen.app/errors/payment-processing-error",
                 Title = "Payment Processing Error",
-                Status = StatusCodes.Status422UnprocessableEntity,
+                Status = StatusCodes.Status503ServiceUnavailable,
                 Detail = paymentEx.Message,
             },
             UnauthorizedAccessException => new ProblemDetails

--- a/Casazen.Web/Program.cs
+++ b/Casazen.Web/Program.cs
@@ -139,7 +139,11 @@ builder.Services.AddScoped<LeaseRegistrationStatusPollingJob>();
 
 // API
 builder.Services.AddControllers()
-    .AddJsonOptions(o => o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()))
+    .AddJsonOptions(o =>
+    {
+        o.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+        o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    })
     .ConfigureApiBehaviorOptions(options =>
     {
         // Override default 400 response with RFC 7807 Problem Details for model validation errors

--- a/Sessions/pipeline-mobile-ui-navigation/state.md
+++ b/Sessions/pipeline-mobile-ui-navigation/state.md
@@ -1,0 +1,40 @@
+# Pipeline State — Issue #252 Mobile UI Navigation
+
+**Stage**: 03 Development  
+**Date**: 2026-06-10  
+**Branch**: `feature/252-mobile-ui-navigation`
+
+## Scope
+
+- **Frontend**: Mobile bottom nav + grouped drawer (iPhone-first)
+- **Backend**: N/A — no API or schema changes
+
+## Gate Status (Iteration 1)
+
+### Backend (casazen/backend)
+
+| Gate | Command | Status | Notes |
+|---|---|---|---|
+| G1 | dotnet test | ✅ | 490 passed |
+| G2 | dotnet format --verify-no-changes | ✅ | |
+| G3 | dotnet build /warnaserror | ✅ | |
+| G4 | EF migration | N/A | No schema changes |
+
+### Frontend (casazen/frontend)
+
+| Gate | Command | Status | Notes |
+|---|---|---|---|
+| G5 | npm test | ✅ | 127 passed |
+| G6 | tsc -b --noEmit | ✅ | |
+| G7 | npm run lint | ⚠️ | 48 pre-existing errors on develop baseline (unchanged by #252) |
+| G8 | npm run build | ✅ | |
+| G9 | npm run test:e2e | ✅ | 73 passed incl. mobile-navigation.spec.ts |
+
+### Compliance
+
+| Gate | Status | Notes |
+|---|---|---|
+| G10 | N/A | No Property entity changes |
+| G11 | ✅ | No secrets in staged files |
+| G12 | N/A | No Guest entity changes |
+| G13 | N/A | No tourist tax changes |


### PR DESCRIPTION
## Summary
- Fix Stripe Connect Express account creation by setting `country=IT` when requesting capabilities (required by Stripe API).
- Surface Stripe configuration/API errors as 503 with readable messages instead of generic 500.
- Return `BookingResponseDto` from booking endpoints to avoid EF circular JSON refs and expose guest contact fields.
- Backfill missing admin user profile fields from Auth0 Management API.

## Test plan
- [x] `dotnet test` — 490 passed
- [ ] After merge/deploy: `POST /api/connect/account` returns 200 on Railway test/prod
- [ ] Pagamenti settings: "Collega Stripe" redirects to Stripe onboarding
- [ ] Bookings list/create returns guest email without 500
