### PR TITLE
fix(connect): upsert user before org provision

### DIFF
--- a/Casazen.Infrastructure/Services/ConnectOnboardingService.cs
+++ b/Casazen.Infrastructure/Services/ConnectOnboardingService.cs
@@ -59,6 +59,13 @@ public class ConnectOnboardingService(
         }
 
         var connectEmail = await ResolveConnectEmailAsync(org, cancellationToken);
+        if (string.IsNullOrWhiteSpace(org.ContactEmail) && !string.IsNullOrWhiteSpace(connectEmail))
+        {
+            org.ContactEmail = connectEmail;
+            org.UpdatedAt = DateTime.UtcNow;
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
         var accountId = await stripeConnectGateway.CreateExpressAccountAsync(connectEmail, cancellationToken);
         org.StripeConnectedAccountId = accountId;
         org.UpdatedAt = DateTime.UtcNow;

--- a/Casazen.Web/Infrastructure/OrgContextResolver.cs
+++ b/Casazen.Web/Infrastructure/OrgContextResolver.cs
@@ -30,14 +30,15 @@ public sealed class OrgContextResolver(
         if (string.IsNullOrWhiteSpace(sub))
             return null;
 
-        var user = await userService.GetUserAsync(sub);
-        if (user?.OrgId is Guid linked)
-            return linked;
-
         var (email, firstName, lastName) = ResolveProfileClaims();
         var displayName = $"{firstName} {lastName}".Trim();
         if (string.IsNullOrWhiteSpace(displayName))
             displayName = string.IsNullOrWhiteSpace(email) ? "La mia organizzazione" : email;
+
+        // Upsert user row first — EnsureOrgForUserAsync requires the User to exist (#217).
+        var user = await userService.GetCurrentUserAsync(sub, email, firstName, lastName);
+        if (user.OrgId is Guid linked)
+            return linked;
 
         logger.LogInformation("Auto-provisioning Starter org for user {UserId}", sub);
         var org = await orgService.EnsureOrgForUserAsync(

--- a/Casazen.Web/Middleware/ErrorHandlingMiddleware.cs
+++ b/Casazen.Web/Middleware/ErrorHandlingMiddleware.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using Casazen.Core.Exceptions;
 using Microsoft.AspNetCore.Mvc;
+using Stripe;
 
 namespace Casazen.Web.Middleware;
 
@@ -60,6 +61,8 @@ public class ErrorHandlingMiddleware(RequestDelegate next, ILogger<ErrorHandling
 
     private Task HandleExceptionAsync(HttpContext context, Exception exception)
     {
+        exception = Unwrap(exception);
+
         var problem = exception switch
         {
             ValidationException validationEx => BuildValidationProblem(validationEx),
@@ -76,6 +79,20 @@ public class ErrorHandlingMiddleware(RequestDelegate next, ILogger<ErrorHandling
                 Title = "Payment Processing Error",
                 Status = StatusCodes.Status503ServiceUnavailable,
                 Detail = paymentEx.Message,
+            },
+            StripeException stripeEx => new ProblemDetails
+            {
+                Type = "https://casazen.app/errors/stripe-integration-error",
+                Title = "Stripe Integration Error",
+                Status = StatusCodes.Status503ServiceUnavailable,
+                Detail = stripeEx.StripeError?.Message ?? stripeEx.Message,
+            },
+            InvalidOperationException invalidOp => new ProblemDetails
+            {
+                Type = "https://casazen.app/errors/operation-failed",
+                Title = "Operation Failed",
+                Status = StatusCodes.Status503ServiceUnavailable,
+                Detail = invalidOp.Message,
             },
             UnauthorizedAccessException => new ProblemDetails
             {
@@ -97,6 +114,14 @@ public class ErrorHandlingMiddleware(RequestDelegate next, ILogger<ErrorHandling
         problem.Extensions["traceId"] = context.TraceIdentifier;
 
         return WriteProblemAsync(context, problem);
+    }
+
+    private static Exception Unwrap(Exception exception)
+    {
+        while (exception.InnerException is not null)
+            exception = exception.InnerException;
+
+        return exception;
     }
 
     private static ValidationProblemDetails BuildValidationProblem(ValidationException ex)


### PR DESCRIPTION
## Summary
- Fix 500 on POST /api/connect/account when user row missing in DB (OrgContextResolver now upserts via GetCurrentUserAsync before EnsureOrgForUserAsync).
- Map StripeException and InvalidOperationException to 503 with readable detail (unwrap inner exceptions).
- Backfill org ContactEmail from user when empty before Stripe account create.

## Test plan
- [x] dotnet test — 490 passed
- [ ] After deploy: POST /api/connect/account on test returns 200 or 503 with Stripe message (not generic 500)

Made with [Cursor](https://cursor.com)