### PR TITLE
fix(billing): replace dynamic DateTime in PlatformBillingMetrics seed

### DIFF
--- a/Casazen.Infrastructure/Data/AppDbContext.cs
+++ b/Casazen.Infrastructure/Data/AppDbContext.cs
@@ -350,10 +350,10 @@ public class AppDbContext(
             new PlatformBillingMetrics
             {
                 Id = 1,
-                CalendarYear = DateTime.UtcNow.Year,
+                CalendarYear = 2026,
                 EuB2cCrossBorderRevenue = 0m,
                 OssThresholdReached = false,
-                UpdatedAt = DateTime.UtcNow,
+                UpdatedAt = new DateTime(2026, 6, 11, 0, 0, 0, DateTimeKind.Utc),
             });
 
         // OrgId indexes on the tenant-scoped tables + Users (AC2/AC9).

--- a/Casazen.Infrastructure/Migrations/20260614123942_FixPlatformBillingMetricsSeed.Designer.cs
+++ b/Casazen.Infrastructure/Migrations/20260614123942_FixPlatformBillingMetricsSeed.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Casazen.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260614123942_FixPlatformBillingMetricsSeed")]
+    partial class FixPlatformBillingMetricsSeed
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Casazen.Infrastructure/Migrations/20260614123942_FixPlatformBillingMetricsSeed.cs
+++ b/Casazen.Infrastructure/Migrations/20260614123942_FixPlatformBillingMetricsSeed.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Casazen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixPlatformBillingMetricsSeed : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "PlatformBillingMetrics",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedAt",
+                value: new DateTime(2026, 6, 11, 0, 0, 0, 0, DateTimeKind.Utc));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "PlatformBillingMetrics",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UpdatedAt",
+                value: new DateTime(2026, 6, 11, 21, 39, 55, 821, DateTimeKind.Utc).AddTicks(3582));
+        }
+    }
+}

--- a/Casazen.Tests/Unit/Infrastructure/MigrationSqlTests.cs
+++ b/Casazen.Tests/Unit/Infrastructure/MigrationSqlTests.cs
@@ -38,9 +38,9 @@ public class MigrationSqlTests
         var keys = db.GetService<IMigrationsAssembly>().Migrations.Keys.ToList();
 
         var lastThree = keys.TakeLast(3).ToList();
-        Assert.EndsWith("AddCheckInTokenExpiresAt", lastThree[0]);
-        Assert.EndsWith("AddComplianceSeoEntities", lastThree[1]);
-        Assert.EndsWith("AddConsentRecords", lastThree[2]);
+        Assert.EndsWith("AddComplianceSeoEntities", lastThree[0]);
+        Assert.EndsWith("AddConsentRecords", lastThree[1]);
+        Assert.EndsWith("FixPlatformBillingMetricsSeed", lastThree[2]);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes EF Core PendingModelChangesWarning that blocked `dotnet ef database update` / `migrate.ps1`:

- Replaces `DateTime.UtcNow` with static `new DateTime(2026, 6, 11, 0, 0, 0, DateTimeKind.Utc)` in `AppDbContext.HasData`
- Adds `FixPlatformBillingMetricsSeed` migration to align model snapshot
- Updates `MigrationSqlTests.Migrations_LandInOrder_AsTheLastThree` assertion