### PR TITLE
fix(prod): pricing empty states and bookings list regression (#234 #235)

### DIFF
--- a/Casazen.Infrastructure/Repositories/BookingRepositories.cs
+++ b/Casazen.Infrastructure/Repositories/BookingRepositories.cs
@@ -58,6 +58,7 @@ public class BookingRepository(AppDbContext context) : IBookingRepository
                    b.CheckInDate <= endDate &&
                    b.CheckOutDate >= startDate &&
                    b.Status != BookingStatus.Cancelled)
+            .Include(b => b.Guest)
             .ToListAsync();
     }
 

--- a/Casazen.Tests/Unit/Controllers/BookingsControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/BookingsControllerTests.cs
@@ -90,6 +90,42 @@ public class BookingsControllerTests
     };
 
     [Fact]
+    public async Task GetAll_ReturnsBookingResponseDtosWithoutCircularRefs()
+    {
+        SetUser(OwnerId);
+        var guest = new Guest { Id = Guid.NewGuid(), FirstName = "Mario", LastName = "Rossi", Email = "mario@test.com" };
+        var property = MakeProperty();
+        var booking = new Booking
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = PropertyId,
+            OrgId = OrgId,
+            GuestId = guest.Id,
+            Guest = guest,
+            Property = property,
+            CheckInDate = DateTime.UtcNow.AddDays(1),
+            CheckOutDate = DateTime.UtcNow.AddDays(3),
+            NumberOfGuests = 2,
+            BasePrice = 200m,
+            TouristTax = 10m,
+            TotalPrice = 210m,
+            Status = BookingStatus.Confirmed,
+            Source = BookingSource.Direct,
+        };
+
+        _mockBookingService.Setup(b => b.GetAllBookingsAsync()).ReturnsAsync([booking]);
+
+        var result = await _controller.GetAll(null);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var items = Assert.IsAssignableFrom<IEnumerable<BookingResponseDto>>(ok.Value);
+        var dto = Assert.Single(items);
+        Assert.Equal(booking.Id, dto.Id);
+        Assert.Equal("Test Villa", dto.PropertyName);
+        Assert.Equal("mario@test.com", dto.Guest.Email);
+    }
+
+    [Fact]
     public async Task Create_WithValidRequest_ReturnsCreated()
     {
         SetUser(OwnerId);

--- a/Casazen.Tests/Unit/Controllers/PricingAdapterControllerTests.cs
+++ b/Casazen.Tests/Unit/Controllers/PricingAdapterControllerTests.cs
@@ -102,7 +102,7 @@ public class PricingAdapterControllerTests
     }
 
     [Fact]
-    public async Task GetConfig_WhenConfigNotFound_ReturnsNotFound()
+    public async Task GetConfig_WhenConfigNotFound_ReturnsDefaultDisabledConfig()
     {
         // Arrange
         var propertyId = Guid.NewGuid();
@@ -115,7 +115,10 @@ public class PricingAdapterControllerTests
         var result = await _controller.GetConfig(propertyId);
 
         // Assert
-        Assert.IsType<NotFoundResult>(result.Result);
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<PricingAdapterConfigResponse>(ok.Value);
+        Assert.Equal(propertyId, dto.PropertyId);
+        Assert.False(dto.IsEnabled);
     }
 
     [Fact]
@@ -473,7 +476,7 @@ public class PricingAdapterControllerTests
     }
 
     [Fact]
-    public async Task GetPreview_WhenConfigNotFound_ReturnsNotFound()
+    public async Task GetPreview_WhenConfigNotFound_ReturnsEmptyPreview()
     {
         // Arrange
         var propertyId = Guid.NewGuid();
@@ -486,7 +489,9 @@ public class PricingAdapterControllerTests
         var result = await _controller.GetPreview(propertyId);
 
         // Assert
-        Assert.IsType<NotFoundResult>(result.Result);
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var preview = Assert.IsType<PricingPreviewResponse>(ok.Value);
+        Assert.Empty(preview.Prices);
     }
 
     [Fact]

--- a/Casazen.Web/Controllers/PricingAdapterController.cs
+++ b/Casazen.Web/Controllers/PricingAdapterController.cs
@@ -100,7 +100,8 @@ public class PricingAdapterController(
         }
 
         var config = await pricingService.GetConfigAsync(propertyId);
-        if (config == null) return NotFound();
+        if (config == null)
+            return Ok(ToDefaultResponse(propertyId));
 
         return Ok(ToResponse(config));
     }
@@ -274,7 +275,10 @@ public class PricingAdapterController(
         }
 
         var config = await pricingService.GetConfigAsync(propertyId);
-        if (config == null) return NotFound();
+        if (config == null || !config.IsEnabled)
+        {
+            return Ok(new PricingPreviewResponse { Prices = [] });
+        }
 
         var preview = await pricingService.PreviewPricesAsync(propertyId, property.NightlyRate, config);
 
@@ -299,6 +303,15 @@ public class PricingAdapterController(
 
     private IEnumerable<string> GetUserRoles() =>
         User.FindAll(ClaimTypes.Role).Select(c => c.Value);
+
+    private static PricingAdapterConfigResponse ToDefaultResponse(Guid propertyId) => new()
+    {
+        PropertyId = propertyId,
+        IsEnabled = false,
+        AdaptationFrequency = "daily",
+        IncludeSeasonality = true,
+        IncludePublicHolidays = true,
+    };
 
     private static PricingAdapterConfigResponse ToResponse(PricingAdapterConfig config) => new()
     {


### PR DESCRIPTION
## Summary
- Return default disabled pricing config and empty preview instead of 404 when no adapter config exists (#235)
- Include guest data in calendar date-range queries for guest names on the calendar
- Add regression test ensuring GET /api/bookings returns flat BookingResponseDto list (#234)

Note: booking DTO serialization fix (#233/#234) and Auth0 user backfill (#219) are already on develop via 8b55603.

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~BookingsControllerTests`
- [x] `dotnet test --filter FullyQualifiedName~PricingAdapterControllerTests`
- [ ] Stage 05: verify GET/POST /api/bookings return 200/201 on staging
- [ ] Stage 05: verify pricing page loads without infinite spinner

Closes #234, #235