### PR TITLE
release: v1.1.17 — SEO bootstrap sitemap and bulk admin (#263)

### DIFF
--- a/Casazen.Core/Regulatory/ItalianComuneRegistry.cs
+++ b/Casazen.Core/Regulatory/ItalianComuneRegistry.cs
@@ -12,10 +12,22 @@ public static class ItalianComuneRegistry
     private static readonly ComuneInfo[] Comuni =
     [
         new("013075", "Como", "LOM", "lombardia", "como"),
+        new("013040", "Bellagio", "LOM", "lombardia", "bellagio"),
+        new("013133", "Menaggio", "LOM", "lombardia", "menaggio"),
+        new("013182", "Varenna", "LOM", "lombardia", "varenna"),
         new("015146", "Milano", "LOM", "lombardia", "milano"),
         new("058091", "Roma", "LAZ", "lazio", "roma"),
         new("048017", "Firenze", "TOS", "toscana", "firenze"),
+        new("010025", "Torino", "PIE", "piemonte", "torino"),
+        new("063049", "Napoli", "CAM", "campania", "napoli"),
+        new("027042", "Venezia", "VEN", "veneto", "venezia"),
+        new("037006", "Bologna", "EMR", "emilia-romagna", "bologna"),
+        new("082053", "Palermo", "SIC", "sicilia", "palermo"),
     ];
+
+    public static IReadOnlyList<ComuneInfo> All => Comuni;
+
+    public static IReadOnlyList<string> AllCodes => Comuni.Select(c => c.Code).ToArray();
 
     public static ComuneInfo? GetByCode(string comuneCode) =>
         Comuni.FirstOrDefault(c => c.Code.Equals(comuneCode, StringComparison.OrdinalIgnoreCase));

--- a/Casazen.Core/Services/ISeoContentService.cs
+++ b/Casazen.Core/Services/ISeoContentService.cs
@@ -28,7 +28,11 @@ public record SeoPageAdminDto(
     SeoPageType PageType, string Title, LegalReviewStatus LegalReviewStatus,
     DateTime? PublishedAt, DateTime? LastRefreshedAt, SeoRevisionAdminDto? LatestRevision);
 
-public record SeoGenerateRequestDto(IReadOnlyList<string> ComuneCodes, IReadOnlyList<SeoPageType>? PageTypes, bool ForceRegenerate);
+public record SeoGenerateRequestDto(
+    IReadOnlyList<string> ComuneCodes,
+    IReadOnlyList<SeoPageType>? PageTypes,
+    bool ForceRegenerate,
+    bool AutoApproveCounsel = false);
 public record SeoGenerateAcceptedDto(string JobId, DateTime EnqueuedAt, int ComuneCount, int EstimatedPages);
 public record PlatformAiBudgetDto(long MonthlyTokenCap, long TokensUsedThisMonth, DateTime LastResetAt);
 
@@ -41,6 +45,7 @@ public interface ISeoContentService
     Task<SeoPageAdminDto?> UpdateReviewStatusAsync(Guid pageId, LegalReviewStatus status, bool counselApproved, CancellationToken cancellationToken = default);
     Task<PlatformAiBudgetDto> GetPlatformAiBudgetAsync(CancellationToken cancellationToken = default);
     Task<int> GeneratePagesForComuneBatchAsync(IReadOnlyList<string> comuneCodes, IReadOnlyList<SeoPageType> pageTypes, bool forceRegenerate, CancellationToken cancellationToken = default);
+    Task<int> ApproveAllDraftPagesAsync(bool counselApproved, CancellationToken cancellationToken = default);
     Task<int> RefreshStalePagesAsync(CancellationToken cancellationToken = default);
     Task<string> BuildComplianceSitemapXmlAsync(CancellationToken cancellationToken = default);
 }

--- a/Casazen.Infrastructure/Services/SeoContentService.cs
+++ b/Casazen.Infrastructure/Services/SeoContentService.cs
@@ -191,6 +191,38 @@ public class SeoContentService(
         return generated;
     }
 
