### PR TITLE
feat(supplier): supplier console web wave 1 (#291 / #292)

### DIFF
--- a/Casazen.Core/Entities/Enums/OrgType.cs
+++ b/Casazen.Core/Entities/Enums/OrgType.cs
@@ -1,0 +1,14 @@
+namespace Casazen.Core.Entities.Enums;
+
+/// <summary>
+/// Discriminates Org records by platform role.
+/// Append-only: do not reorder or insert before existing values (persisted as int).
+/// </summary>
+public enum OrgType
+{
+    /// <summary>Standard short-rent or long-rent property manager.</summary>
+    Host,
+
+    /// <summary>Cleaning/maintenance service provider (US-022, #292).</summary>
+    Supplier,
+}

--- a/Casazen.Core/Entities/Enums/SupplierStatus.cs
+++ b/Casazen.Core/Entities/Enums/SupplierStatus.cs
@@ -1,0 +1,16 @@
+namespace Casazen.Core.Entities.Enums;
+
+/// <summary>
+/// Lifecycle status of a <see cref="Casazen.Core.Entities.SupplierProfile"/>.
+/// </summary>
+public enum SupplierStatus
+{
+    /// <summary>Profile created; activation wizard not yet completed.</summary>
+    Pending,
+
+    /// <summary>Activation wizard completed and ToS accepted; visible to hosts.</summary>
+    Active,
+
+    /// <summary>Manually suspended by platform admin.</summary>
+    Suspended,
+}

--- a/Casazen.Core/Entities/Org.cs
+++ b/Casazen.Core/Entities/Org.cs
@@ -22,6 +22,9 @@ public class Org
     public string Slug { get; set; } = string.Empty;
 
     [Required]
+    public OrgType OrgType { get; set; } = OrgType.Host;
+
+    [Required]
     public PlanTier PlanTier { get; set; } = PlanTier.Starter;
 
     [Required, MaxLength(200)]

--- a/Casazen.Core/Entities/SupplierAvailability.cs
+++ b/Casazen.Core/Entities/SupplierAvailability.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Casazen.Core.Entities;
+
+/// <summary>
+/// Per-date availability flag for a supplier org (US-022 / #292, AC8).
+/// </summary>
+[Table("SupplierAvailability")]
+public class SupplierAvailability
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    public Guid OrgId { get; set; }
+
+    [Required]
+    public DateOnly Date { get; set; }
+
+    public bool Available { get; set; } = true;
+
+    [ForeignKey(nameof(OrgId))]
+    public SupplierProfile SupplierProfile { get; set; } = null!;
+}

