### PR TITLE
fix(ci): resolve test race condition and format check failures

### DIFF
--- a/Casazen.Tests/Integration/CasazenWebApplicationFactory.cs
+++ b/Casazen.Tests/Integration/CasazenWebApplicationFactory.cs
@@ -19,7 +19,7 @@ using Moq;
 namespace Casazen.Tests.Integration;
 
 /// <summary>
-/// WebApplicationFactory for integration tests â€” in-memory EF, test auth, mocked Hangfire.
+/// WebApplicationFactory for integration tests — in-memory EF, test auth, mocked Hangfire.
 /// </summary>
 public class CasazenWebApplicationFactory : WebApplicationFactory<Program>
 {
@@ -124,10 +124,10 @@ public class CasazenWebApplicationFactory : WebApplicationFactory<Program>
 
     public async Task<Property> SeedPropertyAsync(string ownerId = TestAuthHandler.DefaultUserId, decimal nightlyRate = 100m)
     {
+        var org = await SeedOrgForOwnerAsync(ownerId);
+
         using var scope = Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-
-        var org = await EnsureOrgAsync(db, ownerId);
 
         var property = new Property
         {
@@ -167,7 +167,21 @@ public class CasazenWebApplicationFactory : WebApplicationFactory<Program>
         using var scope = Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         var org = await EnsureOrgAsync(db, ownerId);
-        await db.SaveChangesAsync();
+
+        try
+        {
+            await db.SaveChangesAsync();
+        }
+        catch (ArgumentException ex) when (ex.Message.Contains("same key", StringComparison.OrdinalIgnoreCase))
+        {
+            // Parallel test already seeded the same user/org — re-query for committed values
+            db.ChangeTracker.Clear();
+            var slug = $"test-org-{ownerId}";
+            org = await db.Orgs.FirstOrDefaultAsync(o => o.Slug == slug);
+            if (org is null)
+                throw;
+        }
+
         return org;
     }
 

--- a/Casazen.Web/Program.cs
+++ b/Casazen.Web/Program.cs
@@ -111,19 +111,19 @@ builder.Services.AddHttpClient("Openapi");
 // OTA Integrations with resilience patterns
 builder.Services.AddCasazenOtaIntegrations(builder.Configuration);
 
-	// Localization — Italian (default) and English
-	builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
+// Localization — Italian (default) and English
+builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 
-	builder.Services.AddRequestLocalization(options =>
-	{
-	    var supportedCultures = new[] { "it-IT", "en-US" };
-	    options.SetDefaultCulture(supportedCultures[0])
-	           .AddSupportedCultures(supportedCultures)
-	           .AddSupportedUICultures(supportedCultures);
-	    options.ApplyCurrentCultureToResponseHeaders = true;
-	});
+builder.Services.AddRequestLocalization(options =>
+{
+    var supportedCultures = new[] { "it-IT", "en-US" };
+    options.SetDefaultCulture(supportedCultures[0])
+           .AddSupportedCultures(supportedCultures)
+           .AddSupportedUICultures(supportedCultures);
+    options.ApplyCurrentCultureToResponseHeaders = true;
+});
 
-	// Authentication & Authorization
+// Authentication & Authorization
 builder.Services.AddCasazenAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddCasazenAuthorization();
 


### PR DESCRIPTION
## Summary
- Fixes the CI pipeline that has been failing for the last 5 commits on `develop`
- **Root cause 1**: `SeedOrgForOwnerAsync` had a race condition when parallel tests (`--maxcpucount`) both try to seed the same user/org in the in-memory DB, throwing `ArgumentException: An item with the same key has already been added`
- **Root cause 2**: `Program.cs` had tab-indented whitespace in the localization block, causing `dotnet format --verify-no-changes` to fail with exit code 2

## Changes
- `Casazen.Tests/Integration/CasazenWebApplicationFactory.cs`: Catch duplicate-key `ArgumentException` in `SeedOrgForOwnerAsync`, clear change tracker, and re-query for the now-committed entity
- `Casazen.Web/Program.cs`: Fix whitespace formatting (tabs → spaces) in localization and auth sections

## Test Plan
- `dotnet test`: 598 passed, 1 failed (pre-existing PostgreSQL/Docker test), 25 skipped — same as the last green CI run
- `dotnet format --verify-no-changes`: exit 0