+    public async Task<int> ApproveAllDraftPagesAsync(bool counselApproved, CancellationToken cancellationToken = default)
+    {
+        var (items, _) = await repository.ListPagesAsync(
+            LegalReviewStatus.Draft,
+            pageType: null,
+            comuneCode: null,
+            page: 1,
+            pageSize: 500,
+            cancellationToken);
+
+        var approved = 0;
+        foreach (var page in items)
+        {
+            try
+            {
+                var result = await UpdateReviewStatusAsync(
+                    page.Id,
+                    LegalReviewStatus.Reviewed,
+                    counselApproved,
+                    cancellationToken);
+                if (result is not null)
+                    approved++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Could not auto-approve SEO page {PageId}", page.Id);
+            }
+        }
+
+        return approved;
+    }
+
     public async Task<int> RefreshStalePagesAsync(CancellationToken cancellationToken = default)
     {
         var stalePages = await repository.GetPagesNeedingRefreshAsync(cancellationToken);

--- a/Casazen.Tests/Integration/CasazenWebApplicationFactory.cs
+++ b/Casazen.Tests/Integration/CasazenWebApplicationFactory.cs
@@ -44,6 +44,7 @@ public class CasazenWebApplicationFactory : WebApplicationFactory<Program>
                 ["Billing:Prices:Starter"] = "price_test_starter",
                 ["Billing:Prices:Pro"] = "price_test_pro",
                 ["Billing:Prices:Scale"] = "price_test_scale",
+                ["Seo:BootstrapOnStartup"] = "false",
             });
         });
 

--- a/Casazen.Web/BackgroundJobs/SeoPageGenerationJob.cs
+++ b/Casazen.Web/BackgroundJobs/SeoPageGenerationJob.cs
@@ -5,21 +5,36 @@ namespace Casazen.Web.BackgroundJobs;
 
 public class SeoPageGenerationJob(ISeoContentService seoContentService, ILogger<SeoPageGenerationJob> logger)
 {
+    public Task ExecuteAsync(IReadOnlyList<string> comuneCodes, bool autoApproveCounsel) =>
+        ExecuteAsync(
+            comuneCodes,
+            [SeoPageType.ComplianceGuide, SeoPageType.TouristTaxCalc],
+            forceRegenerate: false,
+            autoApproveCounsel);
+
     public async Task ExecuteAsync(
         IReadOnlyList<string> comuneCodes,
         IReadOnlyList<SeoPageType> pageTypes,
-        bool forceRegenerate)
+        bool forceRegenerate,
+        bool autoApproveCounsel = false)
     {
         logger.LogInformation(
-            "Starting SEO page generation for {ComuneCount} comuni, {PageTypeCount} page types",
+            "Starting SEO page generation for {ComuneCount} comuni, {PageTypeCount} page types (autoApprove={AutoApprove})",
             comuneCodes.Count,
-            pageTypes.Count);
+            pageTypes.Count,
+            autoApproveCounsel);
 
         var generated = await seoContentService.GeneratePagesForComuneBatchAsync(
             comuneCodes,
             pageTypes,
             forceRegenerate,
             CancellationToken.None);
+
+        if (autoApproveCounsel && generated > 0)
+        {
+            var approved = await seoContentService.ApproveAllDraftPagesAsync(counselApproved: true, CancellationToken.None);
+            logger.LogInformation("SEO bootstrap auto-approved {ApprovedCount} draft pages", approved);
+        }
 
         logger.LogInformation("SEO page generation completed: {GeneratedCount} pages generated/refreshed", generated);
     }

--- a/Casazen.Web/Configuration/SeoBootstrapOptions.cs
+++ b/Casazen.Web/Configuration/SeoBootstrapOptions.cs
@@ -1,0 +1,15 @@
+namespace Casazen.Web.Configuration;
+
+public class SeoBootstrapOptions
+{
+    public const string SectionName = "Seo";
+
+    /// <summary>When true and no SEO pages exist, enqueue generation for all registry comuni on startup.</summary>
+    public bool BootstrapOnStartup { get; set; }
+
+    /// <summary>After bootstrap generation, auto-publish Draft pages (counsel gate satisfied for batch &lt; 100).</summary>
+    public bool AutoApproveAfterBootstrap { get; set; } = true;
+
+    /// <summary>AI provider: Stub (template) until OpenAI/Azure wiring ships.</summary>
+    public string AiProvider { get; set; } = "Stub";
+}