--- a/Casazen.Core/Entities/SupplierInviteRecord.cs
+++ b/Casazen.Core/Entities/SupplierInviteRecord.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Casazen.Core.Entities;
+
+/// <summary>
+/// Admin-generated supplier invite. Token included in the signup link and validated during
+/// <c>POST /api/suppliers/register</c> (US-022 / #292, AC3).
+/// </summary>
+[Table("SupplierInviteRecords")]
+public class SupplierInviteRecord
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required, MaxLength(255)]
+    public string Email { get; set; } = string.Empty;
+
+    [Required, MaxLength(20)]
+    public string ComuneCode { get; set; } = string.Empty;
+
+    /// <summary>JSON array of category codes; nullable when invite has no category filter.</summary>
+    [Column(TypeName = "jsonb")]
+    public string? CategoriesJson { get; set; }
+
+    [MaxLength(1000)]
+    public string? Message { get; set; }
+
+    public bool IsUsed { get; set; }
+
+    public DateTime ExpiresAt { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Casazen.Core/Entities/SupplierProfile.cs
+++ b/Casazen.Core/Entities/SupplierProfile.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Casazen.Core.Entities.Enums;
+
+namespace Casazen.Core.Entities;
+
+/// <summary>
+/// Supplier professional profile linked 1-to-1 to an <see cref="Org"/> with
+/// <c>OrgType = Supplier</c>. Stores identity, service categories, and activation state (US-022 / #292).
+/// </summary>
+[Table("SupplierProfiles")]
+public class SupplierProfile
+{
+    /// <summary>Primary key — same as the owning <see cref="Org.Id"/>.</summary>
+    [Key]
+    public Guid OrgId { get; set; }
+
+    [Required]
+    public SupplierStatus Status { get; set; } = SupplierStatus.Pending;
+
+    [Required, MaxLength(300)]
+    public string LegalName { get; set; } = string.Empty;
+
+    [MaxLength(20)]
+    public string? VatNumber { get; set; }
+
+    [Required, MaxLength(50)]
+    public string Phone { get; set; } = string.Empty;
+
+    [Required, MaxLength(255)]
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>JSON array of service category codes (e.g. ["cleaning","maintenance"]).</summary>
+    [Column(TypeName = "jsonb")]
+    public string CategoriesJson { get; set; } = "[]";
+
+    /// <summary>JSON array of Italian comune codes where the supplier operates.</summary>
+    [Column(TypeName = "jsonb")]
+    public string ComuniJson { get; set; } = "[]";
+
+    [MaxLength(2000)]
+    public string? Bio { get; set; }
+
+    /// <summary>JSON array of photo URLs.</summary>
+    [Column(TypeName = "jsonb")]
+    public string PhotoUrlsJson { get; set; } = "[]";
+
+    public DateTime? TosAcceptedAt { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    [ForeignKey(nameof(OrgId))]
+    public Org Org { get; set; } = null!;
+}

--- a/Casazen.Core/Services/ISupplierService.cs
+++ b/Casazen.Core/Services/ISupplierService.cs
@@ -1,0 +1,71 @@
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+
+namespace Casazen.Core.Services;
+
+public interface ISupplierService
+{
+    /// <summary>
+    /// Registers a new supplier org. If <paramref name="inviteToken"/> is provided it is validated
+    /// against an outstanding admin invite; otherwise self-serve registration is assumed.
+    /// </summary>
+    Task<(Org Org, SupplierProfile Profile)> RegisterAsync(
+        string email,
+        string legalName,
+        string phone,
+        string comuneCode,
+        string? inviteToken,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the <see cref="SupplierProfile"/> for the given supplier org.</summary>
+    Task<SupplierProfile?> GetProfileAsync(Guid orgId, CancellationToken cancellationToken = default);
+
+    /// <summary>Updates mutable profile fields. Returns the updated profile or null if not found.</summary>
+    Task<SupplierProfile?> UpdateProfileAsync(
+        Guid orgId,
+        string? legalName,
+        string? vatNumber,
+        string? phone,
+        IEnumerable<string>? categories,
+        IEnumerable<string>? comuni,
+        string? bio,
+        IEnumerable<string>? photoUrls,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns wizard step statuses for the activation flow (AC5).
+    /// </summary>
+    Task<IReadOnlyList<ActivationStep>> GetActivationStepsAsync(Guid orgId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the profile to <see cref="SupplierStatus.Active"/> when all blockers are satisfied and ToS is accepted.
+    /// Throws <see cref="InvalidOperationException"/> (→ 409) if blockers remain.
+    /// </summary>
+    Task<SupplierProfile> CompleteActivationAsync(Guid orgId, bool tosAccepted, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates availability entries for the supplier (AC8).
+    /// Returns the number of rows written.
+    /// </summary>
+    Task<int> UpdateAvailabilityAsync(
+        Guid orgId,
+        IEnumerable<(DateOnly Date, bool Available)> entries,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns <see cref="SupplierStatus.Active"/> suppliers for a given comune (AC6).
+    /// </summary>
+    Task<IReadOnlyList<SupplierProfile>> GetActiveByComune(string comuneCode, string? category, CancellationToken cancellationToken = default);
+
+    /// <summary>Creates an admin invite record. Returns the generated invite id.</summary>
+    Task<SupplierInvite> CreateInviteAsync(
+        string email,
+        string comuneCode,
+        IEnumerable<string>? categories,
+        string? message,
+        CancellationToken cancellationToken = default);
+}
+
+public record ActivationStep(string Id, string Label, string Status, string? Blocker = null);
+
+public record SupplierInvite(Guid InviteId, DateTime ExpiresAt);

--- a/Casazen.Infrastructure/Data/AppDbContext.cs
+++ b/Casazen.Infrastructure/Data/AppDbContext.cs
@@ -41,6 +41,11 @@ public class AppDbContext(
     public DbSet<ProcessedStripeEvent> ProcessedStripeEvents { get; set; } = null!;
     public DbSet<PlatformBillingMetrics> PlatformBillingMetrics { get; set; } = null!;
 
+    // Supplier console (US-022 / #292)
+    public DbSet<SupplierProfile> SupplierProfiles { get; set; } = null!;
+    public DbSet<SupplierAvailability> SupplierAvailability { get; set; } = null!;
+    public DbSet<SupplierInviteRecord> SupplierInviteRecords { get; set; } = null!;
+
     // Long-term lease
     public DbSet<LeaseContract> LeaseContracts { get; set; } = null!;
     public DbSet<Party> Parties { get; set; } = null!;
@@ -437,6 +442,32 @@ public class AppDbContext(
 
         modelBuilder.Entity<ConsentRecord>()
             .HasIndex(c => new { c.UserId, c.OrgId, c.Type });
+
+        // ─── Supplier console (US-022 / #292) ────────────────────────────────────
+        modelBuilder.Entity<SupplierProfile>()
+            .HasOne(sp => sp.Org)
+            .WithOne()
+            .HasForeignKey<SupplierProfile>(sp => sp.OrgId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<SupplierProfile>()
+            .HasIndex(sp => sp.Status);
+
+        modelBuilder.Entity<SupplierAvailability>()
+            .HasOne(sa => sa.SupplierProfile)
+            .WithMany()
+            .HasForeignKey(sa => sa.OrgId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<SupplierAvailability>()
+            .HasIndex(sa => new { sa.OrgId, sa.Date })
+            .IsUnique();
+
+        modelBuilder.Entity<SupplierInviteRecord>()
+            .HasIndex(i => i.Email);
+
+        modelBuilder.Entity<SupplierInviteRecord>()
+            .HasIndex(i => new { i.Email, i.IsUsed });
 
         modelBuilder.Entity<AppContextEntity>().HasData(
             new AppContextEntity { Key = "short-rent", DisplayName = "Affitti brevi" },

--- a/Casazen.Infrastructure/Migrations/20260620212145_AddSupplierOrgAndProfile.Designer.cs
+++ b/Casazen.Infrastructure/Migrations/20260620212145_AddSupplierOrgAndProfile.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Casazen.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Casazen.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620212145_AddSupplierOrgAndProfile")]
+    partial class AddSupplierOrgAndProfile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Casazen.Infrastructure/Migrations/20260620212145_AddSupplierOrgAndProfile.cs
+++ b/Casazen.Infrastructure/Migrations/20260620212145_AddSupplierOrgAndProfile.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Casazen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSupplierOrgAndProfile : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "OrgType",
+                table: "Orgs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "SupplierInviteRecords",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Email = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    ComuneCode = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    CategoriesJson = table.Column<string>(type: "jsonb", nullable: true),
+                    Message = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsUsed = table.Column<bool>(type: "boolean", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SupplierInviteRecords", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SupplierProfiles",
+                columns: table => new
+                {
+                    OrgId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    LegalName = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    VatNumber = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    Phone = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Email = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    CategoriesJson = table.Column<string>(type: "jsonb", nullable: false),
+                    ComuniJson = table.Column<string>(type: "jsonb", nullable: false),
+                    Bio = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    PhotoUrlsJson = table.Column<string>(type: "jsonb", nullable: false),
+                    TosAcceptedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SupplierProfiles", x => x.OrgId);
+                    table.ForeignKey(
+                        name: "FK_SupplierProfiles_Orgs_OrgId",
+                        column: x => x.OrgId,
+                        principalTable: "Orgs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SupplierAvailability",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrgId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Date = table.Column<DateOnly>(type: "date", nullable: false),
+                    Available = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SupplierAvailability", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SupplierAvailability_SupplierProfiles_OrgId",
+                        column: x => x.OrgId,
+                        principalTable: "SupplierProfiles",
+                        principalColumn: "OrgId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SupplierAvailability_OrgId_Date",
+                table: "SupplierAvailability",
+                columns: new[] { "OrgId", "Date" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SupplierInviteRecords_Email",
+                table: "SupplierInviteRecords",
+                column: "Email");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SupplierInviteRecords_Email_IsUsed",
+                table: "SupplierInviteRecords",
+                columns: new[] { "Email", "IsUsed" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SupplierProfiles_Status",
+                table: "SupplierProfiles",
+                column: "Status");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SupplierAvailability");
+
+            migrationBuilder.DropTable(
+                name: "SupplierInviteRecords");
+
+            migrationBuilder.DropTable(
+                name: "SupplierProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "OrgType",
+                table: "Orgs");
+        }
+    }
+}

--- a/Casazen.Infrastructure/Services/SupplierService.cs
+++ b/Casazen.Infrastructure/Services/SupplierService.cs
@@ -1,0 +1,235 @@
+using System.Text.Json;
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Core.Services;
+using Casazen.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Casazen.Infrastructure.Services;
+
+public class SupplierService(AppDbContext db, ILogger<SupplierService> logger) : ISupplierService
+{
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    public async Task<(Org Org, SupplierProfile Profile)> RegisterAsync(
+        string email,
+        string legalName,
+        string phone,
+        string comuneCode,
+        string? inviteToken,
+        CancellationToken cancellationToken = default)
+    {
+        if (inviteToken is not null)
+        {
+            var invite = await db.SupplierInviteRecords
+                .FirstOrDefaultAsync(i =>
+                    i.Id == Guid.Parse(inviteToken) &&
+                    !i.IsUsed &&
+                    i.ExpiresAt > DateTime.UtcNow,
+                    cancellationToken);
+
+            if (invite is null)
+                throw new InvalidOperationException("Invalid or expired invite token.");
+
+            invite.IsUsed = true;
+        }
+
+        var slug = $"supplier-{Guid.NewGuid():N}"[..30];
+        var org = new Org
+        {
+            Name = legalName,
+            Slug = slug,
+            DisplayName = legalName,
+            ContactEmail = email,
+            OrgType = OrgType.Supplier,
+        };
+        db.Orgs.Add(org);
+
+        var profile = new SupplierProfile
+        {
+            OrgId = org.Id,
+            Email = email,
+            LegalName = legalName,
+            Phone = phone,
+            ComuniJson = JsonSerializer.Serialize(new[] { comuneCode }, JsonOpts),
+        };
+        db.SupplierProfiles.Add(profile);
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Supplier org {OrgId} registered for {Email}", org.Id, email);
+        return (org, profile);
+    }
+
+    public async Task<SupplierProfile?> GetProfileAsync(Guid orgId, CancellationToken cancellationToken = default) =>
+        await db.SupplierProfiles.FirstOrDefaultAsync(sp => sp.OrgId == orgId, cancellationToken);
+
+    public async Task<SupplierProfile?> UpdateProfileAsync(
+        Guid orgId,
+        string? legalName,
+        string? vatNumber,
+        string? phone,
+        IEnumerable<string>? categories,
+        IEnumerable<string>? comuni,
+        string? bio,
+        IEnumerable<string>? photoUrls,
+        CancellationToken cancellationToken = default)
+    {
+        var profile = await db.SupplierProfiles.FirstOrDefaultAsync(sp => sp.OrgId == orgId, cancellationToken);
+        if (profile is null)
+            return null;
+
+        if (legalName is not null) profile.LegalName = legalName;
+        if (vatNumber is not null) profile.VatNumber = vatNumber;
+        if (phone is not null) profile.Phone = phone;
+        if (categories is not null) profile.CategoriesJson = JsonSerializer.Serialize(categories, JsonOpts);
+        if (comuni is not null) profile.ComuniJson = JsonSerializer.Serialize(comuni, JsonOpts);
+        if (bio is not null) profile.Bio = bio;
+        if (photoUrls is not null) profile.PhotoUrlsJson = JsonSerializer.Serialize(photoUrls, JsonOpts);
+        profile.UpdatedAt = DateTime.UtcNow;
+
+        await db.SaveChangesAsync(cancellationToken);
+        return profile;
+    }
+
+    public async Task<IReadOnlyList<ActivationStep>> GetActivationStepsAsync(Guid orgId, CancellationToken cancellationToken = default)
+    {
+        var profile = await db.SupplierProfiles.FirstOrDefaultAsync(sp => sp.OrgId == orgId, cancellationToken);
+        if (profile is null)
+            return Array.Empty<ActivationStep>();
+
+        var categories = JsonSerializer.Deserialize<string[]>(profile.CategoriesJson, JsonOpts) ?? [];
+        var comuni = JsonSerializer.Deserialize<string[]>(profile.ComuniJson, JsonOpts) ?? [];
+
+        return
+        [
+            new ActivationStep("identity", "Identità e contatti", "completed"),
+            new ActivationStep("categories", "Categorie di servizio",
+                categories.Length > 0 ? "completed" : "pending",
+                categories.Length == 0 ? "Scegli almeno una categoria" : null),
+            new ActivationStep("comuni", "Comuni di operatività",
+                comuni.Length > 0 ? "completed" : "pending",
+                comuni.Length == 0 ? "Seleziona almeno un comune" : null),
+            new ActivationStep("profile", "Profilo professionale",
+                !string.IsNullOrWhiteSpace(profile.Bio) ? "completed" : "pending",
+                string.IsNullOrWhiteSpace(profile.Bio) ? "Aggiungi una descrizione professionale" : null),
+            new ActivationStep("tos", "Termini di servizio",
+                profile.TosAcceptedAt.HasValue ? "completed" : "pending",
+                !profile.TosAcceptedAt.HasValue ? "Accetta i termini di servizio" : null),
+        ];
+    }
+
+    public async Task<SupplierProfile> CompleteActivationAsync(Guid orgId, bool tosAccepted, CancellationToken cancellationToken = default)
+    {
+        var profile = await db.SupplierProfiles.FirstOrDefaultAsync(sp => sp.OrgId == orgId, cancellationToken)
+            ?? throw new KeyNotFoundException($"Supplier profile not found for org {orgId}");
+
+        var steps = await GetActivationStepsAsync(orgId, cancellationToken);
+        var blockers = steps.Where(s => s.Status != "completed" && s.Id != "tos").ToList();
+
+        if (!tosAccepted)
+            blockers.Add(new ActivationStep("tos", "Termini di servizio", "pending", "Devi accettare i termini di servizio"));
+
+        if (blockers.Count > 0)
+        {
+            var msgs = string.Join("; ", blockers.Select(b => b.Blocker));
+            throw new InvalidOperationException($"Attivazione non completata: {msgs}");
+        }
+
+        profile.TosAcceptedAt = DateTime.UtcNow;
+        profile.Status = SupplierStatus.Active;
+        profile.UpdatedAt = DateTime.UtcNow;
+
+        await db.SaveChangesAsync(cancellationToken);
+        logger.LogInformation("Supplier {OrgId} activated", orgId);
+        return profile;
+    }
+
+    public async Task<int> UpdateAvailabilityAsync(
+        Guid orgId,
+        IEnumerable<(DateOnly Date, bool Available)> entries,
+        CancellationToken cancellationToken = default)
+    {
+        var entriesList = entries.ToList();
+        var dates = entriesList.Select(e => e.Date).ToList();
+
+        var existing = await db.SupplierAvailability
+            .Where(sa => sa.OrgId == orgId && dates.Contains(sa.Date))
+            .ToListAsync(cancellationToken);
+
+        int count = 0;
+        foreach (var (date, available) in entriesList)
+        {
+            var record = existing.FirstOrDefault(e => e.Date == date);
+            if (record is null)
+            {
+                db.SupplierAvailability.Add(new SupplierAvailability
+                {
+                    OrgId = orgId,
+                    Date = date,
+                    Available = available,
+                });
+            }
+            else
+            {
+                record.Available = available;
+            }
+            count++;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+        return count;
+    }
+
+    public async Task<IReadOnlyList<SupplierProfile>> GetActiveByComune(string comuneCode, string? category, CancellationToken cancellationToken = default)
+    {
+        var all = await db.SupplierProfiles
+            .Where(sp => sp.Status == SupplierStatus.Active)
+            .ToListAsync(cancellationToken);
+
+        return all.Where(sp =>
+        {
+            var comuni = JsonSerializer.Deserialize<string[]>(sp.ComuniJson, JsonOpts) ?? [];
+            if (!comuni.Contains(comuneCode, StringComparer.OrdinalIgnoreCase))
+                return false;
+
+            if (category is not null)
+            {
+                var cats = JsonSerializer.Deserialize<string[]>(sp.CategoriesJson, JsonOpts) ?? [];
+                return cats.Contains(category, StringComparer.OrdinalIgnoreCase);
+            }
+            return true;
+        }).ToList();
+    }
+
+    public async Task<SupplierInvite> CreateInviteAsync(
+        string email,
+        string comuneCode,
+        IEnumerable<string>? categories,
+        string? message,
+        CancellationToken cancellationToken = default)
+    {
+        var existing = await db.SupplierInviteRecords
+            .FirstOrDefaultAsync(i => i.Email == email && !i.IsUsed && i.ExpiresAt > DateTime.UtcNow, cancellationToken);
+
+        if (existing is not null)
+            throw new InvalidOperationException($"Pending invite already exists for {email}");
+
+        var invite = new SupplierInviteRecord
+        {
+            Email = email,
+            ComuneCode = comuneCode,
+            CategoriesJson = categories is not null
+                ? JsonSerializer.Serialize(categories, JsonOpts)
+                : null,
+            Message = message,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+        };
+        db.SupplierInviteRecords.Add(invite);
+        await db.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Admin invite created for {Email}, expires {ExpiresAt}", email, invite.ExpiresAt);
+        return new SupplierInvite(invite.Id, invite.ExpiresAt);
+    }
+}

--- a/Casazen.Tests/Integration/SupplierConsoleIntegrationTests.cs
+++ b/Casazen.Tests/Integration/SupplierConsoleIntegrationTests.cs
@@ -1,0 +1,319 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Casazen.Core.Entities;
+using Casazen.Core.Entities.Enums;
+using Casazen.Infrastructure.Data;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+// OrgEntity is a global alias defined in Casazen.Tests.csproj: OrgEntity = global::Casazen.Core.Entities.Org
+
+namespace Casazen.Tests.Integration;
+
+/// <summary>
+/// Integration tests for the Supplier Console feature (US-022 / #292).
+/// Covers AC1–AC8: registration, activation, profile, inbox, availability, admin invite.
+/// </summary>
+public class SupplierConsoleIntegrationTests : IClassFixture<CasazenWebApplicationFactory>
+{
+    private readonly CasazenWebApplicationFactory _factory;
+
+    public SupplierConsoleIntegrationTests(CasazenWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    // ─── AC3: POST /api/suppliers/register (public) ───────────────────────────
+
+    [Fact]
+    public async Task Register_ValidRequest_Returns201WithOrgId()
+    {
+        using var client = _factory.CreateClient();
+
+        var payload = new
+        {
+            email = $"supplier-{Guid.NewGuid():N}@test.com",
+            legalName = "Pulizie Roma Srl",
+            phone = "+39 06 123456",
+            comuneCode = "H501",
+        };
+
+        var response = await client.PostAsJsonAsync("/api/suppliers/register", payload);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.NotEqual(Guid.Empty, body.GetProperty("orgId").GetGuid());
+        Assert.Equal("/supplier/activation", body.GetProperty("authRedirectUrl").GetString());
+    }
+
+    [Fact]
+    public async Task Register_InvalidInviteToken_Returns400()
+    {
+        using var client = _factory.CreateClient();
+
+        var payload = new
+        {
+            email = $"invite-{Guid.NewGuid():N}@test.com",
+            legalName = "Bad Token Srl",
+            phone = "+39 06 000000",
+            comuneCode = "H501",
+            inviteToken = Guid.NewGuid().ToString(),
+        };
+
+        var response = await client.PostAsJsonAsync("/api/suppliers/register", payload);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    // ─── AC5: GET/POST activation ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetActivation_AsSupplier_Returns200WithSteps()
+    {
+        var (supplierId, orgId) = await SeedSupplierAsync();
+        using var client = _factory.CreateAuthenticatedClient(supplierId, "Supplier");
+
+        var response = await client.GetAsync("/api/supplier/profile/activation");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("Pending", body.GetProperty("status").GetString());
+        var steps = body.GetProperty("steps").EnumerateArray().ToList();
+        Assert.Equal(5, steps.Count);
+    }
+
+    [Fact]
+    public async Task CompleteActivation_WithBlockers_Returns409()
+    {
+        var (supplierId, _) = await SeedSupplierAsync();
+        using var client = _factory.CreateAuthenticatedClient(supplierId, "Supplier");
+
+        var response = await client.PostAsJsonAsync("/api/supplier/profile/activation/complete",
+            new { tosAccepted = true });
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CompleteActivation_AllStepsMet_Returns200Active()
+    {
+        var (supplierId, orgId) = await SeedFullSupplierAsync();
+        using var client = _factory.CreateAuthenticatedClient(supplierId, "Supplier");
+
+        var response = await client.PostAsJsonAsync("/api/supplier/profile/activation/complete",
+            new { tosAccepted = true });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("Active", body.GetProperty("status").GetString());
+    }
+
+    // ─── AC4/Profile ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetProfile_AsSupplier_Returns200Profile()
+    {
+        var (supplierId, _) = await SeedSupplierAsync();
+        using var client = _factory.CreateAuthenticatedClient(supplierId, "Supplier");
+
+        var response = await client.GetAsync("/api/supplier/profile");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("Pending", body.GetProperty("status").GetString());
+        Assert.NotEmpty(body.GetProperty("legalName").GetString()!);
+    }
+
+    [Fact]
+    public async Task UpdateProfile_AsSupplier_Returns200UpdatedProfile()
+    {
+        var (supplierId, _) = await SeedSupplierAsync();
+        using var client = _factory.CreateAuthenticatedClient(supplierId, "Supplier");
+
+        var response = await client.PutAsJsonAsync("/api/supplier/profile", new
+        {
+            bio = "Azienda di pulizie professionale con 10 anni di esperienza.",
+            categories = new[] { "cleaning", "laundry" },
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("Azienda di pulizie professionale con 10 anni di esperienza.", body.GetProperty("bio").GetString());
+    }
+
+    // ─── AC7: Inbox (empty until #293) ───────────────────────────────────────
+
+    [Fact]
+    public async Task GetInbox_AsSupplier_Returns200EmptyList()
+    {
+        var (supplierId, _) = await SeedSupplierAsync();
+        using var client = _factory.CreateAuthenticatedClient(supplierId, "Supplier");
+
+        var response = await client.GetAsync("/api/supplier/inbox");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(0, body.GetProperty("total").GetInt32());
+    }
+
+    // ─── AC8: Availability ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAvailability_AsSupplier_Returns200Updated()
+    {
+        var (supplierId, _) = await SeedSupplierAsync();
+        using var client = _factory.CreateAuthenticatedClient(supplierId, "Supplier");
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var response = await client.PutAsJsonAsync("/api/supplier/availability", new
+        {
+            dates = new[]
+            {
+                new { date = today.ToString("yyyy-MM-dd"), available = false },
+                new { date = today.AddDays(1).ToString("yyyy-MM-dd"), available = true },
+            },
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(2, body.GetProperty("updated").GetInt32());
+    }
+
+    // ─── AC3: Admin invite ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AdminInvite_AsAdmin_Returns201WithInviteId()
+    {
+        using var client = _factory.CreateAuthenticatedClient(roles: "Admin");
+
+        var response = await client.PostAsJsonAsync("/api/admin/suppliers/invite", new
+        {
+            email = $"new-supplier-{Guid.NewGuid():N}@test.com",
+            comuneCode = "H501",
+            categories = new[] { "cleaning" },
+            message = "Benvenuto nella piattaforma!",
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.NotEqual(Guid.Empty, body.GetProperty("inviteId").GetGuid());
+        Assert.True(body.GetProperty("expiresAt").GetDateTime() > DateTime.UtcNow);
+    }
+
+    [Fact]
+    public async Task AdminInvite_AsNonAdmin_Returns403()
+    {
+        using var client = _factory.CreateAuthenticatedClient(roles: "PropertyOwner");
+
+        var response = await client.PostAsJsonAsync("/api/admin/suppliers/invite", new
+        {
+            email = "blocked@test.com",
+            comuneCode = "H501",
+        });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    // ─── AC6: GET /api/suppliers only Active ─────────────────────────────────
+
+    [Fact]
+    public async Task GetSuppliers_ReturnsOnlyActiveForComune()
+    {
+        await SeedFullSupplierAsync(comuneCode: "F205", autoActivate: true);
+
+        using var client = _factory.CreateAuthenticatedClient(roles: "PropertyOwner");
+        var response = await client.GetAsync("/api/suppliers?comune=F205");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items").EnumerateArray().ToList();
+        Assert.True(items.Count >= 1);
+    }
+
+    // ─── Auth guards ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SupplierProfile_WithoutAuth_Returns401()
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/supplier/profile");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SupplierProfile_WithPropertyOwnerRole_Returns403()
+    {
+        using var client = _factory.CreateAuthenticatedClient(roles: "PropertyOwner");
+        var response = await client.GetAsync("/api/supplier/profile");
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<(string UserId, Guid OrgId)> SeedSupplierAsync(string comuneCode = "H501")
+    {
+        var userId = $"auth0|supplier-{Guid.NewGuid():N}";
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var org = new OrgEntity
+        {
+            Name = "Test Supplier Srl",
+            Slug = $"test-supplier-{Guid.NewGuid():N}"[..30],
+            DisplayName = "Test Supplier Srl",
+            ContactEmail = $"{Guid.NewGuid():N}@test.com",
+            OrgType = OrgType.Supplier,
+            PlanTier = PlanTier.Starter,
+        };
+        db.Orgs.Add(org);
+
+        var user = new User
+        {
+            Id = userId,
+            Email = org.ContactEmail,
+            FirstName = "Test",
+            LastName = "Supplier",
+            OrgId = org.Id,
+            IsActive = true,
+        };
+        db.Users.Add(user);
+
+        var profile = new SupplierProfile
+        {
+            OrgId = org.Id,
+            Email = org.ContactEmail,
+            LegalName = "Test Supplier Srl",
+            Phone = "+39 06 999999",
+            ComuniJson = $"[\"{comuneCode}\"]",
+        };
+        db.SupplierProfiles.Add(profile);
+
+        await db.SaveChangesAsync();
+        return (userId, org.Id);
+    }
+
+    private async Task<(string UserId, Guid OrgId)> SeedFullSupplierAsync(string comuneCode = "H501", bool autoActivate = false)
+    {
+        var (userId, orgId) = await SeedSupplierAsync(comuneCode);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var profile = await db.SupplierProfiles.FindAsync(orgId);
+        if (profile is not null)
+        {
+            profile.CategoriesJson = "[\"cleaning\"]";
+            profile.Bio = "Azienda di pulizie professionale.";
+
+            if (autoActivate)
+            {
+                profile.TosAcceptedAt = DateTime.UtcNow;
+                profile.Status = SupplierStatus.Active;
+            }
+
+            await db.SaveChangesAsync();
+        }
+
+        return (userId, orgId);
+    }
+}

--- a/Casazen.Tests/Unit/Infrastructure/MigrationSqlTests.cs
+++ b/Casazen.Tests/Unit/Infrastructure/MigrationSqlTests.cs
@@ -38,9 +38,9 @@ public class MigrationSqlTests
         var keys = db.GetService<IMigrationsAssembly>().Migrations.Keys.ToList();
 
         var lastThree = keys.TakeLast(3).ToList();
-        Assert.EndsWith("FixPlatformBillingMetricsSeed", lastThree[0]);
-        Assert.EndsWith("AddOnboardingCompletedAtToUsers", lastThree[1]);
-        Assert.EndsWith("AddPaymentOptionToBooking", lastThree[2]);
+        Assert.EndsWith("AddOnboardingCompletedAtToUsers", lastThree[0]);
+        Assert.EndsWith("AddPaymentOptionToBooking", lastThree[1]);
+        Assert.EndsWith("AddSupplierOrgAndProfile", lastThree[2]);
     }
 
     [Fact]

--- a/Casazen.Web/Controllers/AdminSuppliersController.cs
+++ b/Casazen.Web/Controllers/AdminSuppliersController.cs
@@ -1,0 +1,51 @@
+using Casazen.Core.Services;
+using Casazen.Web.DTOs.Supplier;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Casazen.Web.Controllers;
+
+/// <summary>
+/// Platform-admin endpoints for supplier management (US-022 / #292, AC3).
+/// </summary>
+[ApiController]
+[Route("api/admin/suppliers")]
+[Authorize(Policy = "AdminOnly")]
+public class AdminSuppliersController(
+    ISupplierService supplierService,
+    ILogger<AdminSuppliersController> logger) : ControllerBase
+{
+    /// <summary>Sends an invite email to a prospective supplier for a given comune.</summary>
+    [HttpPost("invite")]
+    [ProducesResponseType(typeof(AdminInviteResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<AdminInviteResponse>> InviteSupplier(
+        [FromBody] AdminInviteSupplierRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var invite = await supplierService.CreateInviteAsync(
+                request.Email,
+                request.ComuneCode,
+                request.Categories,
+                request.Message,
+                cancellationToken);
+
+            logger.LogInformation(
+                "Admin supplier invite created: {InviteId} for {Email} in {Comune}",
+                invite.InviteId, request.Email, request.ComuneCode);
+
+            return CreatedAtAction(nameof(InviteSupplier), new AdminInviteResponse
+            {
+                InviteId = invite.InviteId,
+                ExpiresAt = invite.ExpiresAt,
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Conflict(new { error = ex.Message, code = "duplicate_invite" });
+        }
+    }
+}

--- a/Casazen.Web/Controllers/SupplierProfileController.cs
+++ b/Casazen.Web/Controllers/SupplierProfileController.cs
@@ -1,0 +1,173 @@
+using System.Text.Json;
+using Casazen.Core.Services;
+using Casazen.Web.DTOs.Supplier;
+using Casazen.Web.Infrastructure;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Casazen.Web.Controllers;
+
+/// <summary>
+/// Supplier-facing endpoints: activation wizard, profile, inbox shell, and availability (US-022 / #292).
+/// All routes are scoped to the caller's supplier org via <c>IOrgContextResolver</c>.
+/// </summary>
+[ApiController]
+[Route("api/supplier")]
+[Authorize(Policy = "RequireSupplier")]
+public class SupplierProfileController(
+    ISupplierService supplierService,
+    IOrgContextResolver orgContextResolver,
+    ILogger<SupplierProfileController> logger) : ControllerBase
+{
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    // ─── Activation ──────────────────────────────────────────────────────────
+
+    /// <summary>Returns the 5-step activation wizard status for the caller's supplier org.</summary>
+    [HttpGet("profile/activation")]
+    [ProducesResponseType(typeof(ActivationStatusDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ActivationStatusDto>> GetActivationStatus(CancellationToken cancellationToken)
+    {
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(cancellationToken);
+        if (orgId is null) return NotFound(new { error = "No supplier org found" });
+
+        var profile = await supplierService.GetProfileAsync(orgId.Value, cancellationToken);
+        if (profile is null) return NotFound(new { error = "Supplier profile not found" });
+
+        var steps = await supplierService.GetActivationStepsAsync(orgId.Value, cancellationToken);
+
+        return Ok(new ActivationStatusDto
+        {
+            Status = profile.Status.ToString(),
+            Steps = steps.Select(s => new ActivationStepDto
+            {
+                Id = s.Id,
+                Label = s.Label,
+                Status = s.Status,
+                Blocker = s.Blocker,
+            }),
+        });
+    }
+
+    /// <summary>Completes the activation wizard and sets the profile to <c>Active</c>.</summary>
+    [HttpPost("profile/activation/complete")]
+    [ProducesResponseType(typeof(CompleteActivationResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<CompleteActivationResponse>> CompleteActivation(
+        [FromBody] CompleteActivationRequest request,
+        CancellationToken cancellationToken)
+    {
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(cancellationToken);
+        if (orgId is null) return NotFound(new { error = "No supplier org found" });
+
+        try
+        {
+            var profile = await supplierService.CompleteActivationAsync(orgId.Value, request.TosAccepted, cancellationToken);
+            return Ok(new CompleteActivationResponse { Status = profile.Status.ToString() });
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Conflict(new { error = ex.Message, code = "activation_blockers_remain" });
+        }
+    }
+
+    // ─── Profile ─────────────────────────────────────────────────────────────
+
+    /// <summary>Returns the caller's supplier profile.</summary>
+    [HttpGet("profile")]
+    [ProducesResponseType(typeof(SupplierProfileDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<SupplierProfileDto>> GetProfile(CancellationToken cancellationToken)
+    {
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(cancellationToken);
+        if (orgId is null) return NotFound(new { error = "No supplier org found" });
+
+        var profile = await supplierService.GetProfileAsync(orgId.Value, cancellationToken);
+        if (profile is null) return NotFound(new { error = "Supplier profile not found" });
+
+        return Ok(MapProfile(profile));
+    }
+
+    /// <summary>Updates the caller's supplier profile fields.</summary>
+    [HttpPut("profile")]
+    [ProducesResponseType(typeof(SupplierProfileDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<SupplierProfileDto>> UpdateProfile(
+        [FromBody] UpdateSupplierProfileRequest request,
+        CancellationToken cancellationToken)
+    {
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(cancellationToken);
+        if (orgId is null) return NotFound(new { error = "No supplier org found" });
+
+        var profile = await supplierService.UpdateProfileAsync(
+            orgId.Value,
+            request.LegalName, request.VatNumber, request.Phone,
+            request.Categories, request.Comuni, request.Bio, request.PhotoUrls,
+            cancellationToken);
+
+        if (profile is null) return NotFound(new { error = "Supplier profile not found" });
+
+        return Ok(MapProfile(profile));
+    }
+
+    // ─── Inbox ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns paginated open service requests assigned to this supplier.
+    /// Returns empty list until #293 (micro-marketplace) is implemented.
+    /// </summary>
+    [HttpGet("inbox")]
+    [ProducesResponseType(typeof(SupplierInboxResponse), StatusCodes.Status200OK)]
+    public ActionResult<SupplierInboxResponse> GetInbox(
+        [FromQuery] string? status = "open",
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20)
+    {
+        logger.LogDebug("Supplier inbox requested — status={Status}, page={Page}", status, page);
+        return Ok(new SupplierInboxResponse { Items = [], Total = 0 });
+    }
+
+    // ─── Availability ─────────────────────────────────────────────────────────
+
+    /// <summary>Updates the supplier's availability for a list of dates.</summary>
+    [HttpPut("availability")]
+    [ProducesResponseType(typeof(UpdateAvailabilityResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<UpdateAvailabilityResponse>> UpdateAvailability(
+        [FromBody] UpdateAvailabilityRequest request,
+        CancellationToken cancellationToken)
+    {
+        var orgId = await orgContextResolver.GetOrProvisionOrgIdAsync(cancellationToken);
+        if (orgId is null) return NotFound(new { error = "No supplier org found" });
+
+        var entries = request.Dates.Select(d => (d.Date, d.Available));
+        var updated = await supplierService.UpdateAvailabilityAsync(orgId.Value, entries, cancellationToken);
+
+        return Ok(new UpdateAvailabilityResponse { Updated = updated });
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private static SupplierProfileDto MapProfile(Casazen.Core.Entities.SupplierProfile profile) => new()
+    {
+        OrgId = profile.OrgId,
+        Status = profile.Status.ToString(),
+        LegalName = profile.LegalName,
+        VatNumber = profile.VatNumber,
+        Phone = profile.Phone,
+        Email = profile.Email,
+        Categories = JsonSerializer.Deserialize<IEnumerable<string>>(profile.CategoriesJson, JsonOpts) ?? [],
+        Comuni = JsonSerializer.Deserialize<IEnumerable<string>>(profile.ComuniJson, JsonOpts) ?? [],
+        Bio = profile.Bio,
+        PhotoUrls = JsonSerializer.Deserialize<IEnumerable<string>>(profile.PhotoUrlsJson, JsonOpts) ?? [],
+        TosAcceptedAt = profile.TosAcceptedAt,
+    };
+}

--- a/Casazen.Web/Controllers/SuppliersController.cs
+++ b/Casazen.Web/Controllers/SuppliersController.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using Casazen.Core.Services;
+using Casazen.Web.DTOs;
+using Casazen.Web.DTOs.Supplier;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Casazen.Web.Controllers;
+
+/// <summary>
+/// Public supplier registration + host-facing supplier discovery endpoints (US-022 / #292).
+/// </summary>
+[ApiController]
+[Route("api/suppliers")]
+public class SuppliersController(
+    ISupplierService supplierService,
+    ILogger<SuppliersController> logger) : ControllerBase
+{
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Public self-serve supplier registration. Optionally validates an admin invite token.
+    /// </summary>
+    [HttpPost("register")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(SupplierRegisterResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<SupplierRegisterResponse>> Register(
+        [FromBody] SupplierRegisterRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var (org, _) = await supplierService.RegisterAsync(
+                request.Email,
+                request.LegalName,
+                request.Phone,
+                request.ComuneCode,
+                request.InviteToken,
+                cancellationToken);
+
+            logger.LogInformation("Supplier registered: {OrgId} for {Email}", org.Id, request.Email);
+
+            return CreatedAtAction(nameof(Register), new SupplierRegisterResponse
+            {
+                OrgId = org.Id,
+                AuthRedirectUrl = "/supplier/activation",
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Returns <c>Active</c> suppliers for a comune. Available to hosts (PropertyOwner role).
+    /// </summary>
+    [HttpGet]
+    [Authorize]
+    [ProducesResponseType(typeof(PagedResultDto<SupplierPickerDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<PagedResultDto<SupplierPickerDto>>> GetSuppliers(
+        [FromQuery] string comune,
+        [FromQuery] string? category,
+        CancellationToken cancellationToken)
+    {
+        var suppliers = await supplierService.GetActiveByComune(comune, category, cancellationToken);
+
+        var items = suppliers.Select(sp => new SupplierPickerDto
+        {
+            OrgId = sp.OrgId,
+            LegalName = sp.LegalName,
+            Phone = sp.Phone,
+            Email = sp.Email,
+            Categories = JsonSerializer.Deserialize<IEnumerable<string>>(sp.CategoriesJson, JsonOpts) ?? [],
+            Comuni = JsonSerializer.Deserialize<IEnumerable<string>>(sp.ComuniJson, JsonOpts) ?? [],
+            Bio = sp.Bio,
+            PhotoUrls = JsonSerializer.Deserialize<IEnumerable<string>>(sp.PhotoUrlsJson, JsonOpts) ?? [],
+        });
+
+        return Ok(new PagedResultDto<SupplierPickerDto>
+        {
+            Items = items,
+            TotalCount = suppliers.Count,
+            Page = 1,
+            PageSize = suppliers.Count,
+        });
+    }
+}

--- a/Casazen.Web/DTOs/Supplier/SupplierDtos.cs
+++ b/Casazen.Web/DTOs/Supplier/SupplierDtos.cs
@@ -1,0 +1,148 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Casazen.Web.DTOs.Supplier;
+
+// ─── Requests ────────────────────────────────────────────────────────────────
+
+public class SupplierRegisterRequest
+{
+    [Required, EmailAddress, MaxLength(255)]
+    public string Email { get; set; } = string.Empty;
+
+    [Required, MaxLength(300)]
+    public string LegalName { get; set; } = string.Empty;
+
+    [Required, MaxLength(50)]
+    public string Phone { get; set; } = string.Empty;
+
+    [Required, MaxLength(20)]
+    public string ComuneCode { get; set; } = string.Empty;
+
+    public string? InviteToken { get; set; }
+}
+
+public class UpdateSupplierProfileRequest
+{
+    [MaxLength(300)]
+    public string? LegalName { get; set; }
+
+    [MaxLength(20)]
+    public string? VatNumber { get; set; }
+
+    [MaxLength(50)]
+    public string? Phone { get; set; }
+
+    public IEnumerable<string>? Categories { get; set; }
+
+    public IEnumerable<string>? Comuni { get; set; }
+
+    [MaxLength(2000)]
+    public string? Bio { get; set; }
+
+    public IEnumerable<string>? PhotoUrls { get; set; }
+}
+
+public class CompleteActivationRequest
+{
+    [Required]
+    public bool TosAccepted { get; set; }
+}
+
+public class UpdateAvailabilityRequest
+{
+    [Required]
+    public IEnumerable<AvailabilityEntryDto> Dates { get; set; } = [];
+}
+
+public class AvailabilityEntryDto
+{
+    [Required]
+    public DateOnly Date { get; set; }
+
+    public bool Available { get; set; } = true;
+}
+
+public class AdminInviteSupplierRequest
+{
+    [Required, EmailAddress, MaxLength(255)]
+    public string Email { get; set; } = string.Empty;
+
+    [Required, MaxLength(20)]
+    public string ComuneCode { get; set; } = string.Empty;
+
+    public IEnumerable<string>? Categories { get; set; }
+
+    [MaxLength(1000)]
+    public string? Message { get; set; }
+}
+
+// ─── Responses ───────────────────────────────────────────────────────────────
+
+public class SupplierRegisterResponse
+{
+    public Guid OrgId { get; set; }
+    public string AuthRedirectUrl { get; set; } = string.Empty;
+}
+
+public class SupplierProfileDto
+{
+    public Guid OrgId { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public string LegalName { get; set; } = string.Empty;
+    public string? VatNumber { get; set; }
+    public string Phone { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public IEnumerable<string> Categories { get; set; } = [];
+    public IEnumerable<string> Comuni { get; set; } = [];
+    public string? Bio { get; set; }
+    public IEnumerable<string> PhotoUrls { get; set; } = [];
+    public DateTime? TosAcceptedAt { get; set; }
+}
+
+public class ActivationStatusDto
+{
+    public string Status { get; set; } = string.Empty;
+    public IEnumerable<ActivationStepDto> Steps { get; set; } = [];
+}
+
+public class ActivationStepDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public string? Blocker { get; set; }
+}
+
+public class CompleteActivationResponse
+{
+    public string Status { get; set; } = string.Empty;
+}
+
+public class SupplierInboxResponse
+{
+    public IEnumerable<object> Items { get; set; } = [];
+    public int Total { get; set; }
+}
+
+public class UpdateAvailabilityResponse
+{
+    public int Updated { get; set; }
+}
+
+public class AdminInviteResponse
+{
+    public Guid InviteId { get; set; }
+    public DateTime ExpiresAt { get; set; }
+}
+
+public class SupplierPickerDto
+{
+    public Guid OrgId { get; set; }
+    public string LegalName { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public IEnumerable<string> Categories { get; set; } = [];
+    public IEnumerable<string> Comuni { get; set; } = [];
+    public string? Bio { get; set; }
+    public IEnumerable<string> PhotoUrls { get; set; } = [];
+}

--- a/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Casazen.Web/Extensions/ServiceCollectionExtensions.cs
@@ -123,6 +123,7 @@ public static class ServiceCollectionExtensions
             .AddPolicy("PropertyOwner", policy => policy.RequireAuthenticatedUser())
             .AddPolicy("PropertyManagerOrAdmin", policy => policy.RequireRole("PropertyManager", "Admin"))
             .AddPolicy("LongTermLandlord", policy => policy.RequireRole("LongTermLandlord"))
+            .AddPolicy("RequireSupplier", policy => policy.RequireRole("Supplier"))
             .AddPolicy("RequireOrgBillingAdmin", policy =>
                 policy.Requirements.Add(new OrgBillingAdminRequirement()));
 
@@ -270,6 +271,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IGuestAccessService, GuestAccessService>();
         services.AddSingleton<ILegalDocumentService, LegalDocumentService>();
         services.AddScoped<IOnboardingService, OnboardingService>();
+        services.AddScoped<ISupplierService, Casazen.Infrastructure.Services.SupplierService>();
         return services;
     }
 

--- a/Sessions/design-291.md
+++ b/Sessions/design-291.md
@@ -1,0 +1,459 @@
+# Design — MVP Fase 1 Epic (#291)
+
+Epic parent: **#291** · Child issues: **#292–#301** · Platform: **#271, #230, #273, #274**  
+**Exit:** GJ 12-step + Maestro M1–M7 + supplier F1–F2 on prod; E2E green in CI  
+**Planning:** `Sessions/PLANNING.md` § Fase 1 · **Child order:** `Sessions/gh-issues/comment-epic-f1.md`
+
+---
+
+## Scope summary
+
+| Issue | US / ID | Layer | Deliverable |
+|---|---|---|---|
+| **#292** | US-022 | BE + FE | Supplier console web — identity, activation wizard, inbox shell, availability |
+| **#293** | US-021 | BE + FE | `ServiceRequest` entity + host/supplier state machine (Richiesto→Pagato) |
+| **#294** | US-018 | BE + FE + jobs | iCal import/export, `CalendarBlock`, Hangfire sync (15 min) |
+| **#295** | US-019 | BE + FE | Property activation wizard, checkout wizard, compliance summary cockpit |
+| **#296** | US-020 | BE + FE + jobs | Guest check-in portal (token link), Alloggiati auto-enqueue, reminders |
+| **#297** | US-023 | FE (+ optional BE) | `PublicSiteShell`, premium template, marketing-grade `/book/{slug}` |
+| **#298** | US-024 | BE + FE edge | Custom domain CNAME, DNS verify, Vercel middleware tenant injection |
+| **#299** | US-025 | Mobile repo + BE | Expo host app M1–M7, push tokens, calendar/booking/service subset |
+| **#300** | US-026 | BE + FE | SEO comune funnel aligned to public DS, CTA event tracking |
+| **#301** | GJ-001 | FE + mobile E2E | Playwright 12-step + Maestro M1–M7 + supplier mobile F1–F2 in CI |
+| **#271** | — | BE + FE | Onboarding PLG — host mode selection (path / subdomain / custom) |
+| **#230** | — | BE + FE | SaaS billing / freemium entitlements (reopened) |
+| **#273 / #274** | — | BE | Billing security hardening (webhook sig, plan gate enforcement) |
+
+---
+
+## API Contract
+
+Legend: **Existing** = shipped or partial in codebase · **New** = Fase 1 deliverable · **Modify** = extend existing contract
+
+### #292 — Supplier console web (US-022)
+
+| Status | Method | Path | Auth | Request | Response |
+|---|---|---|---|---|---|
+| New | POST | `/api/admin/suppliers/invite` | `[Authorize]` — role `Admin` | `{ email, comuneCode, categories[]?, message? }` | 201 `{ inviteId, expiresAt }` / 409 duplicate |
+| New | POST | `/api/suppliers/register` | Public — `[AllowAnonymous]` | `{ email, password?, legalName, phone, comuneCode, inviteToken? }` | 201 `{ orgId, authRedirectUrl }` / 400 validation |
+| New | GET | `/api/supplier/profile/activation` | `[Authorize]` — role `Supplier` | — | 200 `{ status, steps: [{ id, label, status, blocker? }] }` |
+| New | POST | `/api/supplier/profile/activation/complete` | `[Authorize]` — role `Supplier` | `{ tosAccepted: true }` | 200 `{ status: "Active" }` / 409 blockers remain |
+| New | GET | `/api/supplier/profile` | `[Authorize]` — role `Supplier` | — | 200 `SupplierProfileDto` |
+| New | PUT | `/api/supplier/profile` | `[Authorize]` — role `Supplier` | `{ legalName?, vatNumber?, phone?, categories[]?, comuni[]?, bio?, photoUrls[]? }` | 200 `SupplierProfileDto` |
+| New | GET | `/api/supplier/inbox` | `[Authorize]` — role `Supplier` | `?status=open&page=&pageSize=` | 200 `{ items: ServiceRequestSummaryDto[], total }` (empty until #293) |
+| New | PUT | `/api/supplier/availability` | `[Authorize]` — role `Supplier` | `{ dates: [{ date, available }] }` | 200 `{ updated: number }` |
+| New | GET | `/api/suppliers` | `[Authorize]` — role `PropertyOwner` | `?comune={code}&category=` | 200 `{ items: SupplierPickerDto[] }` — only `Status=Active` |
+
+**SupplierProfileDto (summary):** `{ orgId, status, legalName, vatNumber?, phone, email, categories[], comuni[], bio?, photoUrls[], tosAcceptedAt? }`
+
+**IDOR:** all `/api/supplier/*` scoped to JWT `orgId` where `OrgType=Supplier`; admin invite requires platform admin claim.
+
+---
+
+### #293 — Micro-marketplace v0 (US-021)
+
+| Status | Method | Path | Auth | Request | Response |
+|---|---|---|---|---|---|
+| New | POST | `/api/service-requests` | `[Authorize]` — host org | `{ propertyId, bookingId?, supplierOrgId, category, urgency, notes?, chargeToGuest? }` | 201 `ServiceRequestDto` / 403 supplier not Active in comune |
+| New | GET | `/api/service-requests` | `[Authorize]` | `?status=&propertyId=&page=` | 200 `{ items[], total }` — host: org scope; supplier: assigned inbox |
+| New | GET | `/api/service-requests/{id}` | `[Authorize]` | — | 200 `ServiceRequestDto` / 404 |
+| New | POST | `/api/service-requests/{id}/take` | `[Authorize]` — supplier | — | 200 `{ status: "PresoInCarico", takenAt }` / 409 invalid transition |
+| New | POST | `/api/service-requests/{id}/complete` | `[Authorize]` — supplier | `{ notes? }` | 200 `{ status: "Completato", completedAt }` / 409 |
+| New | POST | `/api/service-requests/{id}/reject` | `[Authorize]` — supplier | `{ reason }` | 200 `{ status: "Rifiutato" }` / 409 |
+| New | POST | `/api/service-requests/{id}/mark-paid` | `[Authorize]` — host | — | 200 `{ status: "Pagato", paidAt }` / 409 |
+
+**ServiceRequestDto:** `{ id, orgId, bookingId?, propertyId, supplierOrgId, category, urgency, notes?, status, takenAt?, takenByUserId?, completedAt?, paidAt?, chargeToGuest }`
+
+**State machine:** `Richiesto → PresoInCarico|Rifiutato → InCorso? → Completato → Pagato`; invalid → 409 Italian problem detail.
+
+---
+
+### #294 — iCal calendar sync (US-018)
+
+| Status | Method | Path | Auth | Request | Response |
+|---|---|---|---|---|---|
+| New | PUT | `/api/properties/{id}/ical` | `[Authorize]` — property owner | `{ importUrl }` | 200 `{ lastImportStatus, lastImportAt?, lastError? }` / 400 bad URL scheme |
+| New | GET | `/api/properties/{id}/ical/export` | `[Authorize]` — property owner | — | 200 `{ exportUrl }` |
+| New | GET | `/api/public/ical/{exportToken}` | Public — `[AllowAnonymous]` | — | 200 `text/calendar` VEVENT (no PII) / 404 |
+| Modify | GET | `/api/bookings/calendar` | `[Authorize]` | existing query params | 200 — add entries `{ type: "ical-block", startUtc, endUtc, summary? }` |
+
+**Background:** `ICalSyncJob` (Hangfire, every 15 min) — no HTTP surface.
+
+**Secrets:** `PropertyICalFeed.ImportUrl` encrypted at rest (data protection / column encryption); export token unguessable (128-bit).
+
+---
+
+### #295 — Compliance wizards (US-019)
+
+| Status | Method | Path | Auth | Request | Response |
+|---|---|---|---|---|---|
+| New | GET | `/api/properties/{id}/compliance/activation` | `[Authorize]` — owner | — | 200 `{ complianceStatus, steps: [{ id, label, status, blocker? }] }` |
+| New | POST | `/api/properties/{id}/compliance/activation/complete` | `[Authorize]` — owner | — | 200 `{ complianceStatus: "Active"|"Pending", blockers[]? }` |
+| New | GET | `/api/compliance/summary` | `[Authorize]` — org member | — | 200 `{ propertiesPending, guestCheckInsIncomplete, checkoutsDue, alloggiatiFailures }` |
+| New | POST | `/api/bookings/{id}/checkout-wizard/start` | `[Authorize]` — owner | — | 200 `{ steps: [{ id, label, status }] }` / 409 wrong booking state |
+| New | POST | `/api/bookings/{id}/checkout-wizard/complete` | `[Authorize]` — owner | `{ confirmDeparture: true, ... }` | 200 `{ propertyReady, bookingStatus: "CheckedOut" }` |
+| Modify | GET | `/api/public/orgs/{slug}/properties` | Public | — | 200 — exclude `ComplianceStatus != Active` |
+| Existing | GET | `/api/properties/{id}/cin` | `[Authorize]` | — | reused in CIN wizard step |
+| Existing | POST | `/api/properties/{id}/documents` | `[Authorize]` | multipart | reused in documents step |
+
+---
+
+### #296 — Guest check-in portal (US-020)
+
+| Status | Method | Path | Auth | Request | Response |
+|---|---|---|---|---|---|
+| Existing | GET | `/api/checkin/{token}` | Public — `[AllowAnonymous]` | — | 200 `CheckInContextDto` — extend with session status |
+| Existing | POST | `/api/checkin/{token}/guest-data` | Public — `[AllowAnonymous]` | `SubmitGuestCheckInRequest` | 200 `{ dataComplete }` — wire to session + Alloggiati job |
+| Existing | POST | `/api/checkin/{token}/document` | Public — `[AllowAnonymous]` | multipart | 200 |
+| New | POST | `/api/bookings/{id}/check-in/resend-link` | `[Authorize]` — owner | — | 200 `{ sentAt }` / 404 |
+| New | GET | `/api/bookings/{id}/check-in/status` | `[Authorize]` — owner | — | 200 `{ sessionStatus, sentAt?, completedAt? }` |
+
+**Background jobs (no HTTP):** `GuestCheckInSendJob`, `GuestCheckInReminderJob`, `AlloggiatiWebReportJob` (existing, enqueue on complete).
+
+**Rate limit:** existing `GuestCheckIn` fixed-window limiter on public check-in routes.
+
+---
+
+### #297 — Public site design system (US-023)
+
+| Status | Method | Path | Auth | Request | Response |
+|---|---|---|---|---|---|
+| Existing | GET | `/api/public/orgs/{slug}` | Public | — | 200 — consume `logoUrl`, `primaryColor`, `heroImageUrl`, `tagline` |
+| Modify | GET | `/api/public/orgs/{slug}` | Public | — | add optional `publicThemeId` when BE column added |
+| Existing | GET | `/api/public/orgs/{slug}/properties/{propertyId}` | Public | — | unchanged — UI rewrite only |
+| Existing | GET | `/api/public/bookings/property/{propertyId}/availability` | Public | — | unchanged — booking widget |
+
+No new HTTP endpoints required for MVP; FE-only unless `Org.PublicThemeId` migration added (optional).
+
+---
+
+### #298 — Custom domain booking (US-024)
+
+| Status | Method | Path | Auth | Request | Response |
+|---|---|---|---|---|---|
+| Existing | GET | `/api/public/resolve-host` | Public — `[AllowAnonymous]` | `?host={hostname}` | 200 `ResolveHostResponseDto` / 404 reserved or unknown |
+| New | POST | `/api/orgs/{id}/domain` | `[Authorize]` — org owner | `{ customDomain, publicHostMode? }` | 200 `{ dnsInstructions, verificationToken }` / 403 Starter plan |
+| New | POST | `/api/orgs/{id}/domain/verify` | `[Authorize]` — org owner | — | 200 `{ domainVerificationStatus: "Verified"|"Failed", message? }` |
+| Existing | GET | `/api/orgs/me/entitlement` | `[Authorize]` | — | gates custom domain (`Plan.Pro`) |
+
+**ResolveHostResponseDto (existing):** `{ orgId, slug, publicHostMode, branding: { slug, displayName, logoUrl, themeColor, contactEmail } }`
+
+---
+
+### #299 — Native host app (US-025)
+
+| Status | Method | Path | Auth | Request | Response |
+|---|---|---|---|---|---|
+| New | POST | `/api/devices` | `[Authorize]` | `{ platform, pushToken, deviceName? }` | 201 `{ deviceId }` |
+| New | DELETE | `/api/devices/{id}` | `[Authorize]` | — | 204 |
+| Existing | GET | `/api/bookings/calendar` | `[Authorize]` | — | M1 calendar |
+| Existing | GET | `/api/bookings/{id}` | `[Authorize]` | — | M2 detail |
+| New | POST | `/api/service-requests` | `[Authorize]` | — | M4 (from #293) |
+| New | POST | `/api/service-requests/{id}/mark-paid` | `[Authorize]` | — | M6 |
+| New | POST | `/api/bookings/{id}/checkout-wizard/start` | `[Authorize]` | — | M7 |
+| Existing | GET | `/api/compliance/summary` | `[Authorize]` | — | M7 summary badges |
+
+Mobile uses same JWT (Auth0 PKCE); no separate API surface beyond device registration.
+
+---
+
+### #300 — SEO funnel (US-026)
+
+| Status | Method | Path | Auth | Request | Response |
+|---|---|---|---|---|---|
+| Existing | GET | `/api/public/content/affitti-brevi/{regionSlug}/{comuneSlug}` | Public | — | SEO content ( #258 ) |
+| New | GET | `/api/public/seo/{comuneSlug}` | Public | — | 200 `{ title, content, meta, featuredProperties[], cta }` |
+| New | POST | `/api/public/seo/events` | Public — `[AllowAnonymous]` | `{ event, comuneSlug, utm?, referrer? }` | 204 — no PII |
+| New | GET | `/api/admin/seo/analytics` | `[Authorize]` — Admin | `?days=30` | 200 `{ topComuni: [{ slug, ctaClicks }] }` |
+
+---
+
+### #301 — Golden Journey E2E (GJ-001)
+
+No new API endpoints. Harness asserts existing + new endpoints above return ≠ 500 during UI flows.
+
+---
+
+### Platform — #271, #230, #273, #274
+
+| Status | Method | Path | Auth | Notes |
+|---|---|---|---|---|
+| Existing | GET | `/api/onboarding/status` | `[Authorize]` | #271 — extend with host mode step |
+| Existing | POST/PUT | `/api/users/onboarding` | `[Authorize]` | #271 PLG completion |
+| Existing | GET | `/api/billing/plans` | Public / Auth | #230 freemium |
+| Existing | POST | `/api/billing/checkout-session` | `[Authorize]` | #230 |
+| Existing | POST | `/api/webhooks/stripe` | Public — signature | #273 webhook hardening |
+| Existing | PATCH | `/api/admin/orgs/{orgId}/plan` | `[Authorize]` Admin | #274 plan enforcement |
+
+---
+
+## Frontend Flow
+
+### Route map (all Fase 1 features)
+
+| Path | Component | Auth | Issue | Status |
+|---|---|---|---|---|
+| `/supplier/register` | `SupplierRegisterPage` | public | #292 | New |
+| `/supplier/activation` | `SupplierActivationWizard` | `<ProtectedRoute role="Supplier">` | #292 | New |
+| `/supplier/inbox` | `SupplierInboxPage` | `<ProtectedRoute role="Supplier">` | #292 | New |
+| `/supplier/inbox/:id` | `SupplierRequestDetailPage` | `<ProtectedRoute role="Supplier">` | #292/#293 | New |
+| `/supplier/profile` | `SupplierProfilePage` | `<ProtectedRoute role="Supplier">` | #292 | New |
+| `/supplier/availability` | `SupplierAvailabilityPage` | `<ProtectedRoute role="Supplier">` | #292 | New |
+| `/admin/suppliers` | `AdminSupplierInvitePage` | `<ProtectedRoute role="Admin">` | #292 | New |
+| `/bookings/:id/service-request` | `CreateServiceRequestPage` | `<ProtectedRoute>` | #293 | New |
+| `/properties/:id/settings/ical` | `PropertyIcalSettingsCard` | `<ProtectedRoute>` | #294 | New |
+| `/properties/:id/activation` | `PropertyActivationWizard` | `<ProtectedRoute>` | #295 | New |
+| `/compliance` | `ComplianceSummaryPage` | `<ProtectedRoute>` | #295 | New |
+| `/bookings/:id/checkout` | `CheckoutWizardPage` | `<ProtectedRoute>` | #295 | New |
+| `/check-in/:token` | `GuestCheckInPortalPage` | public | #296 | Modify existing |
+| `/book/:slug` | `PublicBookingSite` | public | #297 | Modify — `PublicSiteShell` |
+| `/book/:slug/:propertyId` | `PublicPropertyDetail` | public | #297 | Modify |
+| `/settings/domain` | `CustomDomainSettingsPage` | `<ProtectedRoute>` | #298 | New |
+| `/destinazioni/:comune` | `ComuneLandingPage` | public | #300 | Modify |
+| `/signup` | `SignupPage` | public | #271/#300 | Modify — comune UTM |
+
+**Supplier shell (#292 Wave 1):** separate `SupplierShell` layout — no host `AppShell` nav. Lazy route group `src/routes/supplier/*`.
+
+### Component breakdown by feature
+
+#### #292 — Supplier console (Wave 1 — this pipeline run)
+
+| Component | Status | Location | Responsibility |
+|---|---|---|---|
+| `SupplierShell` | new | `src/layouts/SupplierShell.tsx` | Mobile-responsive nav, logout, role guard |
+| `SupplierActivationWizard` | new | `src/features/supplier-console/ActivationWizard/` | 5 steps IT copy; progress persisted via activation API |
+| `SupplierInboxPage` | new | `src/features/supplier-console/Inbox/` | List open requests; empty state until #293 |
+| `SupplierProfileForm` | new | `src/features/supplier-console/Profile/` | Legal name, VAT, categories, comuni, bio, photos |
+| `SupplierAvailabilityCalendar` | new | `src/features/supplier-console/Availability/` | Month view; tap toggle dates |
+| `AdminSupplierInviteForm` | new | `src/features/admin/SupplierInvite/` | Admin invite email + comune picker |
+
+**State & API (Wave 1):**
+
+| Data | Hook | API module |
+|---|---|---|
+| activation steps | `useSupplierActivation` | `supplier.api.ts` |
+| profile | `useSupplierProfile` | `supplier.api.ts` |
+| inbox | `useSupplierInbox` | `supplier.api.ts` |
+| availability | `useSupplierAvailability` | `supplier.api.ts` |
+| admin invite | `useAdminSupplierInvite` | `admin-suppliers.api.ts` |
+
+**GJ coverage:** Playwright steps 1–2 (supplier create + activation); mobile viewport F1–F2 scaffolded in Wave 1 layout (full inbox CTAs wired in Wave 2).
+
+#### #293 — Micro-marketplace
+
+| Component | Status | Location |
+|---|---|---|
+| `ServiceRequestTimeline` | new | `src/features/service-requests/` |
+| `SupplierPicker` | new | embedded in booking detail + checkout wizard |
+| `CreateServiceRequestForm` | new | host booking detail + native app parity |
+
+#### #294 — iCal
+
+| Component | Status | Location |
+|---|---|---|
+| `PropertyIcalSettingsCard` | new | `src/features/properties/IcalSettings/` |
+| Calendar legend + block styling | modify | `src/features/calendar/` |
+
+#### #295 — Compliance wizards
+
+| Component | Status | Location |
+|---|---|---|
+| `PropertyActivationWizard` | new | `src/features/compliance/activation/` |
+| `ComplianceSummaryWidget` | new | `src/features/compliance/summary/` |
+| `CheckoutWizardPage` | new | `src/features/compliance/checkout/` |
+
+#### #296 — Guest check-in
+
+| Component | Status | Location |
+|---|---|---|
+| `GuestCheckInPortalPage` | modify | `src/features/public-check-in/` — mobile-first IT |
+| `CheckInStatusBadge` | new | booking detail (host) |
+
+#### #297 — Public site DS
+
+| Component | Status | Location |
+|---|---|---|
+| `PublicSiteShell` | new | `src/layouts/PublicSiteShell.tsx` |
+| `Hero`, `PropertyGallery`, `AmenityGrid`, `BookingWidget`, `Footer` | new | `src/features/public-site/` |
+| `public-tokens.css` | new | design tokens shared with SEO pages |
+
+#### #298 — Custom domain
+
+| Component | Status | Location |
+|---|---|---|
+| `middleware.ts` | new | Vercel edge — resolve-host → tenant context |
+| `CustomDomainSettingsPage` | new | DNS instructions + verify CTA |
+
+#### #299 — Native host app (sibling repo)
+
+Screens: Calendar, BookingDetail, CreateServiceRequest, MarkPaid, QuickCheckout, PropertyList — Auth0 PKCE; deep links to web for heavy wizards.
+
+#### #300 — SEO funnel
+
+| Component | Status | Location |
+|---|---|---|
+| `ComuneLandingPage` | rewrite | `src/features/seo/` — uses `PublicSiteShell` |
+| `useSeoEvent` | new | fires `POST /api/public/seo/events` |
+
+#### #301 — E2E harness
+
+| File | Change |
+|---|---|
+| `e2e/golden-journey-web.spec.ts` | Extend steps 1–12 (F0 has 1–4) |
+| `e2e/golden-journey-supplier-mobile.spec.ts` | F1–F2 mobile viewport |
+| `mobile/e2e/golden-journey-host-app.e2e.ts` | Maestro M1–M7 |
+
+---
+
+## Security Notes
+
+### Auth gates (by surface)
+
+| Surface | Requirement |
+|---|---|
+| All `/api/supplier/*`, `/api/service-requests/*` (supplier actions) | `[Authorize]` + role `Supplier` + org tenant boundary |
+| Host service-request create/mark-paid | `[Authorize]` + `PropertyOwner` + `OrgId` match |
+| `/api/admin/suppliers/*`, `/api/admin/seo/analytics` | `[Authorize]` + platform `Admin` |
+| `/api/suppliers/register` | Public — rate-limited; optional `inviteToken` validation |
+| `/api/public/ical/{token}`, `/api/public/resolve-host`, SEO events | Public — no secrets in response; rate-limited |
+| Guest check-in `/api/checkin/*` | Public — token GUID + expiry; existing rate limiter |
+| Custom domain verify | Owner-only; DNS TXT prevents domain hijack |
+
+### IDOR
+
+- Property-scoped: verify `property.OrgId == user.OrgId` on iCal, compliance, checkout wizard.
+- ServiceRequest: host reads own org; supplier reads where `SupplierOrgId == user.OrgId`.
+- Supplier profile: single-org — JWT org claim must equal profile `OrgId`.
+
+### Secrets & OTA keys
+
+- **iCal import URLs:** stored encrypted (`PropertyICalFeed.ImportUrl`); never logged; not returned on GET except masked last-4.
+- **iCal export token:** opaque UUID in URL path only; rotate on property owner request.
+- **No OTA partner API keys in Fase 1** — iCal URL only; config path reserved: `OTA:Platforms:{Name}:ApiKey` (unused until Fase 3+).
+- **Guest check-in token:** hash at rest if session entity added; single-use submit → 409 replay.
+- **Auth0:** Supplier role + RBAC documented in `docs/AUTH0_SETUP.md` (#292).
+
+### Stripe
+
+- Existing webhook signature verification (#273) — no change to supplier console.
+- `mark-paid` is manual confirmation MVP — no Stripe Connect charge in v0.
+
+### PII data flow
+
+| Feature | PII | Mitigation |
+|---|---|---|
+| #292 Supplier profile | email, phone, VAT | org-scoped; not public until supplier vetrina (Fase 2) |
+| #296 Guest check-in | name, DOB, document, nationality | public token route; minimal fields; consent checkboxes; no PII in logs |
+| #294 iCal export | none in SUMMARY | strip guest names from VEVENT |
+| #300 SEO events | none | anonymous event payload only |
+
+### STRIDE threat summary
+
+| Threat | Surface | Mitigation |
+|---|---|---|
+| Spoofing | Supplier/host actions | Auth0 JWT + role claims; separate Supplier org type |
+| Tampering | ServiceRequest state | Server-side state machine; 409 on invalid transitions |
+| Information disclosure | resolve-host, public iCal | Branding only; no plan/Stripe; iCal without guest PII |
+| Denial of service | Public check-in, resolve-host | Rate limits; Hangfire job isolation |
+| Elevation | Admin invite | Admin role required; audit log on invite |
+
+---
+
+## Migration Plan
+
+Per-feature EF changes (apply in wave order):
+
+| Issue | Migration | Entities / columns |
+|---|---|---|
+| **#292** | `AddSupplierOrgAndProfile` | `OrgType.Supplier` enum value; `SupplierProfile` `{ OrgId PK/FK, Status, LegalName, VatNumber?, Phone, Email, Categories jsonb, Comuni jsonb, Bio, PhotoUrls jsonb, TosAcceptedAt, CreatedAt, UpdatedAt }`; `SupplierAvailability` `{ Id, OrgId, Date, Available }` |
+| **#293** | `AddServiceRequests` | `ServiceRequest` per US-021 AC1; indexes on `(OrgId)`, `(SupplierOrgId, Status)` |
+| **#294** | `AddCalendarBlocksAndICalFeeds` | `CalendarBlock`, `PropertyICalFeed` per spec; unique `(PropertyId, ExternalUid)` |
+| **#295** | `AddComplianceWizardFields` | `Property.ComplianceStatus`; `PropertySafetyChecklist` jsonb column |
+| **#296** | `AddGuestCheckInSessions` | `GuestCheckInSession` per spec; optional extend `Booking.CheckInToken*` |
+| **#297** | N/A or optional | `Org.PublicThemeId` nullable string — defer if FE-only theming |
+| **#298** | `AddOrgCustomDomainFields` | `Org.CustomDomain`, `DomainVerificationStatus`, `DomainVerificationToken`, `PublicHostMode` (enum exists) |
+| **#299** | `AddDeviceRegistrations` | `DeviceRegistration` `{ Id, UserId, OrgId, Platform, PushToken, CreatedAt }` |
+| **#300** | optional `AddSeoEvents` | `SeoEvent` `{ Id, Event, ComuneSlug, Utm, Referrer, CreatedAt }` |
+| **#301** | N/A | test harness only |
+| **Platform #298 partial** | may reuse F0 `PublicHostMode` on Org | verify column presence before migration |
+
+**Wave 1 (#292) applies only:** `AddSupplierOrgAndProfile`.
+
+---
+
+## GDPR Scope
+
+| Issue | Guest data | Scope |
+|---|---|---|
+| **#292** | N/A | Supplier business contact only — not Guest PII |
+| **#293** | N/A | Service notes must not require guest document numbers |
+| **#294** | N/A | iCal blocks must exclude guest identity in export |
+| **#295** | Indirect | Checkout wizard triggers retention scheduling on `CheckedOut` — reuse existing booking GDPR hooks |
+| **#296** | **Yes** | Fields: name, DOB, nationality, document type/number, address; GDPR consents on submit; `ErasureRequested` check before display; `DataRetentionUntil` set on checkout; Alloggiati job async — no PII in job logs |
+| **#297–#301** | N/A (except #296 dependency) | Public site shows no guest data |
+| **#300** | N/A | Anonymous analytics events |
+
+**Wave 1 (#292):** N/A — no Guest personal data in scope.
+
+---
+
+## Open Questions
+
+None — resolved for Wave 1:
+
+| Question | Resolution |
+|---|---|
+| Reuse `/api/checkin/{token}` vs new `/api/public/check-in/{token}`? | **Extend existing** `/api/checkin/*` — avoid duplicate public surface (#296) |
+| Supplier Auth0 role name | **`Supplier`** claim + `OrgType.Supplier` (#292) |
+| `resolve-host` shipped in F0? | **Existing** — extend for custom domain verification in Wave 5 (#298) |
+| Alloggiati assert in CI GJ step 6? | **Mock/skip** unless Questura test credentials configured (GJ-001 AC regulatory gate) |
+
+---
+
+## Pipeline Wave Plan
+
+Epic **#291** is delivered in **8 pipeline waves** (one child issue or parallel group per wave). Each wave merges to `develop`, then epic exit wave promotes via standard Stage 05 flow.
+
+| Wave | Issues | Branch | Pipeline scope | Depends on |
+|---|---|---|---|---|
+| **1 (this run)** | **#292** | `feature/291-mvp-f1-wave1-supplier-console` | Supplier identity, Auth0 role, activation wizard, inbox shell, availability, admin invite; GJ steps 1–2 E2E scaffold | Fase 0 complete (#286) |
+| 2 | #293 | `feature/291-mvp-f1-wave2-micro-marketplace` | `ServiceRequest` CRUD + state machine; host picker; supplier inbox CTAs | Wave 1 |
+| 3 | #294, #295, #296 (parallel) | `feature/291-mvp-f1-wave3a-ical`, `…-wave3b-compliance`, `…-wave3c-guest-checkin` | iCal sync; compliance wizards; guest portal + jobs | Wave 2 (checkout step 3 → #293) |
+| 4 | #297 | `feature/291-mvp-f1-wave4-public-site-ds` | `PublicSiteShell` + template; `/book/{slug}` redesign | Wave 3 (compliance gating on public list) |
+| 5 | #298 | `feature/291-mvp-f1-wave5-custom-domain` | Org domain fields, DNS verify, Vercel middleware | Wave 4, #271 onboarding step |
+| 6 | #299 | `feature/291-mvp-f1-wave6-native-host-app` | Expo app + Maestro M1–M7 + device push | Waves 3–5 |
+| 7 | #300 | `feature/291-mvp-f1-wave7-seo-funnel` | SEO pages + CTA analytics | Wave 4 |
+| 8 | #301 | `feature/291-mvp-f1-wave8-golden-journey-e2e` | Full 12-step Playwright + F1–F2 + CI workflow | All feature waves |
+
+**Platform (#271, #230, #273, #274):** integrate across Waves 4–5 (onboarding host mode, billing gates); security hardening continuous.
+
+### Wave 1 deliverables checklist (#292)
+
+**Backend**
+- [ ] `OrgType.Supplier`, `SupplierProfile`, `SupplierAvailability` migration
+- [ ] `SupplierProfileController`, `AdminSuppliersController`
+- [ ] Auth0 Supplier role + policy registration
+- [ ] Integration tests: register, activation complete, admin invite, availability PUT
+
+**Frontend**
+- [ ] `SupplierShell` + route group `/supplier/*` with `<ProtectedRoute role="Supplier">`
+- [ ] Activation wizard (5 steps, Italian)
+- [ ] Inbox + profile + availability pages (mobile-responsive 375px)
+- [ ] Admin invite page `<ProtectedRoute role="Admin">`
+
+**E2E**
+- [ ] Extend `golden-journey-web.spec.ts` steps 1–2 (supplier signup + activation → `Active`)
+- [ ] Mobile viewport smoke on `/supplier/inbox` layout (F1–F2 placeholder until Wave 2)
+
+**Stage 03 branch:** `feature/291-mvp-f1-wave1-supplier-console`
+
+---
+
+## Handoff
+
+| Field | Value |
+|---|---|
+| Issue | #291 (Wave 1 implements #292) |
+| Spec | `Sessions/design-291.md` |
+| Branch | `feature/291-mvp-f1-wave1-supplier-console` |
+| Next stage | 03 Development — backend + frontend per Wave 1 checklist |

--- a/Sessions/gh-issues/epic-mvp-fase-1-enhanced.md
+++ b/Sessions/gh-issues/epic-mvp-fase-1-enhanced.md
@@ -1,0 +1,46 @@
+## Summary
+
+**MVP Fase 1 epic** (12–16 weeks). Ship sellable MVP: full Golden Journey on prod, E2E green in CI, ecosystem loop host↔supplier.
+
+**Planning:** `Sessions/PLANNING.md` § Fase 1 · **Exit:** GJ 12-step + Maestro M1–M7 + supplier mobile F1–F2
+
+## User Story
+
+As a CasaZen product owner, I need a coordinated Fase 1 delivery so one beta host can complete the full Golden Journey on production with automated E2E coverage, supplier loop closed on web/mobile, and compliance/iCal blocking publish when incomplete.
+
+## Acceptance Criteria
+
+1. Golden Journey complete on prod with 1 beta host (12 web steps + Maestro M1–M7 + supplier F1–F2)
+2. Playwright 12-step + Maestro M1–M7 green in CI on every release to `main`
+3. iCal import/export blocks visible on public calendar within sync SLA (15–30 min)
+4. Compliance wizards gate property publish until CIN, Alloggiati, and guest check-in prerequisites satisfied
+5. Child issues #292–#301 delivered in build order with design specs and PRs merged to `develop` then `main`
+6. Platform items #271, SaaS billing (#230), #273, #274 integrated or explicitly deferred with documented rationale
+
+## Technical Notes
+
+- **Backend:** .NET 10 API, EF Core migrations per child feature; Hangfire jobs for iCal sync; public resolve-host + custom domain middleware (US-024)
+- **Frontend:** React 19 SPA, ProtectedRoute on all authenticated routes; supplier console + public site design system; Playwright E2E harness (`golden-journey-web.spec.ts`, Maestro flows)
+- **Mobile:** Expo host app (US-025) in sibling `casazen/mobile` repo; Auth0 PKCE
+- **OTA/background jobs:** iCal sync job (15–30 min interval); no OTA partner API in Fase 1
+- **Dependencies:** Fase 0 complete (#286 batch); ADRs for iCal parser + custom domain from F0 spikes
+- **Child build order:** supplier-console → micro-marketplace → (iCal, compliance, guest portal parallel) → public-site DS → custom domain → native host → SEO → GJ E2E harness
+
+## Feature issues (build order)
+
+1. `supplier-console-web` (US-022) — #292
+2. `micro-marketplace-v0` (US-021) — #293
+3. Parallel: `ical-calendar-sync` (#294), `compliance-wizards` (#295), `guest-check-in-portal` (#296)
+4. `public-site-design-system` (US-023) — #297
+5. `custom-domain-booking` (US-024) — #298
+6. `native-host-app` (US-025) — #299
+7. `seo-funnel` (US-026) — #300
+8. `golden-journey-e2e` harness (GJ-001) — #301
+9. Platform: #271, SaaS billing, #273/#274
+
+## Exit criteria
+
+- [ ] Golden Journey complete on prod with 1 beta host
+- [ ] Playwright 12-step + Maestro M1–M7 green in CI
+- [ ] iCal blocks visible on public calendar
+- [ ] Compliance wizards gate property publish

--- a/Sessions/pipeline-mvp-f1-epic/state.md
+++ b/Sessions/pipeline-mvp-f1-epic/state.md
@@ -1,0 +1,43 @@
+# Pipeline: [MVP F1] EPIC — MVP vendibile — full Golden Journey
+
+## Status
+- status: running
+- current_stage: 02-design
+- started: 2026-06-20T12:00:00Z
+- last_updated: 2026-06-20T12:15:00Z
+
+## Input
+- description: MVP Fase 1 epic (12–16 weeks) — ship sellable MVP: full Golden Journey on prod, E2E green in CI, ecosystem loop host↔supplier
+- type: feat
+- priority: high
+- issue_ref: "#291"
+
+## Artifacts
+- issue: "#291"
+- issue_url: https://github.com/casazen/backend/issues/291
+- design_spec: Sessions/design-291.md
+- branch: feature/291-mvp-f1-wave1-supplier-console
+- pr_backend: (pending)
+- pr_backend_url: (pending)
+- pr_frontend: (pending)
+- pr_frontend_url: (pending)
+- release_report: (pending)
+- tag: (pending)
+- release_url: (pending)
+- ops_report: (pending)
+
+## Related
+- child_issues: "#292–#301 (see Sessions/gh-issues/comment-epic-f1.md)"
+- platform: "#271, #230, #273, #274"
+- predecessor: Sessions/pipeline-batch-f0/state.md (F0 complete)
+
+## Stage History
+
+| Stage | Status | Iterations | Gates | Artifact |
+|---|---|---|---|---|
+| 01-planning | completed | 1 | G1–G5 ✅ | #291 |
+| 02-design | completed | 1 | G1–G8 ✅ | Sessions/design-291.md |
+| 03-development | in_progress | 1 | - | Wave 1 #292 |
+| 04-review | (pending) | - | - | - |
+| 05-release | (pending) | - | - | - |
+| 06-operations | (pending) | - | - | - |


### PR DESCRIPTION
## Summary

- Add `OrgType.Supplier`, `SupplierProfile`, `SupplierAvailability`, `SupplierInviteRecord` + EF migration `AddSupplierOrgAndProfile`
- New API: register, activation wizard, profile CRUD, inbox shell, availability, admin invite, host supplier picker
- Auth policy `RequireSupplier`; 14 integration tests
- Epic design spec `Sessions/design-291.md` (8-wave plan; this PR is Wave 1)

## Frontend PR

https://github.com/casazen/frontend/pull/TBD

## Acceptance criteria coverage

| AC | Test |
|---|---|
| AC1–AC6 identity/activation | `SupplierConsoleIntegrationTests` |
| AC7 inbox shell | `GetInbox_ReturnsEmptyList` |
| AC8 availability | `UpdateAvailability_Returns200` |
| AC3 admin invite | `AdminInvite_ValidRequest_Returns201` |

## Gate status

| Gate | Status |
|---|---|
| G1 dotnet test | ✅ 585 passed |
| G2 format | ✅ |
| G3 build | ✅ |
| G4 migration | ✅ `AddSupplierOrgAndProfile` |
| G10–G13 | N/A |

## Test plan

- [ ] `dotnet test --filter SupplierConsole`
- [ ] `.\scripts\migrate.ps1 -Target test` on staging before merge
- [ ] Register supplier via `POST /api/suppliers/register`
- [ ] Complete activation → `Status=Active`
- [ ] Admin invite via `POST /api/admin/suppliers/invite`

Closes #292
