### PR TITLE
fix(auth): admin SEO menu — add admin.seo.read to bootstrap (#266)

### DIFF
--- a/Casazen.Core/Authorization/ContextAccessBootstrap.cs
+++ b/Casazen.Core/Authorization/ContextAccessBootstrap.cs
@@ -51,6 +51,7 @@ public static class ContextAccessBootstrap
                 "admin.users.manage",
                 "admin.cin.read",
                 "admin.jobs.read",
+                "admin.seo.read",
                 "admin.tax.manage",
             ]),
     ];

--- a/Casazen.Tests/Unit/Auth/ContextAccessBootstrapTests.cs
+++ b/Casazen.Tests/Unit/Auth/ContextAccessBootstrapTests.cs
@@ -21,6 +21,14 @@ public class ContextAccessBootstrapTests
     }
 
     [Fact]
+    public void BuildFallbackAccess_AdminIncludesSeoPermission()
+    {
+        var contexts = ContextAccessBootstrap.BuildFallbackAccess(["Admin"]);
+        var admin = Assert.Single(contexts);
+        Assert.Contains("admin.seo.read", admin.Permissions);
+    }
+
+    [Fact]
     public void DeriveContextsFromJwtRoles_IgnoresUnknownRoles()
     {
         var contexts = ContextAccessBootstrap.DeriveContextsFromJwtRoles([

--- a/Sessions/fix-admin-seo-menu/issue-body.md
+++ b/Sessions/fix-admin-seo-menu/issue-body.md
@@ -1,0 +1,11 @@
+## Summary
+
+Admin users cannot see **SEO Compliance** in the admin sidebar because `admin.seo.read` is missing from `ContextAccessBootstrap` JWT fallback permissions.
+
+## Acceptance criteria
+
+- [ ] `GET /api/me/contexts` returns `admin.seo.read` for Admin JWT fallback
+- [ ] SEO nav item visible in admin sidebar after re-login
+- [ ] Unit test covers admin fallback permissions
+
+Related: #263


### PR DESCRIPTION
## Summary

- Add `admin.seo.read` to Admin permissions in `ContextAccessBootstrap` (JWT fallback path for `/api/me/contexts`)
- Unit test asserts admin fallback includes SEO permission

Closes #266

## Test plan

- [x] `ContextAccessBootstrapTests` 3/3
- [ ] After deploy: logout/login as Admin → SEO Compliance visible in sidebar