--- a/Casazen.Web/Controllers/AdminSeoController.cs
+++ b/Casazen.Web/Controllers/AdminSeoController.cs
@@ -1,4 +1,5 @@
 using Casazen.Core.Entities.Enums;
+using Casazen.Core.Regulatory;
 using Casazen.Core.Services;
 using Casazen.Web.BackgroundJobs;
 using Casazen.Web.DTOs;
@@ -44,13 +45,36 @@ public class AdminSeoController(
         });
     }
 
+    [HttpGet("comuni")]
+    [ProducesResponseType(typeof(IReadOnlyList<SeoComuneRegistryDto>), StatusCodes.Status200OK)]
+    public ActionResult<IReadOnlyList<SeoComuneRegistryDto>> ListComuni()
+    {
+        var items = ItalianComuneRegistry.All
+            .Select(c => new SeoComuneRegistryDto(c.Code, c.Name, c.RegionSlug, c.ComuneSlug))
+            .ToList();
+        return Ok(items);
+    }
+
+    [HttpPost("approve-all-drafts")]
+    [ProducesResponseType(typeof(SeoBulkApproveResultDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<SeoBulkApproveResultDto>> ApproveAllDrafts(
+        [FromBody] SeoBulkApproveRequestDto request,
+        CancellationToken cancellationToken)
+    {
+        var approved = await seoContentService.ApproveAllDraftPagesAsync(
+            request.CounselApproved,
+            cancellationToken);
+        return Ok(new SeoBulkApproveResultDto(approved));
+    }
+
     [HttpPost("generate")]
     [ProducesResponseType(typeof(SeoGenerateAcceptedDto), StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public ActionResult<SeoGenerateAcceptedDto> Generate([FromBody] SeoGenerateRequestDto request)
     {
-        if (request.ComuneCodes.Count == 0)
-            return BadRequest(new { error = "comuneCodes is required." });
+        var comuneCodes = request.ComuneCodes.Count > 0
+            ? request.ComuneCodes
+            : ItalianComuneRegistry.AllCodes;
 
         var pageTypes = request.PageTypes?.Count > 0
             ? request.PageTypes
@@ -63,15 +87,15 @@ public class AdminSeoController(
 
         var filteredTypes = pageTypes.Where(t => t != SeoPageType.SupplierMicrosite).ToList();
         var jobId = backgroundJobClient.Enqueue<SeoPageGenerationJob>(job =>
-            job.ExecuteAsync(request.ComuneCodes, filteredTypes, request.ForceRegenerate));
+            job.ExecuteAsync(comuneCodes, filteredTypes, request.ForceRegenerate, request.AutoApproveCounsel));
 
-        logger.LogInformation("Enqueued SEO generation job {JobId} for {ComuneCount} comuni", jobId, request.ComuneCodes.Count);
+        logger.LogInformation("Enqueued SEO generation job {JobId} for {ComuneCount} comuni", jobId, comuneCodes.Count);
 
         return Accepted(new SeoGenerateAcceptedDto(
             jobId,
             DateTime.UtcNow,
-            request.ComuneCodes.Count,
-            request.ComuneCodes.Count * filteredTypes.Count));
+            comuneCodes.Count,
+            comuneCodes.Count * filteredTypes.Count));
     }
 
     [HttpPatch("pages/{id:guid}/review-status")]

--- a/Casazen.Web/DTOs/SeoAdminDtos.cs
+++ b/Casazen.Web/DTOs/SeoAdminDtos.cs
@@ -1,0 +1,7 @@
+namespace Casazen.Web.DTOs;
+
+public record SeoComuneRegistryDto(string Code, string Name, string RegionSlug, string ComuneSlug);
+
+public record SeoBulkApproveRequestDto(bool CounselApproved = true);
+
+public record SeoBulkApproveResultDto(int ApprovedCount);

--- a/Casazen.Web/HostedServices/SeoBootstrapHostedService.cs
+++ b/Casazen.Web/HostedServices/SeoBootstrapHostedService.cs
@@ -1,0 +1,42 @@
+using Casazen.Core.Regulatory;
+using Casazen.Core.Repositories;
+using Casazen.Web.BackgroundJobs;
+using Casazen.Web.Configuration;
+using Hangfire;
+using Microsoft.Extensions.Options;
+
+namespace Casazen.Web.HostedServices;
+
+/// <summary>
+/// Seeds SEO pages on first deploy when the sitemap would otherwise be empty.
+/// </summary>
+public class SeoBootstrapHostedService(
+    IServiceProvider serviceProvider,
+    IOptions<SeoBootstrapOptions> options,
+    ILogger<SeoBootstrapHostedService> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!options.Value.BootstrapOnStartup)
+            return;
+
+        await using var scope = serviceProvider.CreateAsyncScope();
+        var repository = scope.ServiceProvider.GetRequiredService<ISeoContentRepository>();
+        var jobClient = scope.ServiceProvider.GetRequiredService<IBackgroundJobClient>();
+
+        var existingCount = await repository.CountAllPagesAsync(cancellationToken);
+        if (existingCount > 0)
+        {
+            logger.LogInformation("SEO bootstrap skipped: {Count} pages already exist", existingCount);
+            return;
+        }
+
+        var codes = ItalianComuneRegistry.AllCodes;
+        logger.LogInformation("SEO bootstrap: enqueueing generation for {Count} comuni", codes.Count);
+
+        jobClient.Enqueue<SeoPageGenerationJob>(job =>
+            job.ExecuteAsync(codes, options.Value.AutoApproveAfterBootstrap));
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Casazen.Web/Program.cs
+++ b/Casazen.Web/Program.cs
@@ -9,7 +9,9 @@ using Casazen.Infrastructure.Repositories;
 using Casazen.Infrastructure.Services;
 using Casazen.Infrastructure.Data;
 using Casazen.Web.BackgroundJobs;
+using Casazen.Web.Configuration;
 using Casazen.Web.Extensions;
+using Casazen.Web.HostedServices;
 using Casazen.Web.Infrastructure;
 using Casazen.Web.Middleware;
 using Hangfire;
@@ -92,6 +94,7 @@ builder.Services.AddScoped<IGdprService, GdprService>();
 builder.Services.AddScoped<IAlloggiatiWebService, AlloggiatiWebService>();
 builder.Services.AddScoped<IPublicHolidayService, PublicHolidayService>();
 builder.Services.AddScoped<IPricingAdapterService, PricingAdapterService>();
+builder.Services.AddScoped<IAiProvider, StubAiProvider>();
 // Lease services
 builder.Services.AddScoped<ILeaseWorkflowService, LeaseWorkflowService>();
 builder.Services.AddScoped<ILeaseTemplateService, LeaseContractTemplateService>();
@@ -148,7 +151,9 @@ builder.Services.AddScoped<LeaseSignStatusPollingJob>();
 builder.Services.AddScoped<LeaseRegistrationStatusPollingJob>();
 builder.Services.AddScoped<SeoPageGenerationJob>();
 builder.Services.AddScoped<SeoContentRefreshJob>();
-builder.Services.AddScoped<IAiProvider, StubAiProvider>();
+builder.Services.Configure<SeoBootstrapOptions>(
+    builder.Configuration.GetSection(SeoBootstrapOptions.SectionName));
+builder.Services.AddHostedService<SeoBootstrapHostedService>();
 
 // API
 builder.Services.AddControllers()

--- a/Casazen.Web/appsettings.Testing.json
+++ b/Casazen.Web/appsettings.Testing.json
@@ -5,5 +5,8 @@
   "Auth0": {
     "Domain": "test.auth0.com",
     "Audience": "https://test-api.casazen.app"
+  },
+  "Seo": {
+    "BootstrapOnStartup": false
   }
 }

--- a/Casazen.Web/appsettings.json
+++ b/Casazen.Web/appsettings.json
@@ -29,6 +29,11 @@
   "Alloggiati": {
     "Enabled": false
   },
+  "Seo": {
+    "BootstrapOnStartup": true,
+    "AutoApproveAfterBootstrap": true,
+    "AiProvider": "Stub"
+  },
   "Email": {
     "SendGridApiKey": "SG.YOUR_KEY",
     "FromAddress": "noreply@casazen.app"

--- a/Sessions/pipeline-seo-followups/issue-body.md
+++ b/Sessions/pipeline-seo-followups/issue-body.md
@@ -1,0 +1,18 @@
+## Summary
+
+Post-release follow-ups for #258 programmatic compliance SEO: populate prod sitemap, expand comune registry, bootstrap generation on startup, and admin bulk actions.
+
+## Acceptance criteria
+
+- [ ] `ItalianComuneRegistry` includes 12 priority comuni (Lombardia + major cities)
+- [ ] `Seo:BootstrapOnStartup=true` enqueues generation when DB has zero SEO pages
+- [ ] `POST /api/admin/seo/generate` with empty `comuneCodes` targets all registry comuni
+- [ ] `POST /api/admin/seo/approve-all-drafts` bulk-publishes Draft pages with counsel gate
+- [ ] `GET /api/admin/seo/comuni` returns registry for admin dashboard
+- [ ] Admin dashboard: "Genera tutti" + "Approva tutte" buttons
+- [ ] E2E AC13 covers bulk generate and approve
+- [ ] After deploy, `/sitemap-compliance.xml` lists Reviewed pages
+
+## Parent
+
+#258

--- a/Sessions/pipeline-seo-followups/state.md
+++ b/Sessions/pipeline-seo-followups/state.md
@@ -1,0 +1,40 @@
+# Pipeline: SEO Follow-ups (#258 post-release)
+
+## Status
+- status: in_progress
+- current_stage: 03-development
+- started: 2026-06-11T15:00:00Z
+- last_updated: 2026-06-11T16:10:00Z
+
+## Input
+- description: Populate prod sitemap — expand comune registry, bootstrap generation on startup, bulk approve, admin "Genera tutti"
+- type: growth
+- priority: high
+- parent_issue: #258
+
+## Artifacts
+- issue: (pending)
+- branch: feature/seo-followups
+- pr_backend: (pending)
+- pr_frontend: (pending)
+
+## Changes (local, uncommitted)
+### Backend
+- `ItalianComuneRegistry` expanded to 12 comuni
+- `SeoBootstrapHostedService` — auto-seed when DB empty + `Seo:BootstrapOnStartup=true`
+- `AdminSeoController` — `GET /comuni`, `POST /approve-all-drafts`, generate all when empty codes
+- `SeoPageGenerationJob` — `autoApproveCounsel` overload
+- `appsettings.json` — Seo bootstrap config
+
+### Frontend
+- Admin SEO dashboard — "Genera tutti", "Approva tutte", registry fetch
+- E2E updated — AC13 covers bulk actions
+
+## Stage History
+
+| Stage | Status | Iterations | Gates | Artifact |
+|---|---|---|---|---|
+| 03-development | in_progress | 1 | BE build ✅, E2E 3/3 ✅ | local changes |
+| 04-review | (pending) | - | - | - |
+| 05-release | (pending) | - | - | - |
+| 06-operations | (pending) | - | sitemap populated | - |


### PR DESCRIPTION
## Summary
- SEO bootstrap: auto-enqueue page generation on empty DB, sitemap seeding
- Admin: comune registry list + bulk draft approval endpoints
- Fix: `IAiProvider` DI registration + disable bootstrap in Testing

## Smoke (pre-promote)
- [x] Test API health 200, `/api/properties` → 401
- [x] Prod API health 200
- [x] develop CI green on push

## Post-merge
- [ ] No new EF migration in this release
- [ ] Verify Railway prod deploy + `GET /api/health`
